### PR TITLE
Lots of new linting - mostly conda env

### DIFF
--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -390,7 +390,11 @@ class PipelineLint(object):
 
                     # Check if each dependency is the latest available version
                     depname, depver = dep.split('=', 1)
-                    for ch in reversed(self.conda_config.get('channels', [])):
+                    dep_channels = self.conda_config.get('channels', [])
+                    if '::' in depname:
+                        dep_channels = [depname.split('::')[0]]
+                        depname = depname.split('::')[1]
+                    for ch in reversed(dep_channels):
                         response = requests.get('https://api.anaconda.org/package/{}/{}'.format(ch, depname))
                         if response.status_code == 200:
                             dep_json = response.json()
@@ -401,8 +405,7 @@ class PipelineLint(object):
                                 self.passed.append((8, "Conda package is latest available: {}".format(dep)))
                             break
                     else:
-                        self.warned.append((8, "Could not find Conda dependency using the Anaconda API: {}".format(dep)))
-
+                        self.failed.append((8, "Could not find Conda dependency using the Anaconda API: {}".format(dep)))
 
     def print_results(self):
         # Print results

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -80,7 +80,11 @@ class PipelineLint(object):
                     break
 
     def check_files_exist(self):
-        """ Check a given pipeline directory for required files. """
+        """ Check a given pipeline directory for required files.
+
+        Throws an AssertionError if neither nextflow.config or main.nf found
+        Gives either test failures or warnings for set of other filenames
+        """
 
         # NB: Should all be files, not directories
         # Supplying a list means if any are present it's a pass
@@ -136,7 +140,7 @@ class PipelineLint(object):
 
 
     def check_docker(self):
-        """Check Dockerfile"""
+        """ Check that Dockerfile contains the string 'FROM ' """
         fn = os.path.join(self.path, "Dockerfile")
         content = ""
         with open(fn, 'r') as fh: content = fh.read()
@@ -150,7 +154,12 @@ class PipelineLint(object):
 
 
     def check_licence(self):
-        """ Check licence file is MIT """
+        """ Check licence file is MIT
+
+        Ensures that Licence file is long enough (4 or more lines)
+        Checks that licence contains the string 'without restriction'
+        Checks that licence doesn't have any placeholder variables
+        """
         for l in ['LICENSE', 'LICENSE.md', 'LICENCE', 'LICENCE.md']:
             fn = os.path.join(self.path, l)
             if os.path.isfile(fn):
@@ -189,7 +198,12 @@ class PipelineLint(object):
 
 
     def check_nextflow_config(self):
-        """ Check a given pipeline for required config variables. """
+        """ Check a given pipeline for required config variables.
+
+        Uses `nextflow config -flat` to parse pipeline nextflow.config
+        and print all config variables.
+        NB: Does NOT parse contents of main.nf / nextflow script
+        """
 
         # NB: Should all be files, not directories
         config_fail = [
@@ -264,7 +278,11 @@ class PipelineLint(object):
                 self.failed.append((4, "Config variable 'dag.file' did not end with .svg"))
 
     def check_ci_config(self):
-        """ Check that the Travis or Circle CI YAML config is valid """
+        """ Check that the Travis or Circle CI YAML config is valid
+
+        Makes sure that `nf-core lint` runs in travis tests
+        Checks that tests run with the stated nf_required_version
+        """
 
         for cf in ['.travis.yml', 'circle.yml']:
             fn = os.path.join(self.path, cf)
@@ -294,7 +312,10 @@ class PipelineLint(object):
 
 
     def check_readme(self):
-        """ Check the repository README file for errors """
+        """ Check the repository README file for errors
+
+        Currently just checks the badges at the top of the README
+        """
         with open(os.path.join(self.path, 'README.md'), 'r') as fh:
             content = fh.read()
 
@@ -324,8 +345,12 @@ class PipelineLint(object):
 
 
     def check_version_consistency(self):
-        """ Checking if versions are consistent between container,
-        release tag and config and numeric """
+        """ Check container tags versions
+
+        Runs on process.container, params.container and $TRAVIS_TAG (each only if set)
+        Check that the container has a tag
+        Check that the version numbers are numeric
+        Check that the version numbers are the same as one-another """
 
         versions = {}
         # Get the version definitions
@@ -367,7 +392,11 @@ class PipelineLint(object):
 
 
     def check_conda_env_yaml(self):
-        """ Check the conda environment file - that versions are pinned and are the latest version """
+        """ Check that the conda environment file is valid
+
+        Make sure that a name is given and is consistent with the pipeline name
+        Check that depedency versions are pinned
+        Warn if dependency versions are not the latest available """
 
         if 'environment.yml' not in self.files:
             return

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -206,9 +206,7 @@ class PipelineLint(object):
             'trace.enabled',
             'trace.file',
             'dag.enabled',
-            'dag.file',
-            'manifest.homePage',
-            'manifest.description'
+            'dag.file'
         ]
         config_warn = [
             'manifest.mainScript',
@@ -218,8 +216,7 @@ class PipelineLint(object):
             'params.reads',
             'process.container',
             'params.container',
-            'params.singleEnd',
-            'manifest.mainScript'
+            'params.singleEnd'
         ]
 
         # Call `nextflow config` and pipe stderr to /dev/null

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -200,24 +200,18 @@ class PipelineLint(object):
             'timeline.enabled',
             'trace.enabled',
             'report.enabled',
