### PR TITLE
Increase code coverage

### DIFF
--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -14,7 +14,6 @@ Provide example wokflow directory contents like:
 import os
 import unittest
 import nf_core.lint
-import io
 from nose.tools import raises
 
 def listfiles(path):
@@ -34,7 +33,7 @@ PATH_MISSING_LICENSE_EXAMPLE = pf(WD, 'lint_examples/missing_license_example')
 PATHS_WRONG_LICENSE_EXAMPLE = [pf(WD, 'lint_examples/wrong_license_example'),
     pf(WD, 'lint_examples/license_incomplete_example')]
 
-
+# The maximum sum of passed tests currently possible
 MAX_PASS_CHECKS = 36
 
 class TestLint(unittest.TestCase):
@@ -47,22 +46,18 @@ class TestLint(unittest.TestCase):
             observed = len(getattr(lint_obj, list_type))
             self.assertEqual(observed, expect, "Expected {} tests in '{}', but found {}.\n{}".format(expect, list_type.upper(), observed, getattr(lint_obj, list_type)))
 
-    def test_call_lint_pipeline(self):
+    def test_call_lint_pipeline_pass(self):
         """Test the main execution function of PipelineLint (pass)
         This should not result in any exception for the minimal
         working example"""
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         lint_obj.lint_pipeline()
-        expectations = {"failed": 0, "warned": 0, "passed": MAX_PASS_CHECKS}
+        # Minimal example has no environment.yml
+        expectations = {"failed": 0, "warned": 1, "passed": MAX_PASS_CHECKS-1}
         self.assess_lint_status(lint_obj, **expectations)
-        captured_output = io.StringIO()
-        sys.stdout = captured_output
         lint_obj.print_results()
-        sys.stdout = sys.__stdout__
-        assert captured_output.getvalue()      
 
-
-    def test_call_lint_pipeline(self):
+    def test_call_lint_pipeline_fail(self):
         """Test the main execution function of PipelineLint (fail)
         This should fail after the first test and halt execution """
         lint_obj = nf_core.lint.PipelineLint(PATH_FAILING_EXAMPLE)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -53,9 +53,9 @@ class TestLint(unittest.TestCase):
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         lint_obj.lint_pipeline()
         expectations = {"failed": 0, "warned": 0, "passed": MAX_PASS_CHECKS}
-        self.assess_lint_status(lint_obj, **expectations)
         lint_obj.print_results()
-
+        self.assess_lint_status(lint_obj, **expectations)
+        
     def test_call_lint_pipeline(self):
         """Test the main execution function of PipelineLint (fail)
         This should fail after the first test and halt execution """

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -53,9 +53,9 @@ class TestLint(unittest.TestCase):
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         lint_obj.lint_pipeline()
         expectations = {"failed": 0, "warned": 0, "passed": MAX_PASS_CHECKS}
-        lint_obj.print_results()
         self.assess_lint_status(lint_obj, **expectations)
-        
+        lint_obj.print_results()
+
     def test_call_lint_pipeline(self):
         """Test the main execution function of PipelineLint (fail)
         This should fail after the first test and halt execution """

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -172,3 +172,10 @@ class TestLint(unittest.TestCase):
         lint_obj.check_readme()
         expectations = {"failed": 1, "warned": 1, "passed": 0}
         self.assess_lint_status(lint_obj, **expectations)
+
+    def test_dockerfile_pass(self):
+        """Tests if a valid Dockerfile passes the lint checks"""
+        lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
+        lint_obj.check_docker()
+        expectations = {"failed": 0, "warned": 0, "passed": 1}
+        self.assess_lint_status(lint_obj, **expectations)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -14,6 +14,7 @@ Provide example wokflow directory contents like:
 import os
 import unittest
 import nf_core.lint
+import io
 from nose.tools import raises
 
 def listfiles(path):
@@ -54,7 +55,12 @@ class TestLint(unittest.TestCase):
         lint_obj.lint_pipeline()
         expectations = {"failed": 0, "warned": 0, "passed": MAX_PASS_CHECKS}
         self.assess_lint_status(lint_obj, **expectations)
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
         lint_obj.print_results()
+        sys.stdout = sys.__stdout__
+        assert captured_output.getvalue()      
+
 
     def test_call_lint_pipeline(self):
         """Test the main execution function of PipelineLint (fail)


### PR DESCRIPTION
The function `test_call_lint_pipeline()` was present twice and screwed up the unittest.

This PR fixes the issue.