### PR TITLE
Fix py3.6 syntax error

### DIFF
--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -265,7 +265,7 @@ class PipelineLint(object):
         # Check that the homePage is set to the GitHub URL
         try:
             assert self.config['manifest.homePage'].strip('\'"')[0:27] == 'https://github.com/nf-core/'
-        except AssertionError, IndexError:
+        except (AssertionError, IndexError):
             self.failed.append((4, "Config variable 'manifest.homePage' did not begin with https://github.com/nf-core/:\n    {}".format(self.config['manifest.homePage'].strip('\'"'))))
         else:
             self.passed.append((4, "Config variable 'manifest.homePage' began with 'https://github.com/nf-core/'"))


### PR DESCRIPTION
I have no idea why the tests pass with this 🤔 

But running on a pipeline with 3.6 throws a syntax error without this fix. Tests run fine...