### PR TITLE
Allow Brit/US spellings of Licence. Catch nextflow errors.

### DIFF
--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -64,7 +64,7 @@ class PipelineLint(object):
             'nextflow.config',
             'Dockerfile',
             ['.travis.yml', 'circle.yml'],
-            ['LICENSE', 'LICENSE.md'],
+            ['LICENSE', 'LICENSE.md', 'LICENCE', 'LICENCE.md'], # NB: British / American spelling
             'README.md',
             'CHANGELOG.md',
             'docs/README.md',
@@ -105,7 +105,7 @@ class PipelineLint(object):
 
     def check_licence(self):
         logging.debug('Checking licence file is MIT')
-        for l in ['LICENSE', 'LICENSE.md']:
+        for l in ['LICENSE', 'LICENSE.md', 'LICENCE', 'LICENCE.md']:
             fn = os.path.join(self.path, l)
             if os.path.isfile(fn):
                 if 'MIT' in open(fn).read():

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -133,8 +133,11 @@ class PipelineLint(object):
         ]
 
         # Call `nextflow config` and pipe stderr to /dev/null
-        with open(os.devnull, 'w') as devnull:
-            nfconfig_raw = subprocess.check_output(['nextflow', 'config', self.path], stderr=devnull)
+        try:
+            with open(os.devnull, 'w') as devnull:
+                nfconfig_raw = subprocess.check_output(['nextflow', 'config', self.path], stderr=devnull)
+        except subprocess.CalledProcessError as e:
+            print("ERROR: nextflow config returned non-zero error code: {},\n   {}".format(exc.returncode, exc.output))
 
         logging.debug("{} lines of pipeline config found!".format(len(nfconfig_raw.splitlines())))
 


### PR DESCRIPTION
I kept getting confused about whether it should be Licence or License. Turns out that it can be both.

Also, if the `nextflow config` command files, everything falls over. Instead, capture the code and stderr and continue. This test is way off being finished yet.