### PR TITLE
Enable testing for multiple Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-language: java
+language: python
 jdk: openjdk8
 python:
     - "2.7"
@@ -15,9 +15,9 @@ install:
   - sudo ln -s /tmp/nextflow/nextflow /usr/local/bin/nextflow
   # Set up nf-core and test/coverage modules
   - cd ${TRAVIS_BUILD_DIR}
-  - sudo pip install -e .
-  - sudo pip install codecov
-  - sudo pip install user nose
+  - pip install  -e .
+  - pip install --user codecov
+  - pip install --user nose
 
 script: nosetests --with-coverage --cover-package=nf_core
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ install:
   - sudo ln -s /tmp/nextflow/nextflow /usr/local/bin/nextflow
   # Set up nf-core and test/coverage modules
   - cd ${TRAVIS_BUILD_DIR}
-  - pip install --user -e .
-  - pip install --user codecov
-  - pip install --user nose
+  - sudo pip install -e .
+  - sudo pip install codecov
+  - sudo pip install user nose
 
 script: nosetests --with-coverage --cover-package=nf_core
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
   # Set up nf-core and test/coverage modules
   - cd ${TRAVIS_BUILD_DIR}
   - sudo pip install -e .
+  - sudo pip install -r requirements.txt
   - sudo pip install codecov
   - sudo pip install nose
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ install:
   - sudo pip install -e .
   - sudo pip install -r requirements.txt
   - sudo pip install codecov
-  - sudo pip install nose
+  - sudo pip install nose2
 
-script: python -m nose --with-coverage --cover-package=nf_core
+script: nose2 --with-coverage --coverage nf_core
 
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ install:
   - cd ${TRAVIS_BUILD_DIR}
   - sudo pip install .
   - sudo pip install -r requirements.txt
-  - sudo pip install codecov
-  - sudo pip install nose2
+  - sudo pip install codecov nose nose2
 
 script: nose2 --with-coverage --coverage nf_core
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@ install:
   - sudo ln -s /tmp/nextflow/nextflow /usr/local/bin/nextflow
   # Set up nf-core and test/coverage modules
   - cd ${TRAVIS_BUILD_DIR}
-  - sudo pip install  -e .
+  - sudo pip install -e .
   - sudo pip install codecov
   - sudo pip install nose
 
-script: nosetests --with-coverage --cover-package=nf_core
+script: python -m nose --with-coverage --cover-package=nf_core
 
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - sudo ln -s /tmp/nextflow/nextflow /usr/local/bin/nextflow
   # Set up nf-core and test/coverage modules
   - cd ${TRAVIS_BUILD_DIR}
-  - sudo pip install -e .
+  - sudo pip install .
   - sudo pip install -r requirements.txt
   - sudo pip install codecov
   - sudo pip install nose2

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ install:
   - sudo ln -s /tmp/nextflow/nextflow /usr/local/bin/nextflow
   # Set up nf-core and test/coverage modules
   - cd ${TRAVIS_BUILD_DIR}
-  - pip install  -e .
-  - pip install --user codecov
-  - pip install --user nose
+  - sudo pip install  -e .
+  - sudo pip install codecov
+  - sudo pip install nose
 
 script: nosetests --with-coverage --cover-package=nf_core
 


### PR DESCRIPTION
Addresses #20 

Enables CI testing for Python versions with Travis:

- 2.7
- 3.4
- 3.5
- 3.6

