### PR TITLE
Increase code coverage for lint tests

### DIFF
--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -108,11 +108,7 @@ class PipelineLint(object):
         logging.debug('Checking Dockerfile')
         fn = os.path.join(self.path, "Dockerfile")
         content = ""
-        try:
-            with open(fn, 'r') as fh: content = fh.read()
-        except Exception as exc:
-            logging.error("Dockerfile check failed.")
-            logging.error(exc)
+        with open(fn, 'r') as fh: content = fh.read()
 
         # Implicitely also checks if empty.
         if 'FROM ' in content:

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -128,11 +128,8 @@ class PipelineLint(object):
             fn = os.path.join(self.path, l)
             if os.path.isfile(fn):
                 content = ""
-                try:
-                    with open(fn, 'r') as fh: content = fh.read()
-                except Exception as e:
-                    raise AssertionError("Could not open licence file: %s,\n   %s", e.returncode, e.output)
-
+                with open(fn, 'r') as fh: content = fh.read()
+                
                 # needs at least copyright, permission, notice and "as-is" lines
                 nl = content.count("\n")
                 if nl < 4:

--- a/tests/lint_examples/license_incomplete_example/LICENSE
+++ b/tests/lint_examples/license_incomplete_example/LICENSE
@@ -1,0 +1,7 @@
+Copyright 1984 <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/tests/lint_examples/wrong_license_example/LICENSE
+++ b/tests/lint_examples/wrong_license_example/LICENSE
@@ -1,1 +1,9 @@
 Copyright 1984 me-myself-and-I
+
+this is a bad license
+
+that has more than 
+
+four lines
+
+but is acutally no license file

--- a/tests/lint_examples/wrong_license_example/LICENSE
+++ b/tests/lint_examples/wrong_license_example/LICENSE
@@ -1,0 +1,1 @@
+Copyright 1984 me-myself-and-I

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -90,10 +90,6 @@ class TestLint(unittest.TestCase):
         expectations = {"failed": 1, "warned": 0, "passed": 0}
         self.assess_lint_status(bad_lint_obj, **expectations)
 
-    def test_missing_license(self):
-        """Mimics exception for file handler error on the the License"""
-        lint_obj = nf_core.lint.PipelineLint(PATH_HILARIOUS_EXAMPLE)
-        lint_obj.check_licence()
 
     def test_config_variable_example_pass(self):
         """Tests that config variable existence test works with good pipeline example"""

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -57,6 +57,12 @@ class TestLint(unittest.TestCase):
         lint_obj.check_docker()
         self.assess_lint_status(lint_obj, failed=1)
     
+    @raises(IOError)
+    def test_missing_dockerfile_example(self):
+        """Mimics exception for file handler error on the Dockerfile"""
+        lint_obj = nf_core.lint.PipelineLint(PATH_CRITICAL_EXAMPLE)
+        lint_obj.check_docker()
+    
     @raises(AssertionError)
     def test_critical_missingfiles_example(self):
         """Tests for missing nextflow config and main.nf files"""

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -29,6 +29,8 @@ WD = os.path.dirname(__file__)
 PATH_CRITICAL_EXAMPLE =  pf(WD, 'lint_examples/critical_example')
 PATH_FAILING_EXAMPLE = pf(WD, 'lint_examples/failing_example')
 PATH_WORKING_EXAMPLE = pf(WD, 'lint_examples/minimal_working_example')
+PATHS_WRONG_LINENSE_EXAMPLE = [pf(WD, 'lint_examples/wrong_license_example'), 
+    pf(WD, 'lint_examples/license_incomplete_example')]
 
 MAX_PASS_CHECKS = 25
 
@@ -99,3 +101,11 @@ class TestLint(unittest.TestCase):
         expectations = {"failed": 7, "warned": 4, "passed": 0}
         self.assess_lint_status(bad_lint_obj, **expectations)
 
+
+    def test_wrong_license_examples_with_failed(self):
+        """Tests for checking the license test behavior"""
+        for example in PATHS_WRONG_LINENSE_EXAMPLE:
+            lint_obj = nf_core.lint.PipelineLint(example)
+            lint_obj.check_licence()
+            expectations = {"failed": 1, "warned": 0, "passed": 0}
+            self.assess_lint_status(lint_obj, **expectations)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -29,7 +29,6 @@ WD = os.path.dirname(__file__)
 PATH_CRITICAL_EXAMPLE =  pf(WD, 'lint_examples/critical_example')
 PATH_FAILING_EXAMPLE = pf(WD, 'lint_examples/failing_example')
 PATH_WORKING_EXAMPLE = pf(WD, 'lint_examples/minimal_working_example')
