### PR TITLE
New subcommand: release (bumps version numbers)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   # Set up nf-core and test/coverage modules
   - cd ${TRAVIS_BUILD_DIR}
   - pip install .
-  - pip install codecov pytest pytest-cov mock
+  - pip install codecov pytest pytest-datafiles pytest-cov mock
 
 script: python -m pytest --cov=nf_core .
 

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -31,7 +31,8 @@ def run_linting(pipeline_dir, release):
     except AssertionError as e:
         logging.critical("Critical error: {}".format(e))
         logging.info("Stopping tests...")
-        sys.exit(1)
+        lint_obj.print_results()
+        return lint_obj
 
     # Print the results
     lint_obj.print_results()
@@ -42,7 +43,6 @@ def run_linting(pipeline_dir, release):
             "Sorry, some tests failed - exiting with a non-zero error code...{}\n\n"
             .format("\n       Reminder: Lint tests were run in --release mode." if release else '')
         )
-        sys.exit(1)
 
     return lint_obj
 

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -19,6 +19,34 @@ import click
 logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 
+def run_linting(pipeline_dir, release):
+    """ Run all linting tests. Called by main script. """
+
+    # Create the lint object
+    lint_obj = PipelineLint(pipeline_dir)
+
+    # Run the linting tests
+    try:
+        lint_obj.lint_pipeline(release)
+    except AssertionError as e:
+        logging.critical("Critical error: {}".format(e))
+        logging.info("Stopping tests...")
+        sys.exit(1)
+
+    # Print the results
+    lint_obj.print_results()
+
+    # Exit code
+    if len(lint_obj.failed) > 0:
+        logging.error(
+            "Sorry, some tests failed - exiting with a non-zero error code...{}\n\n"
+            .format("\n       Reminder: Lint tests were run in --release mode." if release else '')
+        )
+        sys.exit(1)
+
+    return lint_obj
+
+
 class PipelineLint(object):
     """ Object to hold linting info and results """
 

--- a/nf_core/release.py
+++ b/nf_core/release.py
@@ -59,11 +59,9 @@ def update_file_version(filename, lint_obj, pattern, newstr):
     # Check that we have exactly one match
     matches = re.findall(pattern, content)
     if len(matches) == 0:
-        logging.error("Could not find version number in {}".format(filename))
-        return None
+        raise SyntaxError ("Could not find version number in {}: '{}'".format(filename, pattern))
     if len(matches) > 1:
-        logging.error("Found more than one version number in {}".format(filename))
-        return None
+        raise SyntaxError ("Found more than one version number in {}: '{}'".format(filename, pattern))
 
     # Replace the match
     logging.info("Updating version in {}\n - {}\n + {}".format(filename, matches[0], newstr))

