### PR TITLE
Travis: only check with --release if a nf-core repo

### DIFF
--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -35,7 +35,7 @@ def nf_core_cli(verbose):
 @click.option(
     '--release',
     is_flag = True,
-    default = os.environ.get('TRAVIS_BRANCH') == 'master',
+    default = os.environ.get('TRAVIS_BRANCH') == 'master' and os.environ.get('TRAVIS_REPO_SLUG', '').startswith('nf-core/'),
     help = "Execute additional checks for release-ready workflows."
 )
 def lint(pipeline_dir, release):


### PR DESCRIPTION
At the moment, if you have a version `1.4dev` on the `master` branch of your fork then the tests fail. This change checks that it's `master` **and a `nf-core` repository** before automatically setting `--release` on the Travis tests.