-PATH_HILARIOUS_EXAMPLE = pf(WD, 'lint_examples/hilarious_example')
 
 MAX_PASS_CHECKS = 25
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -57,11 +57,6 @@ class TestLint(unittest.TestCase):
         lint_obj.check_docker()
         self.assess_lint_status(lint_obj, failed=1)
     
-    def test_missing_dockerfile_example(self):
-        """Mimics exception for file handler error on the Dockerfile"""
-        lint_obj = nf_core.lint.PipelineLint(PATH_CRITICAL_EXAMPLE)
-        lint_obj.check_docker()
-    
     @raises(AssertionError)
     def test_critical_missingfiles_example(self):
         """Tests for missing nextflow config and main.nf files"""

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -54,6 +54,7 @@ class TestLint(unittest.TestCase):
         lint_obj.lint_pipeline()
         expectations = {"failed": 0, "warned": 0, "passed": MAX_PASS_CHECKS}
         self.assess_lint_status(lint_obj, **expectations)
+        lint_obj.print_results()
 
     def test_failing_dockerfile_example(self):
         """Tests for empty Dockerfile"""

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -29,6 +29,7 @@ WD = os.path.dirname(__file__)
 PATH_CRITICAL_EXAMPLE =  pf(WD, 'lint_examples/critical_example')
 PATH_FAILING_EXAMPLE = pf(WD, 'lint_examples/failing_example')
 PATH_WORKING_EXAMPLE = pf(WD, 'lint_examples/minimal_working_example')
+PATH_HILARIOUS_EXAMPLE = pf(WD, 'lint_examples/hilarious_example')
 
 MAX_PASS_CHECKS = 14
 
@@ -57,7 +58,6 @@ class TestLint(unittest.TestCase):
         lint_obj.check_docker()
         self.assess_lint_status(lint_obj, failed=1)
     
-    @raises(IOError)
     def test_missing_dockerfile_example(self):
         """Mimics exception for file handler error on the Dockerfile"""
         lint_obj = nf_core.lint.PipelineLint(PATH_CRITICAL_EXAMPLE)
@@ -89,3 +89,9 @@ class TestLint(unittest.TestCase):
         bad_lint_obj.check_licence()
         expectations = {"failed": 1, "warned": 0, "passed": 0}
         self.assess_lint_status(bad_lint_obj, **expectations)
+
+    def test_missing_license(self):
+        """Mimics exception for file handler error on the the License"""
+        lint_obj = nf_core.lint.PipelineLint(PATH_HILARIOUS_EXAMPLE)
+        lint_obj.check_licence()
+

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -29,8 +29,10 @@ WD = os.path.dirname(__file__)
 PATH_CRITICAL_EXAMPLE =  pf(WD, 'lint_examples/critical_example')
 PATH_FAILING_EXAMPLE = pf(WD, 'lint_examples/failing_example')
 PATH_WORKING_EXAMPLE = pf(WD, 'lint_examples/minimal_working_example')
+PATH_MISSING_LICENSE_EXAMPLE = pf(WD, 'lint_examples/missing_license_example')
 PATHS_WRONG_LINENSE_EXAMPLE = [pf(WD, 'lint_examples/wrong_license_example'), 
     pf(WD, 'lint_examples/license_incomplete_example')]
+
 
 MAX_PASS_CHECKS = 25
 
@@ -86,7 +88,6 @@ class TestLint(unittest.TestCase):
         expectations = {"failed": 1, "warned": 0, "passed": 0}
         self.assess_lint_status(bad_lint_obj, **expectations)
 
-
     def test_config_variable_example_pass(self):
         """Tests that config variable existence test works with good pipeline example"""
         good_lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
@@ -101,7 +102,6 @@ class TestLint(unittest.TestCase):
         expectations = {"failed": 7, "warned": 4, "passed": 0}
         self.assess_lint_status(bad_lint_obj, **expectations)
 
-
     def test_wrong_license_examples_with_failed(self):
         """Tests for checking the license test behavior"""
         for example in PATHS_WRONG_LINENSE_EXAMPLE:
@@ -109,3 +109,10 @@ class TestLint(unittest.TestCase):
             lint_obj.check_licence()
             expectations = {"failed": 1, "warned": 0, "passed": 0}
             self.assess_lint_status(lint_obj, **expectations)
+
+    def test_missing_license_example(self):
+        """Tests for missing license behavior"""
+        lint_obj = nf_core.lint.PipelineLint(PATH_MISSING_LICENSE_EXAMPLE)
+        lint_obj.check_licence()
+        expectations = {"failed": 1, "warned": 0, "passed": 0}
+        self.assess_lint_status(lint_obj, **expectations)


### PR DESCRIPTION
Added some tests for corner cases, and check if `lint.py` is behaving as it should.