--- a/nf_core/release.py
+++ b/nf_core/release.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+""" Release code for the nf-core python package.
+
+Bumps the version number in all appropriate files for
+a nf-core pipeline
+"""
+
+import logging
+import os
+import re
+from distutils.version import StrictVersion
+
+def make_release(lint_obj, new_version):
+    """ Function to make the release. Called by the main script """
+
+    # Collect the old and new version numbers
+    current_version = lint_obj.config['params.version'].strip(' \'"')
+    if new_version.startswith('v'):
+        logging.warn("Stripping leading 'v' from new version number")
+        new_version = new_version[1:]
+    logging.info("Changing version number:\n  Current version number is '{}'\n  New version number will be '{}'".format(current_version, new_version))
+
+    # Update nextflow.config
+    nfconfig_pattern = r"version\s*=\s*[\'\"]?{}[\'\"]?".format(current_version.replace('.','\.'))
+    nfconfig_newstr = "version = '{}'".format(new_version)
+    update_file_version("nextflow.config", lint_obj, nfconfig_pattern, nfconfig_newstr)
+
+    # Update Docker tag
+    docker_tag = 'latest'
+    if new_version.replace('.', '').isdigit():
+        docker_tag = new_version
+    else:
+        logging.info("New version contains letters. Setting docker tag to 'latest'")
+    nfconfig_pattern = r"container\s*=\s*[\'\"]nfcore/{}:(?:{}|latest)[\'\"]".format(lint_obj.pipeline_name.lower(), current_version.replace('.','\.'))
+    nfconfig_newstr = "container = 'nfcore/{}:{}'".format(lint_obj.pipeline_name.lower(), docker_tag)
+    update_file_version("nextflow.config", lint_obj, nfconfig_pattern, nfconfig_newstr)
+
+
+    if 'environment.yml' in lint_obj.files:
+        # Update conda environment.yml
+        nfconfig_pattern = r"name: nfcore-{}-{}".format(lint_obj.pipeline_name.lower(), current_version.replace('.','\.'))
+        nfconfig_newstr = "name: nfcore-{}-{}".format(lint_obj.pipeline_name.lower(), new_version)
+        update_file_version("environment.yml", lint_obj, nfconfig_pattern, nfconfig_newstr)
+
+        # Update Dockerfile if based on conda
+        nfconfig_pattern = r"ENV PATH /opt/conda/envs/nfcore-{}-{}/bin:\$PATH".format(lint_obj.pipeline_name.lower(), current_version.replace('.','\.'))
+        nfconfig_newstr = "ENV PATH /opt/conda/envs/nfcore-{}-{}/bin:$PATH".format(lint_obj.pipeline_name.lower(), new_version)
+        update_file_version("Dockerfile", lint_obj, nfconfig_pattern, nfconfig_newstr)
+
+def update_file_version(filename, lint_obj, pattern, newstr):
+    """ Update params.version in the nextflow config file """
+
+    # Load the file
+    fn = os.path.join(lint_obj.path, filename)
+    content = ''
+    with open(fn, 'r') as fh:
+        content = fh.read()
+
+    # Check that we have exactly one match
+    matches = re.findall(pattern, content)
+    if len(matches) == 0:
+        logging.error("Could not find version number in {}".format(filename))
+        return None
+    if len(matches) > 1:
+        logging.error("Found more than one version number in {}".format(filename))
+        return None
+
+    # Replace the match
+    logging.info("Updating version in {}\n - {}\n + {}".format(filename, matches[0], newstr))
+    new_content = re.sub(pattern, newstr, content)
+    with open(fn, 'w') as fh:
+        fh.write(new_content)

--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -42,7 +42,9 @@ def lint(pipeline_dir, release):
     """ Check pipeline against nf-core guidelines """
 
     # Run the lint tests!
-    nf_core.lint.run_linting(pipeline_dir, release)
+    lint_obj = nf_core.lint.run_linting(pipeline_dir, release)
+    if len(lint_obj.failed) > 0:
+        sys.exit(1)
 
 @nf_core_cli.command()
 @click.argument(

--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -53,12 +53,12 @@ def lint(pipeline_dir, release):
     required = True,
     metavar = "<pipeline directory>"
 )
-@click.option(
-    '--version',
+@click.argument(
+    'new_version',
     required = True,
-    help = "New version number (eg. 1.2, 1.3dev, 1.4.2)"
+    metavar = "<new version number>"
 )
-def release(pipeline_dir, version):
+def release(pipeline_dir, new_version):
     """ Update nf-core pipeline version number """
 
     # First, lint the pipeline to check everything is in order
@@ -66,7 +66,7 @@ def release(pipeline_dir, version):
     lint_obj = nf_core.lint.run_linting(pipeline_dir, False)
 
     # Bump the version number in relevant files
-    nf_core.release.make_release(lint_obj, version)
+    nf_core.release.make_release(lint_obj, new_version)
 
 if __name__ == '__main__':
     nf_core_cli()

--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -8,7 +8,7 @@ import sys
 import os
 
 import nf_core
-import nf_core.lint
+import nf_core.lint, nf_core.release
 
 import logging
 
@@ -39,30 +39,32 @@ def nf_core_cli(verbose):
     help = "Execute additional checks for release-ready workflows."
 )
 def lint(pipeline_dir, release):
-    """Check pipeline against nf-core guidelines"""
+    """ Check pipeline against nf-core guidelines """
 
-    # Create the lint object
-    lint_obj = nf_core.lint.PipelineLint(pipeline_dir)
+    # Run the lint tests!
+    nf_core.lint.run_linting(pipeline_dir, release)
 
-    # Run the linting tests
-    try:
-        lint_obj.lint_pipeline(release)
-    except AssertionError as e:
-        logging.critical("Critical error: {}".format(e))
-        logging.info("Stopping tests...")
-        sys.exit(1)
+@nf_core_cli.command()
+@click.argument(
+    'pipeline_dir',
+    type = click.Path(exists=True),
+    required = True,
+    metavar = "<pipeline directory>"
+)
+@click.option(
+    '--version',
+    required = True,
+    help = "New version number (eg. 1.2, 1.3dev, 1.4.2)"
+)
+def release(pipeline_dir, version):
+    """ Update nf-core pipeline version number """
 
