### PR TITLE
Small fixes for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ LABEL authors="phil.ewels@scilifelab.se,alexander.peltzer@qbic.uni-tuebingen.de"
       description="Docker image containing base requirements for the nfcore pipelines"
 
 # Install procps so that Nextflow can poll CPU usage
-RUN apt-get update && apt-get install procps && apt-get purge
+RUN apt-get update && apt-get install -y procps && apt-get clean -y 
 # Update the base version of conda
 RUN conda update -n base conda


### PR DESCRIPTION
- Keep the base smaller with `apt-get clean -y`
- Automatically confirm installation `apt-get install -y procps`

