### PR TITLE
New lint test for Dockerfile that builds from conda

### DIFF
--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -68,7 +68,7 @@ class PipelineLint(object):
             'check_ci_config',
             'check_readme',
             'check_conda_env_yaml',
-            'check_docker_conda_build'
+            'check_conda_dockerfile'
         ]
         if release:
             logging.info('Using --release linting tests')
@@ -447,7 +447,7 @@ class PipelineLint(object):
                     else:
                         self.failed.append((8, "Could not find Conda dependency using the Anaconda API: {}".format(dep)))
 
-    def check_docker_conda_build(self):
+    def check_conda_dockerfile(self):
         """ Check that the Docker build file looks right, if working with conda
 
         Make sure that a name is given and is consistent with the pipeline name

--- a/tests/lint_examples/minimal_working_example/Dockerfile
+++ b/tests/lint_examples/minimal_working_example/Dockerfile
@@ -1,1 +1,10 @@
-FROM busybox
+FROM continuumio/miniconda
+MAINTAINER Phil Ewels <phil.ewels@scilifelab.se>
+LABEL authors="phil.ewels@scilifelab.se" \
+    description="Docker image containing all requirements for the nf-core tools pipeline"
+
+COPY environment.yml /
+RUN conda update -n base conda && \
+    conda env create -f /environment.yml && \
+    conda clean -a
+ENV PATH /opt/conda/envs/nfcore-tools/bin:$PATH

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -35,7 +35,7 @@ PATHS_WRONG_LICENSE_EXAMPLE = [pf(WD, 'lint_examples/wrong_license_example'),
     pf(WD, 'lint_examples/license_incomplete_example')]
 
 # The maximum sum of passed tests currently possible
-MAX_PASS_CHECKS = 52
+MAX_PASS_CHECKS = 53
 # The additional tests passed for releases
 ADD_PASS_RELEASE = 1
 
@@ -280,5 +280,33 @@ class TestLint(unittest.TestCase):
         """ Tests the conda environment config is skipped when not needed """
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         lint_obj.check_conda_env_yaml()
+        expectations = {"failed": 0, "warned": 0, "passed": 0}
+        self.assess_lint_status(lint_obj, **expectations)
+
+    def test_conda_dockerfile_pass(self):
+        """ Tests the conda Dockerfile test works with a working example """
+        lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
+        lint_obj.files = ['environment.yml']
+        with open(os.path.join(PATH_WORKING_EXAMPLE, 'Dockerfile'), 'r') as fh:
+            lint_obj.dockerfile = fh.read().splitlines()
+        lint_obj.conda_config['name'] = 'nfcore-tools'
+        lint_obj.check_conda_dockerfile()
+        expectations = {"failed": 0, "warned": 0, "passed": 1}
+        self.assess_lint_status(lint_obj, **expectations)
+
+    def test_conda_dockerfile_fail(self):
+        """ Tests the conda Dockerfile test fails with a bad example """
+        lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
+        lint_obj.files = ['environment.yml']
+        lint_obj.conda_config['name'] = 'nfcore-tools'
+        lint_obj.dockerfile = ['fubar']
+        lint_obj.check_conda_dockerfile()
+        expectations = {"failed": 6, "warned": 0, "passed": 0}
+        self.assess_lint_status(lint_obj, **expectations)
+
+    def test_conda_dockerfile_skip(self):
+        """ Tests the conda Dockerfile test is skipped when not needed """
+        lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
+        lint_obj.check_conda_dockerfile()
         expectations = {"failed": 0, "warned": 0, "passed": 0}
         self.assess_lint_status(lint_obj, **expectations)


### PR DESCRIPTION
New linting tests to detect the [latest bug](https://github.com/ewels/NGI-RNAseq/commit/2b4f5cbe2f87cbbdcccb323d4387d28798ceaf76) I came across in the NGI-RNAseq port to nf-core.

Basically, if we have a `environment.yml` and `Dockerfile` then it checks that the Dockerfile contains the lines we want it to. It doesn't check the entire file contents, as people may want to customise the meta information and add extra stuff.