### PR TITLE
Get bioconda env name test to include pipeline version.

### DIFF
--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -408,10 +408,11 @@ class PipelineLint(object):
             return
 
         # Check that the environment name matches the pipeline name
-        if self.conda_config['name'] != 'nfcore-{}'.format(self.pipeline_name.lower()):
-            self.failed.append((8, "Conda environment name is not consistent ('{}', should be 'nfcore-{}')".format(self.conda_config['name'], self.pipeline_name.lower())))
+        pipeline_version = self.config['params.version'].strip(' \'"')
+        if self.conda_config['name'] != 'nfcore-{}-{}'.format(self.pipeline_name.lower(), pipeline_version):
+            self.failed.append((8, "Conda environment name is incorrect ('{}', should be 'nfcore-{}')".format(self.conda_config['name'], self.pipeline_name.lower())))
         else:
-            self.passed.append((8, "Conda environment name was consistent ('{}')".format(self.conda_config['name'])))
+            self.passed.append((8, "Conda environment name was correct ('{}')".format(self.conda_config['name'])))
 
         # Check conda dependency list
         for dep in self.conda_config.get('dependencies', []):


### PR DESCRIPTION
Enforce the pattern of `nfcore-[pipeline name]-[pipeline version]` for conda environment name.

See also https://github.com/nf-core/cookiecutter/pull/23