-    # Print the results
-    lint_obj.print_results()
+    # First, lint the pipeline to check everything is in order
+    logging.info("Running nf-core lint tests")
+    lint_obj = nf_core.lint.run_linting(pipeline_dir, False)
 
-    # Exit code
-    if len(lint_obj.failed) > 0:
-        logging.error(
-            "Sorry, some tests failed - exiting with a non-zero error code...{}\n\n"
-            .format("\n       Reminder: Lint tests were run in --release mode." if release else '')
-        )
-        sys.exit(1)
-
+    # Bump the version number in relevant files
+    nf_core.release.make_release(lint_obj, version)
 
 if __name__ == '__main__':
     nf_core_cli()

--- a/tests/lint_examples/minimal_working_example/nextflow.config
+++ b/tests/lint_examples/minimal_working_example/nextflow.config
@@ -5,7 +5,7 @@ params {
   // Minimum version of nextflow required
   nf_required_version = '0.27.0'
   // Container slug. Tag for releases
-  container = 'nf-core/tools:0.4'
+  container = 'nfcore/tools:0.4'
   outdir = './results'
   reads = "data/*.fastq"
   singleEnd = false

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -60,16 +60,14 @@ class TestLint(unittest.TestCase):
         lint_obj = nf_core.lint.run_linting(PATH_WORKING_EXAMPLE, False)
         expectations = {"failed": 0, "warned": 0, "passed": MAX_PASS_CHECKS}
         self.assess_lint_status(lint_obj, **expectations)
-        lint_obj.print_results()
 
+    @pytest.mark.xfail(raises=AssertionError)
     def test_call_lint_pipeline_fail(self):
         """Test the main execution function of PipelineLint (fail)
         This should fail after the first test and halt execution """
-        lint_obj = nf_core.lint.PipelineLint(PATH_FAILING_EXAMPLE)
-        lint_obj.lint_pipeline()
+        lint_obj = nf_core.lint.run_linting(PATH_FAILING_EXAMPLE, False)
         expectations = {"failed": 4, "warned": 2, "passed": 7}
         self.assess_lint_status(lint_obj, **expectations)
-        lint_obj.print_results()
 
     def test_call_lint_pipeline_release(self):
         """Test the main execution function of PipelineLint when running with --release"""
@@ -87,8 +85,7 @@ class TestLint(unittest.TestCase):
     @pytest.mark.xfail(raises=AssertionError)
     def test_critical_missingfiles_example(self):
         """Tests for missing nextflow config and main.nf files"""
-        lint_obj = nf_core.lint.PipelineLint(PATH_CRITICAL_EXAMPLE)
-        lint_obj.check_files_exist()
+        lint_obj = nf_core.lint.run_linting(PATH_CRITICAL_EXAMPLE, False)
 
     def test_failing_missingfiles_example(self):
         """Tests for missing files like Dockerfile or LICENSE"""

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -57,8 +57,7 @@ class TestLint(unittest.TestCase):
         """Test the main execution function of PipelineLint (pass)
         This should not result in any exception for the minimal
         working example"""
-        lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
-        lint_obj.lint_pipeline()
+        lint_obj = nf_core.lint.run_linting(PATH_WORKING_EXAMPLE, False)
         expectations = {"failed": 0, "warned": 0, "passed": MAX_PASS_CHECKS}
         self.assess_lint_status(lint_obj, **expectations)
         lint_obj.print_results()

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+"""Some tests covering the release code.
+"""
+import os
+import pytest
+import shutil
+import unittest
+import nf_core.lint, nf_core.release
+
+WD = os.path.dirname(__file__)
+PATH_WORKING_EXAMPLE = os.path.join(WD, 'lint_examples/minimal_working_example')
+
+
+@pytest.mark.datafiles(PATH_WORKING_EXAMPLE)
+def test_working_release(datafiles):
+    """ Test that making a release with the working example files works """
+    lint_obj = nf_core.lint.PipelineLint(str(datafiles))
+    lint_obj.pipeline_name = 'tools'
+    lint_obj.config['params.version'] = '0.4'
+    lint_obj.files = ['nextflow.config', 'Dockerfile', 'environment.yml']
+    nf_core.release.make_release(lint_obj, '1.1')
+
+@pytest.mark.datafiles(PATH_WORKING_EXAMPLE)
+def test_dev_release(datafiles):
+    """ Test that making a release works with a dev name """
+    lint_obj = nf_core.lint.PipelineLint(str(datafiles))
+    lint_obj.pipeline_name = 'tools'
+    lint_obj.config['params.version'] = '0.4'
+    lint_obj.files = ['nextflow.config', 'Dockerfile', 'environment.yml']
+    nf_core.release.make_release(lint_obj, '1.2dev')
+
+@pytest.mark.datafiles(PATH_WORKING_EXAMPLE)
+@pytest.mark.xfail(raises=SyntaxError)
+def test_pattern_not_found(datafiles):
+    """ Test that making a release raises and error if a pattern isn't found """
+    lint_obj = nf_core.lint.PipelineLint(str(datafiles))
+    lint_obj.pipeline_name = 'tools'
+    lint_obj.config['params.version'] = '0.5'
+    lint_obj.files = ['nextflow.config', 'Dockerfile', 'environment.yml']
+    nf_core.release.make_release(lint_obj, '1.2dev')
+
+@pytest.mark.datafiles(PATH_WORKING_EXAMPLE)
+@pytest.mark.xfail(raises=SyntaxError)
+def test_multiple_patterns_found(datafiles):
+    """ Test that making a release raises if a version number is found twice """
+    lint_obj = nf_core.lint.PipelineLint(str(datafiles))
+    with open(os.path.join(str(datafiles), 'nextflow.config'), "a") as nfcfg:
+        nfcfg.write("params.version = '0.4'")
+    lint_obj.pipeline_name = 'tools'
+    lint_obj.config['params.version'] = '0.4'
+    lint_obj.files = ['nextflow.config', 'Dockerfile', 'environment.yml']
+    nf_core.release.make_release(lint_obj, '1.2dev')

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -22,12 +22,12 @@ def test_working_release(datafiles):
 
 @pytest.mark.datafiles(PATH_WORKING_EXAMPLE)
 def test_dev_release(datafiles):
-    """ Test that making a release works with a dev name """
+    """ Test that making a release works with a dev name and a leading v """
     lint_obj = nf_core.lint.PipelineLint(str(datafiles))
     lint_obj.pipeline_name = 'tools'
     lint_obj.config['params.version'] = '0.4'
     lint_obj.files = ['nextflow.config', 'Dockerfile', 'environment.yml']
-    nf_core.release.make_release(lint_obj, '1.2dev')
+    nf_core.release.make_release(lint_obj, 'v1.2dev')
 
 @pytest.mark.datafiles(PATH_WORKING_EXAMPLE)
 @pytest.mark.xfail(raises=SyntaxError)


### PR DESCRIPTION
New subcommand to bump version numbers everywhere within a pipeline.

* Starts by running linting - no point in searching for strings if there are major problems. Also parses useful things for us such as pipeline name and version
* Take regexes and switch version numbers in:
    * `nextflow.config` - pipeline version and docker image tag
        * If the new version contains non-numeric characters (apart from `.`), assume dev and use `latest` for the docker label
    * `environment.yml` and `Dockerfile`
        * Only if `environment.yml` file is present


Example output:

```
$ nf-core release . --version v1.5

INFO: Running nf-core lint tests
Running pipeline tests  [####################################]  100%  None

INFO: ===========
 LINTING RESULTS
=================
  54 tests passed   0 tests had warnings   0 tests failed

WARNING: Stripping leading 'v' from new version number

INFO: Changing version number:
  Current version number is '1.5dev'
  New version number will be '1.5'

INFO: Updating version in nextflow.config
 - version = '1.5dev'
 + version = '1.5'

INFO: Updating version in nextflow.config
 - container = 'nfcore/example:latest'
 + container = 'nfcore/example:1.5'

INFO: Updating version in environment.yml
 - name: nfcore-example-1.5dev
 + name: nfcore-example-1.5

INFO: Updating version in Dockerfile
 - ENV PATH /opt/conda/envs/nfcore-example-1.5dev/bin:$PATH
 + ENV PATH /opt/conda/envs/nfcore-example-1.5/bin:$PATH
```