### PR TITLE
Allow OR testing for filenames. Check MIT.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+    - "2.7"
+    - "3.4"
+    - "3.5"
+    - "3.6"
+
+# command to install dependencies
+install: pip install -r requirements.txt --use-mirrors
+
+# command to run tests
+script: nosetests

--- a/tests/lint_examples/critical_example/LICENSE
+++ b/tests/lint_examples/critical_example/LICENSE
@@ -1,0 +1,19 @@
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/lint_examples/failing_example/LICENSE.md
+++ b/tests/lint_examples/failing_example/LICENSE.md
@@ -1,0 +1,1 @@
+This is a bad licence file.

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -27,14 +27,28 @@ class TestLint(unittest.TestCase):
     """Class for lint tests"""
 
     @raises(AssertionError)
-    def test_critical_example(self):
+    def test_critical_missingfiles_example(self):
         """Tests for missing nextflow config and main.nf files"""
         lint_obj = nf_core.lint.PipelineLint(PATH_CRITICAL_EXAMPLE)
-        lint_obj.lint_pipeline()
+        lint_obj.check_files_exist()
 
-    def test_failing_example(self):
+    def test_failing_missingfiles_example(self):
         """Tests for missing files like Dockerfile or LICENSE"""
         lint_obj = nf_core.lint.PipelineLint(PATH_FAILING_EXAMPLE)
-        lint_obj.lint_pipeline()
-        assert len(lint_obj.failed) == 4, "Expected 6 files missing, but found %r" % len(lint_obj.failed)
-        assert len(lint_obj.passed) == 2, "Expected 6 files missing, but found %r" % len(lint_obj.passed)
+        lint_obj.check_files_exist()
+        assert len(lint_obj.failed) == 7, "Expected 7 missing file FAIL, but found %r" % len(lint_obj.failed)
+        assert len(lint_obj.warned) == 2, "Expected 2 missing file WARN, but found %r" % len(lint_obj.passed)
+        assert len(lint_obj.passed) == 3, "Expected 3 missing file PASS, but found %r" % len(lint_obj.passed)
+
+    def test_mit_licence_example_pass(self):
+        """Tests that MIT test works with good and bad MIT licences"""
+        good_lint_obj = nf_core.lint.PipelineLint(PATH_CRITICAL_EXAMPLE)
+        good_lint_obj.check_licence()
+        assert len(good_lint_obj.failed) == 0, "Expected 0 MIT FAIL, but found %r" % len(good_lint_obj.failed)
+        assert len(good_lint_obj.warned) == 0, "Expected 0 MIT WARN, but found %r" % len(good_lint_obj.passed)
+        assert len(good_lint_obj.passed) == 1, "Expected 1 MIT PASS, but found %r" % len(good_lint_obj.passed)
+        bad_lint_obj = nf_core.lint.PipelineLint(PATH_FAILING_EXAMPLE)
+        bad_lint_obj.check_licence()
+        assert len(bad_lint_obj.failed) == 1, "Expected 1 MIT FAIL, but found %r" % len(bad_lint_obj.failed)
+        assert len(bad_lint_obj.warned) == 0, "Expected 0 MIT WARN, but found %r" % len(bad_lint_obj.passed)
+        assert len(bad_lint_obj.passed) == 0, "Expected 0 MIT PASS, but found %r" % len(bad_lint_obj.passed)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -2,13 +2,13 @@
 """Some tests covering the linting code.
 Provide example wokflow directory contents like:
 
-    --tests 
+    --tests
         |--lint_examples
         |     |--missing_license
         |     |     |...<files here>
         |     |--missing_config
         |     |     |....<files here>
-        |     |...  
+        |     |...
         |--test_lint.py
 """
 import os


### PR DESCRIPTION
Now having a list of filenames for an object means that the test passes if any of them are present. For example - CI testing with either Travis _or_ Circle CI.