### PR TITLE
Made --release mode activity more obvious in the test results logs

### DIFF
--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -24,6 +24,7 @@ class PipelineLint(object):
 
     def __init__(self, pipeline_dir):
         """ Initialise linting object """
+        self.releaseMode = False
         self.path = pipeline_dir
         self.files = []
         self.config = {}
@@ -69,7 +70,7 @@ class PipelineLint(object):
             'check_conda_env_yaml'
         ]
         if release:
-            logging.info('Using --release linting tests')
+            self.releaseMode = True
             check_functions.extend([
                 'check_version_consistency'
             ])
@@ -446,10 +447,11 @@ class PipelineLint(object):
 
     def print_results(self):
         # Print results
+        rl = "\n  Using --release mode linting tests" if self.releaseMode else ''
         logging.info("===========\n LINTING RESULTS\n=================\n" +
             "{0:>4} tests passed".format(len(self.passed)) +
             "{0:>4} tests had warnings".format(len(self.warned)) +
-            "{0:>4} tests failed".format(len(self.failed))
+            "{0:>4} tests failed".format(len(self.failed)) + rl
         )
         if len(self.passed) > 0:
             logging.debug("Test Passed:\n  {}".format("\n  ".join(["https://nf-core.github.io/errors#{}: {}".format(eid, msg) for eid, msg in self.passed])))

--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -57,7 +57,10 @@ def lint(pipeline_dir, release):
 
     # Exit code
     if len(lint_obj.failed) > 0:
-        logging.error("Sorry, some tests failed - exiting with a non-zero error code...\n\n")
+        logging.error(
+            "Sorry, some tests failed - exiting with a non-zero error code...{}\n\n"
+            .format("\n       Reminder: Lint tests were run in --release mode." if release else '')
+        )
         sys.exit(1)
 
 


### PR DESCRIPTION
As highlighted in https://github.com/nf-core/cookiecutter/pull/19, it's currently not very obvious when the tests are running with `--release` (which they do automatically on Travis under certain circumstances).

These changes move the log message down to the main lint results so that it can't be missed, as well as a bonus message when there are failures.