+            'dag.enabled',
             'process.cpus',
             'process.memory',
             'process.time',
-            'params.outdir',
-            'timeline.enabled',
-            'timeline.file',
-            'report.enabled',
-            'report.file',
-            'trace.enabled',
-            'trace.file',
-            'dag.enabled',
-            'dag.file'
+            'params.outdir'
         ]
         config_warn = [
             'manifest.mainScript',
             'timeline.file',
             'trace.file',
             'report.file',
+            'dag.file',
             'params.reads',
             'process.container',
             'params.container',

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -9,9 +9,14 @@ import logging
 import os
 import subprocess
 import re
+import requests
 import yaml
 
 import click
+
+# Don't pick up debug logs from the requests package
+logging.getLogger("requests").setLevel(logging.WARNING)
+logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 class PipelineLint(object):
     """ Object to hold linting info and results """
@@ -21,6 +26,8 @@ class PipelineLint(object):
         self.path = pipeline_dir
         self.files = []
         self.config = {}
+        self.pipeline_name = None
+        self.conda_config = {}
         self.passed = []
         self.warned = []
         self.failed = []
@@ -51,29 +58,29 @@ class PipelineLint(object):
         Raises:
             If a critical problem is found, an AssertionError is raised.
         """
-        normalchecks = [
+        check_functions = [
             'check_files_exist',
             'check_licence',
             'check_docker',
-            'check_config_vars',
+            'check_nextflow_config',
             'check_ci_config',
-            'check_readme'
+            'check_readme',
+            'check_conda_env_yaml'
         ]
-        releasechecks = [
-            'check_version_consistency'
-        ]
-        if release: normalchecks.extend(releasechecks)
-        with click.progressbar(normalchecks, label='Running pipeline tests') as fnames:
+        if release:
+            logging.info('Using --release linting tests')
+            check_functions.extend([
+                'check_version_consistency'
+            ])
+        with click.progressbar(check_functions, label='Running pipeline tests', item_show_func=repr) as fnames:
             for fname in fnames:
                 getattr(self, fname)()
                 if len(self.failed) > 0:
-                    logging.info("\nFound test failures in '{}', halting lint run.".format(fname))
+                    logging.error("Found test failures in '{}', halting lint run.".format(fname))
                     break
 
     def check_files_exist(self):
         """ Check a given pipeline directory for required files. """
-
-        logging.debug('Checking required files exist')
 
         # NB: Should all be files, not directories
         # Supplying a list means if any are present it's a pass
@@ -124,8 +131,7 @@ class PipelineLint(object):
 
 
     def check_docker(self):
-        """minimal tests only"""
-        logging.debug('Checking Dockerfile')
+        """Check Dockerfile"""
         fn = os.path.join(self.path, "Dockerfile")
         content = ""
         with open(fn, 'r') as fh: content = fh.read()
@@ -139,7 +145,7 @@ class PipelineLint(object):
 
 
     def check_licence(self):
-        logging.debug('Checking licence file is MIT')
+        """ Check licence file is MIT """
         for l in ['LICENSE', 'LICENSE.md', 'LICENCE', 'LICENCE.md']:
             fn = os.path.join(self.path, l)
             if os.path.isfile(fn):
@@ -177,10 +183,8 @@ class PipelineLint(object):
         self.failed.append((3, "Couldn't find MIT licence file"))
 
 
-    def check_config_vars(self):
+    def check_nextflow_config(self):
         """ Check a given pipeline for required config variables. """
-
-        logging.debug('Checking pipeline config variables')
 
         # NB: Should all be files, not directories
         config_fail = [
@@ -194,7 +198,17 @@ class PipelineLint(object):
             'process.cpus',
             'process.memory',
             'process.time',
-            'params.outdir'
+            'params.outdir',
+            'timeline.enabled',
+            'timeline.file',
+            'report.enabled',
+            'report.file',
+            'trace.enabled',
+            'trace.file',
+            'dag.enabled',
+            'dag.file',
+            'manifest.homePage',
+            'manifest.description'
         ]
         config_warn = [
             'manifest.mainScript',
@@ -204,7 +218,8 @@ class PipelineLint(object):
             'params.reads',
             'process.container',
             'params.container',
-            'params.singleEnd'
+            'params.singleEnd',
+            'manifest.mainScript'
         ]
 
         # Call `nextflow config` and pipe stderr to /dev/null
@@ -229,10 +244,25 @@ class PipelineLint(object):
                 else:
                     self.warned.append((4, "Config variable not found: {}".format(cf)))
 
+        # Check the variables that should be set to 'true'
+        for k in ['timeline.enabled', 'report.enabled', 'trace.enabled', 'dag.enabled']:
+            if self.config.get(k) == 'true':
+                self.passed.append((4, "Config variable '{}' had correct value: {}".format(k, self.config.get(k))))
+            else:
+                self.failed.append((4, "Config variable '{}' did not have correct value: {}".format(k, self.config.get(k))))
+
+        # Check that the homePage is set to the GitHub URL
+        try:
+            assert self.config['manifest.homePage'].strip("'")[0:27] == 'https://github.com/nf-core/'
+        except AssertionError, IndexError:
+            self.failed.append((4, "Config variable 'manifest.homePage' did not begin with https://github.com/nf-core/:\n    {}".format(self.config['manifest.homePage'].strip("'"))))
+        else:
+            self.passed.append((4, "Config variable 'manifest.homePage' began with 'https://github.com/nf-core/'"))
+            self.pipeline_name = self.config['manifest.homePage'][28:].rstrip("'")
 
     def check_ci_config(self):
         """ Check that the Travis or Circle CI YAML config is valid """
-        logging.debug('Checking continuous integration testing config')
+
         for cf in ['.travis.yml', 'circle.yml']:
             fn = os.path.join(self.path, cf)
             if os.path.isfile(fn):
@@ -262,7 +292,6 @@ class PipelineLint(object):
 
     def check_readme(self):
         """ Check the repository README file for errors """
-        logging.debug('Checking the repository README')
         with open(os.path.join(self.path, 'README.md'), 'r') as fh:
             content = fh.read()
 
@@ -295,7 +324,6 @@ class PipelineLint(object):
         """ Checking if versions are consistent between container,
         release tag and config and numeric """
 
-        logging.debug('Checking if versions are consistent between container, release tag and config and numeric')
         versions = {}
         # Get the version definitions
         # Get version from nextflow.config
@@ -335,14 +363,58 @@ class PipelineLint(object):
         self.passed.append((7, "Version tags are numeric and consistent between container, release tag and config."))
 
 
+    def check_conda_env_yaml(self):
+        """ Check the conda environment file - that versions are pinned and are the latest version """
+
+        if 'environment.yml' not in self.files:
+            return
+
+        with open(os.path.join(self.path, 'environment.yml'), 'r') as fh:
+            self.conda_config = yaml.load(fh)
+
+        # Check that the environment name matches the pipeline name
+        if self.conda_config['name'] != 'nfcore-{}'.format(self.pipeline_name):
+            self.failed.append((8, "Conda environment name is not consistent ('{}', should be 'nfcore-{}')".format(self.conda_config['name'], self.pipeline_name)))
+        else:
+            self.passed.append((8, "Conda environment name was consistent ('{}')".format(self.conda_config['name'])))
+
+        # Check conda dependency list
+        for dep in self.conda_config.get('dependencies', []):
+            if isinstance(dep, str):
+                # Check that each dependency has a verion number
+                try:
+                    assert dep.count('=') == 1
+                except:
+                    self.failed.append((8, "Conda dependency did not have pinned version number: {}".format(dep)))
+                else:
+                    self.passed.append((8, "Conda dependency had pinned version number: {}".format(dep)))
+
+                    # Check if each dependency is the latest available version
+                    depname, depver = dep.split('=', 1)
+                    for ch in reversed(self.conda_config.get('channels', [])):
+                        response = requests.get('https://api.anaconda.org/package/{}/{}'.format(ch, depname))
+                        if response.status_code == 200:
+                            dep_json = response.json()
+                            last_ver = dep_json.get('latest_version')
+                            if last_ver is not None and last_ver != depver:
+                                self.warned.append((8, "Conda package is not latest available: {}, {} available".format(dep, last_ver)))
+                            else:
+                                self.passed.append((8, "Conda package is latest available: {}".format(dep)))
+                            break
+                    else:
+                        self.warned.append((8, "Could not find Conda dependency using the Anaconda API: {}".format(dep)))
+
+
     def print_results(self):
         # Print results
-        logging.info("\n=================\n LINTING RESULTS\n=================\n")
-        print("{0:>4} tests passed".format(len(self.passed)))
-        print("{0:>4} tests had warnings".format(len(self.warned)))
-        print("{0:>4} tests failed".format(len(self.failed)))
+        logging.info("===========\n LINTING RESULTS\n=================\n" +
+            "{0:>4} tests passed".format(len(self.passed)) +
+            "{0:>4} tests had warnings".format(len(self.warned)) +
+            "{0:>4} tests failed".format(len(self.failed))
+        )
+        if len(self.passed) > 0:
+            logging.debug("Test Passed:\n  {}".format("\n  ".join(["https://nf-core.github.io/errors#{}: {}".format(eid, msg) for eid, msg in self.passed])))
         if len(self.warned) > 0:
-            print("\nWarnings:\n  {}".format("\n  ".join(["https://nf-core.github.io/errors#{}: {}".format(eid, msg) for eid, msg in self.warned])))
+            logging.warn("Test Warnings:\n  {}".format("\n  ".join(["https://nf-core.github.io/errors#{}: {}".format(eid, msg) for eid, msg in self.warned])))
         if len(self.failed) > 0:
-            print("\nFAILURES:\n  {}".format("\n  ".join(["https://nf-core.github.io/errors#{}: {}".format(eid, msg) for eid, msg in self.failed])))
-        print("\n")
+            logging.error("Test Failures:\n  {}".format("\n  ".join(["https://nf-core.github.io/errors#{}: {}".format(eid, msg) for eid, msg in self.failed])))

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -129,6 +129,11 @@ class PipelineLint(object):
             else:
                 self.warned.append((1, "File not found: {}".format(files)))
 
+        # Load and parse files for later
+        if 'environment.yml' in self.files:
+            with open(os.path.join(self.path, 'environment.yml'), 'r') as fh:
+                self.conda_config = yaml.load(fh)
+
 
     def check_docker(self):
         """Check Dockerfile"""
@@ -365,9 +370,6 @@ class PipelineLint(object):
 
         if 'environment.yml' not in self.files:
             return
-
-        with open(os.path.join(self.path, 'environment.yml'), 'r') as fh:
-            self.conda_config = yaml.load(fh)
 
         # Check that the environment name matches the pipeline name
         if self.conda_config['name'] != 'nfcore-{}'.format(self.pipeline_name):

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -249,12 +249,19 @@ class PipelineLint(object):
 
         # Check that the homePage is set to the GitHub URL
         try:
-            assert self.config['manifest.homePage'].strip("'")[0:27] == 'https://github.com/nf-core/'
+            assert self.config['manifest.homePage'].strip('\'"')[0:27] == 'https://github.com/nf-core/'
         except AssertionError, IndexError:
-            self.failed.append((4, "Config variable 'manifest.homePage' did not begin with https://github.com/nf-core/:\n    {}".format(self.config['manifest.homePage'].strip("'"))))
+            self.failed.append((4, "Config variable 'manifest.homePage' did not begin with https://github.com/nf-core/:\n    {}".format(self.config['manifest.homePage'].strip('\'"'))))
         else:
             self.passed.append((4, "Config variable 'manifest.homePage' began with 'https://github.com/nf-core/'"))
             self.pipeline_name = self.config['manifest.homePage'][28:].rstrip("'")
+
+        # Check that the DAG filename ends in `.svg`
+        if 'dag.file' in self.config:
+            if self.config['dag.file'].strip('\'"').endswith('.svg'):
+                self.passed.append((4, "Config variable 'dag.file' ended with .svg"))
+            else:
+                self.failed.append((4, "Config variable 'dag.file' did not end with .svg"))
 
     def check_ci_config(self):
         """ Check that the Travis or Circle CI YAML config is valid """

--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -11,12 +11,19 @@ import nf_core
 import nf_core.lint
 
 import logging
-logging.basicConfig(level=logging.INFO)
 
 @click.group()
 @click.version_option(nf_core.__version__)
-def nf_core_cli():
-    pass
+@click.option(
+    '-v', '--verbose',
+    is_flag = True,
+    help = "Verbose output (print debug statements)"
+)
+def nf_core_cli(verbose):
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG, format="\n%(levelname)s: %(message)s")
+    else:
+        logging.basicConfig(level=logging.INFO, format="\n%(levelname)s: %(message)s")
 
 @nf_core_cli.command()
 @click.argument(
@@ -26,13 +33,14 @@ def nf_core_cli():
     metavar = "<pipeline directory>"
 )
 @click.option(
-    '--release', 
-    is_flag=True,
+    '--release',
+    is_flag = True,
     default = os.environ.get('TRAVIS_BRANCH') == 'master',
     help = "Execute additional checks for release-ready workflows."
 )
 def lint(pipeline_dir, release):
     """Check pipeline against nf-core guidelines"""
+
     # Create the lint object
     lint_obj = nf_core.lint.PipelineLint(pipeline_dir)
 
@@ -49,7 +57,7 @@ def lint(pipeline_dir, release):
 
     # Exit code
     if len(lint_obj.failed) > 0:
-        logging.info("Sorry, some tests failed - exiting with a non-zero error code...")
+        logging.error("Sorry, some tests failed - exiting with a non-zero error code...\n\n")
         sys.exit(1)
 
 

--- a/tests/lint_examples/failing_example/nextflow.config
+++ b/tests/lint_examples/failing_example/nextflow.config
@@ -1,1 +1,3 @@
 manifest.homePage = 'https://nf-core.github.io/pipelines'
+
+dag.file = "dag.html"

--- a/tests/lint_examples/failing_example/nextflow.config
+++ b/tests/lint_examples/failing_example/nextflow.config
@@ -1,0 +1,1 @@
+manifest.homePage = 'https://nf-core.github.io/pipelines'

--- a/tests/lint_examples/minimal_working_example/environment.yml
+++ b/tests/lint_examples/minimal_working_example/environment.yml
@@ -6,4 +6,7 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - multiqc=1.5
+  - conda-forge::openjdk=8.0.144
+  - fastqc=0.11.7
+  - pip:
+    - multiqc

--- a/tests/lint_examples/minimal_working_example/environment.yml
+++ b/tests/lint_examples/minimal_working_example/environment.yml
@@ -1,0 +1,9 @@
+# You can use this file to create a conda environment for this pipeline:
+#   conda env create -f environment.yml
+name: nfcore-tools
+channels:
+  - defaults
+  - conda-forge
+  - bioconda
+dependencies:
+  - multiqc=1.5

--- a/tests/lint_examples/minimal_working_example/nextflow.config
+++ b/tests/lint_examples/minimal_working_example/nextflow.config
@@ -30,6 +30,10 @@ trace {
   enabled = true
   file = "trace.txt"
 }
+dag {
+  enabled = true
+  file = "dag.html"
+}
 
 manifest {
   homePage = 'https://github.com/nf-core/tools'

--- a/tests/lint_examples/minimal_working_example/nextflow.config
+++ b/tests/lint_examples/minimal_working_example/nextflow.config
@@ -32,7 +32,7 @@ trace {
 }
 dag {
   enabled = true
-  file = "dag.html"
+  file = "dag.svg"
 }
 
 manifest {

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -34,7 +34,7 @@ PATHS_WRONG_LICENSE_EXAMPLE = [pf(WD, 'lint_examples/wrong_license_example'),
     pf(WD, 'lint_examples/license_incomplete_example')]
 
 # The maximum sum of passed tests currently possible
-MAX_PASS_CHECKS = 37
+MAX_PASS_CHECKS = 50
 # The additional tests passed for releases
 ADD_PASS_RELEASE = 1
 
@@ -103,15 +103,15 @@ class TestLint(unittest.TestCase):
     def test_config_variable_example_pass(self):
         """Tests that config variable existence test works with good pipeline example"""
         good_lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
-        good_lint_obj.check_config_vars()
-        expectations = {"failed": 0, "warned": 0, "passed": 19}
+        good_lint_obj.check_nextflow_config()
+        expectations = {"failed": 0, "warned": 0, "passed": 32}
         self.assess_lint_status(good_lint_obj, **expectations)
 
     def test_config_variable_example_with_failed(self):
         """Tests that config variable existence test works with bad pipeline example"""
         bad_lint_obj = nf_core.lint.PipelineLint(PATH_FAILING_EXAMPLE)
-        bad_lint_obj.check_config_vars()
-        expectations = {"failed": 11, "warned": 8, "passed": 0}
+        bad_lint_obj.check_nextflow_config()
+        expectations = {"failed": 23, "warned": 8, "passed": 1}
         self.assess_lint_status(bad_lint_obj, **expectations)
 
     def test_ci_conf_pass(self):
@@ -190,7 +190,7 @@ class TestLint(unittest.TestCase):
         lint_obj.lint_pipeline(release=True)
         expectations = {"failed": 1, "warned": 1, "passed": MAX_PASS_CHECKS - 1}
         self.assess_lint_status(lint_obj, **expectations)
-    
+
     def test_version_consistency_pass(self):
         """Tests the workflow version and container version sucessfully"""
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
@@ -199,7 +199,7 @@ class TestLint(unittest.TestCase):
         lint_obj.check_version_consistency()
         expectations = {"failed": 0, "warned": 0, "passed": 1}
         self.assess_lint_status(lint_obj, **expectations)
-    
+
     def test_version_consistency_with_env_fail(self):
         """Tests the behaviour, when a git activity is a release
         and simulate wrong release tag"""
@@ -224,7 +224,7 @@ class TestLint(unittest.TestCase):
 
     def test_version_consistency_with_env_pass(self):
         """Tests the behaviour, when a git activity is a release
-        and simulate correct release tag"""       
+        and simulate correct release tag"""
         os.environ["TRAVIS_TAG"] = "0.4"
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         lint_obj.config["params.version"] = "0.4"
@@ -232,4 +232,3 @@ class TestLint(unittest.TestCase):
         lint_obj.check_version_consistency()
         expectations = {"failed": 0, "warned": 0, "passed": 1}
         self.assess_lint_status(lint_obj, **expectations)
-    

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -35,7 +35,7 @@ PATHS_WRONG_LICENSE_EXAMPLE = [pf(WD, 'lint_examples/wrong_license_example'),
     pf(WD, 'lint_examples/license_incomplete_example')]
 
 # The maximum sum of passed tests currently possible
-MAX_PASS_CHECKS = 57
+MAX_PASS_CHECKS = 51
 # The additional tests passed for releases
 ADD_PASS_RELEASE = 1
 
@@ -113,14 +113,14 @@ class TestLint(unittest.TestCase):
         """Tests that config variable existence test works with good pipeline example"""
         good_lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         good_lint_obj.check_nextflow_config()
-        expectations = {"failed": 0, "warned": 0, "passed": 32}
+        expectations = {"failed": 0, "warned": 0, "passed": 26}
         self.assess_lint_status(good_lint_obj, **expectations)
 
     def test_config_variable_example_with_failed(self):
-        """Tests that config variable existence test works with bad pipeline example"""
+        """Tests that config variable existence test fails with bad pipeline example"""
         bad_lint_obj = nf_core.lint.PipelineLint(PATH_FAILING_EXAMPLE)
         bad_lint_obj.check_nextflow_config()
-        expectations = {"failed": 23, "warned": 8, "passed": 1}
+        expectations = {"failed": 16, "warned": 9, "passed": 1}
         self.assess_lint_status(bad_lint_obj, **expectations)
 
     @raises(AssertionError)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -35,7 +35,7 @@ PATHS_WRONG_LICENSE_EXAMPLE = [pf(WD, 'lint_examples/wrong_license_example'),
     pf(WD, 'lint_examples/license_incomplete_example')]
 
 # The maximum sum of passed tests currently possible
-MAX_PASS_CHECKS = 51
+MAX_PASS_CHECKS = 52
 # The additional tests passed for releases
 ADD_PASS_RELEASE = 1
 
@@ -113,14 +113,14 @@ class TestLint(unittest.TestCase):
         """Tests that config variable existence test works with good pipeline example"""
         good_lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         good_lint_obj.check_nextflow_config()
-        expectations = {"failed": 0, "warned": 0, "passed": 26}
+        expectations = {"failed": 0, "warned": 0, "passed": 27}
         self.assess_lint_status(good_lint_obj, **expectations)
 
     def test_config_variable_example_with_failed(self):
         """Tests that config variable existence test fails with bad pipeline example"""
         bad_lint_obj = nf_core.lint.PipelineLint(PATH_FAILING_EXAMPLE)
         bad_lint_obj.check_nextflow_config()
-        expectations = {"failed": 16, "warned": 9, "passed": 1}
+        expectations = {"failed": 17, "warned": 8, "passed": 2}
         self.assess_lint_status(bad_lint_obj, **expectations)
 
     @raises(AssertionError)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -123,6 +123,12 @@ class TestLint(unittest.TestCase):
         expectations = {"failed": 23, "warned": 8, "passed": 1}
         self.assess_lint_status(bad_lint_obj, **expectations)
 
+    @raises(AssertionError)
+    def test_config_variable_error(self):
+        """Tests that config variable existence test falls over nicely with nextflow can't run"""
+        bad_lint_obj = nf_core.lint.PipelineLint('/non/existant/path')
+        bad_lint_obj.check_nextflow_config()
+
     def test_ci_conf_pass(self):
         """Tests that the continous integration config checks work with a good example"""
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
@@ -208,6 +214,7 @@ class TestLint(unittest.TestCase):
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         lint_obj.config["params.version"] = "0.4"
         lint_obj.config["params.container"] = "nfcore/tools:0.4"
+        lint_obj.config["process.container"] = "nfcore/tools:0.4"
         lint_obj.check_version_consistency()
         expectations = {"failed": 1, "warned": 0, "passed": 0}
         self.assess_lint_status(lint_obj, **expectations)
@@ -255,4 +262,11 @@ class TestLint(unittest.TestCase):
         lint_obj.pipeline_name = 'not_tools'
         lint_obj.check_conda_env_yaml()
         expectations = {"failed": 2, "warned": 2, "passed": 2}
+        self.assess_lint_status(lint_obj, **expectations)
+
+    def test_conda_env_skip(self):
+        """ Tests the conda environment config is skipped when not needed """
+        lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
+        lint_obj.check_conda_env_yaml()
+        expectations = {"failed": 0, "warned": 0, "passed": 0}
         self.assess_lint_status(lint_obj, **expectations)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -47,7 +47,8 @@ class TestLint(unittest.TestCase):
         object status lists"""
         for list_type, expect in expected.items():
             observed = len(getattr(lint_obj, list_type))
-            self.assertEqual(observed, expect, "Expected {} tests in '{}', but found {}.\n{}".format(expect, list_type.upper(), observed, getattr(lint_obj, list_type)))
+            oberved_list = yaml.safe_dump(getattr(lint_obj, list_type))
+            self.assertEqual(observed, expect, "Expected {} tests in '{}', but found {}.\n{}".format(expect, list_type.upper(), observed, oberved_list))
 
     def test_call_lint_pipeline_pass(self):
         """Test the main execution function of PipelineLint (pass)
@@ -262,6 +263,17 @@ class TestLint(unittest.TestCase):
         lint_obj.pipeline_name = 'not_tools'
         lint_obj.check_conda_env_yaml()
         expectations = {"failed": 3, "warned": 1, "passed": 2}
+        self.assess_lint_status(lint_obj, **expectations)
+
+    def test_conda_env_timeout(self):
+        """ Tests the conda environment handles API timeouts """
+        lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
+        lint_obj.files = ['environment.yml']
+        with open(os.path.join(PATH_WORKING_EXAMPLE, 'environment.yml'), 'r') as fh:
+            lint_obj.conda_config = yaml.load(fh)
+        lint_obj.pipeline_name = 'tools'
+        lint_obj.check_conda_env_yaml(api_timeout=0.0001)
+        expectations = {"failed": 2, "warned": 4, "passed": 3}
         self.assess_lint_status(lint_obj, **expectations)
 
     def test_conda_env_skip(self):

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -35,7 +35,7 @@ PATHS_WRONG_LICENSE_EXAMPLE = [pf(WD, 'lint_examples/wrong_license_example'),
     pf(WD, 'lint_examples/license_incomplete_example')]
 
 # The maximum sum of passed tests currently possible
-MAX_PASS_CHECKS = 55
+MAX_PASS_CHECKS = 57
 # The additional tests passed for releases
 ADD_PASS_RELEASE = 1
 
@@ -249,7 +249,7 @@ class TestLint(unittest.TestCase):
             lint_obj.conda_config = yaml.load(fh)
         lint_obj.pipeline_name = 'tools'
         lint_obj.check_conda_env_yaml()
-        expectations = {"failed": 0, "warned": 0, "passed": 3}
+        expectations = {"failed": 0, "warned": 0, "passed": 5}
         self.assess_lint_status(lint_obj, **expectations)
 
     def test_conda_env_fail(self):
@@ -261,7 +261,7 @@ class TestLint(unittest.TestCase):
         lint_obj.conda_config['dependencies'] = ['fastqc', 'multiqc=0.9', 'notapackaage=0.4']
         lint_obj.pipeline_name = 'not_tools'
         lint_obj.check_conda_env_yaml()
-        expectations = {"failed": 2, "warned": 2, "passed": 2}
+        expectations = {"failed": 3, "warned": 1, "passed": 2}
         self.assess_lint_status(lint_obj, **expectations)
 
     def test_conda_env_skip(self):


### PR DESCRIPTION
A WIP pull-request! Most of the core code now written though, so feel free to provide comments..

### Still to do:

* [x] Check that tests work (or at least, don't break) with more complex conda environment files
  * Specifically sublists, such as can be done with `pip` packages
* [x] Write tests!
* [x] Update nf-core website documentation (see nf-core/nf-core.github.io#25)

### Done so far:

A little refactoring:

* Progress bar now tells you the name of the function that is currently running
* New `-v` /  `--verbose` command line flag to print logging debug statements
* Passing test results now shown if debug messages shown
* Logging has been tidied up a bit
    * Nicer log message formatting
    * No more debug statements that mess up the progress bar

Some new linting tests:

* Additional config variables which weren't checked before
    * Checks that dag is turned on by default and that the filename ends with `.svg`
    * Checks that the manifest URL is set to nf-core GitHub, uses this URL to parse the workflow name
* New tests for the conda environment file
    * Make sure that the `name` matches the pipeline name (eg. `nfcore-name`)
    * Checks that dependencies have a pinned version number
    * Uses the anaconda API to check whether this is the latest version available

This works beautifully with my main test suite, the https://github.com/nf-core/methylseq pipeline, finding several problems that I was not aware of:

```
$ nf-core lint .
Running pipeline tests  [####################################]  100%  'check_conda_env_yaml'
ERROR: Found test failures in 'check_conda_env_yaml', halting lint run.


INFO: ===========
 LINTING RESULTS
=================
  73 tests passed   3 tests had warnings   1 tests failed

WARNING: Test Warnings:
  https://nf-core.github.io/errors#8: Conda package is not latest available: fastqc=0.11.5, 0.11.7 available
  https://nf-core.github.io/errors#8: Conda package is not latest available: multiqc=1.4, 1.5 available
  https://nf-core.github.io/errors#8: Conda package is not latest available: picard=2.17.8, 2.18.0 available

ERROR: Test Failures:
  https://nf-core.github.io/errors#8: Conda dependency did not have pinned version number: conda-forge::openjdk

ERROR: Sorry, some tests failed - exiting with a non-zero error code...
```