### PR TITLE
nf-core download <pipeline name>

### DIFF
--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+""" Download a nf-core pipeline """
+
+from __future__ import print_function
+
+from io import BytesIO
+import logging
+import os
+import requests
+import subprocess
+import sys
+from zipfile import ZipFile
+
+
+import nf_core.list, nf_core.lint
+
+def download_workflow(pipeline, release=None, singularity=False, outdir=None):
+    """ Main function to download a nf-core workflow """
+
+    # init
+    wf = DownloadWorkflow(pipeline, release, singularity, outdir)
+
+    # Get workflow details
+    if not wf.get_workflow():
+        sys.exit(1)
+
+    # Check that the outdir doesn't already exist
+    if os.path.exists(wf.outdir):
+        logging.error("Output directory '{}' already exists".format(wf.outdir))
+        sys.exit(1)
+    else:
+        logging.info("Saving nf-core/{} to '{}'".format(wf.wf_name, wf.outdir))
+
+    # Download the pipeline files
+    logging.info("Downloading workflow files from GitHub")
+    wf.download_wf_files()
+
+    # Download the singularity images
+    if singularity:
+        logging.info("Fetching container names for workflow")
+        wf.find_singularity_images()
+        if len(wf.containers) == 0:
+            logging.info("No container names found in workflow")
+        else:
+            os.mkdir(os.path.join(wf.outdir, 'singularity-images'))
+            for container in wf.containers:
+                wf.download_singularity_image(container)
+
+class DownloadWorkflow():
+
+    def __init__(self, pipeline, release=None, singularity=False, outdir=None):
+        """ Set class variables """
+
+        self.pipeline = pipeline
+        self.release = release
+        self.singularity = singularity
+        self.outdir = outdir
+
+        self.wf_name = None
+        self.wf_sha = None
+        self.wf_download_url = None
+        self.containers = list()
+
+
+    def get_workflow(self):
+        """ Fetch details of nf-core workflow to download """
+        wfs = nf_core.list.Workflows()
+        wfs.get_remote_workflows()
+
+        # Get workflow download details
+        for wf in wfs.remote_workflows:
+            if wf.full_name == self.pipeline or wf.name == self.pipeline:
+
+                # Set pipeline name
+                self.wf_name = wf.name
+
+                # Find latest release hash
+                if self.release is None and len(wf.releases) > 0:
+                    self.release = wf.releases[0]['tag_name']
+                    self.wf_sha = wf.releases[0]['tag_sha']
+                # Find specified release hash
+                elif self.release is not None:
+                    for r in wf.releases:
+                        if r['tag_name'] == self.release.lstrip('v'):
+                            self.wf_sha = r['tag_sha']
+                            break
+                    else:
+                        logging.error("Not able to find release '{}' for {} (found '{}')".format(self.release, wf.full_name, "', '".join([r['tag_name'] for r in wf.releases])))
+                        return False
+                # Must be a dev-only pipeline
+                elif self.release is None:
+                    self.release = 'dev'
+                    self.wf_sha = 'master' # Cheating a little, but GitHub download link works
+
+                # Set outdir name if not defined
+                if self.outdir is None:
+                    self.outdir = 'nf-core-{}'.format(wf.name)
+                    if self.release is not None:
+                        self.outdir += '-{}'.format(self.release)
+
+                # Set the download URL
+                self.wf_download_url = 'https://github.com/{}/archive/{}.zip'.format(wf.full_name, self.wf_sha)
+
+                # Finished
+                return True
+
+        # If we got this far, must have not found the pipeline
+        logging.error("Not able to find pipeline '{}'".format(self.pipeline))
+        logging.info("Available pipelines: {}".format(', '.join([w.name for w in wfs.remote_workflows])))
+        return False
+
+    def download_wf_files(self):
+        """ Download workflow files from GitHub - save in outdir """
+
+        # Download GitHub zip file into memory and extract
+        url = requests.get(self.wf_download_url)
+        zipfile = ZipFile(BytesIO(url.content))
+        zipfile.extractall(self.outdir)
+
+        # Rename the internal directory name to be more friendly
+        gh_name = '{}-{}'.format(self.wf_name, self.wf_sha)
+        os.rename(os.path.join(self.outdir, gh_name), os.path.join(self.outdir, 'workflow'))
+
+    def find_singularity_images(self):
+        """ Find singularity image names for workflow """
+
+        # Use linting code to parse the pipeline nextflow config
+        lint_obj = nf_core.lint.PipelineLint(os.path.join(self.outdir, 'workflow'))
+        lint_obj.check_nextflow_config()
+
+        # Find any config variables that look like a container
+        for k,v in lint_obj.config.items():
+            if k.startswith('process.') and k.endswith('.container'):
+                self.containers.append(v.strip('"').strip("'"))
+
+    def download_singularity_image(self, container):
+        """ Download singularity images for workflow """
+
+        out_name = '{}.simg'.format(container.replace('nfcore/', 'nf-core-').replace(':', '-'))
+        out_path = os.path.abspath(os.path.join(self.outdir, 'singularity-images', out_name))
+        address = 'docker://{}'.format(container.replace('docker://', ''))
+        singularity_command = ["singularity", "pull", "--name", out_path, address]
+        docker_command = [
+            'docker', 'run',
+            '-v', '/var/run/docker.sock:/var/run/docker.sock',
+            '-v', '{}:/output'.format(out_path),
+            '--privileged', '-t', '--rm',
+            'singularityware/docker2singularity',
+            container
+        ]
+
+        logging.info("Building singularity image '{}', saving to {}".format(container, out_path))
+
+        # Try to use singularity to pull image
+        try:
+            subprocess.call(singularity_command)
+        except OSError as e:
+            if e.errno == os.errno.ENOENT:
+                # Singularity is not installed
+                logging.warn('Singularity is not installed. Attempting to use Docker instead.')
+
+                # Try to use docker to use singularity to pull image
+                try:
+                    subprocess.call(docker_command)
+                except OSError as e:
+                    if e.errno == os.errno.ENOENT:
+                        # Docker is not installed
+                        logging.warn('Docker is not installed.')
+                    else:
+                        # Something else went wrong with docker command
+                        raise
+            else:
+                # Something else went wrong with singularity command
+                raise

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -34,7 +34,7 @@ class DownloadWorkflow():
         """ Main function to download a nf-core workflow """
 
         # Get workflow details
-        if not self.get_workflow():
+        if not self.fetch_workflow_details():
             sys.exit(1)
 
         # Check that the outdir doesn't already exist
@@ -65,7 +65,7 @@ class DownloadWorkflow():
                     self.download_singularity_image(container)
 
 
-    def get_workflow(self):
+    def fetch_workflow_details(self):
         """ Fetch details of nf-core workflow to download """
         wfs = nf_core.list.Workflows()
         wfs.get_remote_workflows()
@@ -157,15 +157,16 @@ class DownloadWorkflow():
         """ Download singularity images for workflow """
 
         out_name = '{}.simg'.format(container.replace('nfcore', 'nf-core').replace('/','-').replace(':', '-'))
-        out_path = os.path.abspath(os.path.join(self.outdir, 'singularity-images', out_name))
+        out_dir = os.path.abspath(os.path.join(self.outdir, 'singularity-images'))
         address = 'docker://{}'.format(container.replace('docker://', ''))
-        singularity_command = ["singularity", "pull", "--name", out_path, address]
+        singularity_command = ["singularity", "pull", "--name", os.path.join(out_dir, out_name), address]
         docker_command = [
             'docker', 'run',
             '-v', '/var/run/docker.sock:/var/run/docker.sock',
-            '-v', '{}:/output'.format(out_path),
+            '-v', '{}:/output'.format(out_dir),
             '--privileged', '-t', '--rm',
             'singularityware/docker2singularity',
+            '--name', out_name,
             container
         ]
 

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -29,7 +29,12 @@ def download_workflow(pipeline, release=None, singularity=False, outdir=None):
         logging.error("Output directory '{}' already exists".format(wf.outdir))
         sys.exit(1)
     else:
-        logging.info("Saving nf-core/{} to '{}'".format(wf.wf_name, wf.outdir))
+        logging.info(
+            "Saving nf-core/{}".format(wf.wf_name) +
+            "\n Pipeline release: {}".format(wf.release) +
+            "\n Pull singularity containers: {}".format('Yes' if wf.singularity else 'No') +
+            "\n Output directory: {}".format(wf.outdir)
+        )
 
     # Download the pipeline files
     logging.info("Downloading workflow files from GitHub")
@@ -78,6 +83,7 @@ class DownloadWorkflow():
                 if self.release is None and len(wf.releases) > 0:
                     self.release = wf.releases[0]['tag_name']
                     self.wf_sha = wf.releases[0]['tag_sha']
+                    logging.debug("No release specified. Using latest release: {}".format(self.release))
                 # Find specified release hash
                 elif self.release is not None:
                     for r in wf.releases:
@@ -91,6 +97,7 @@ class DownloadWorkflow():
                 elif self.release is None:
                     self.release = 'dev'
                     self.wf_sha = 'master' # Cheating a little, but GitHub download link works
+                    logging.info("Pipeline is in development. Using current code on master branch.")
 
                 # Set outdir name if not defined
                 if self.outdir is None:

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -14,43 +14,6 @@ from zipfile import ZipFile
 
 import nf_core.list, nf_core.utils
 
-def download_workflow(pipeline, release=None, singularity=False, outdir=None):
-    """ Main function to download a nf-core workflow """
-
-    # init
-    wf = DownloadWorkflow(pipeline, release, singularity, outdir)
-
-    # Get workflow details
-    if not wf.get_workflow():
-        sys.exit(1)
-
-    # Check that the outdir doesn't already exist
-    if os.path.exists(wf.outdir):
-        logging.error("Output directory '{}' already exists".format(wf.outdir))
-        sys.exit(1)
-    else:
-        logging.info(
-            "Saving {}".format(wf.pipeline) +
-            "\n Pipeline release: {}".format(wf.release) +
-            "\n Pull singularity containers: {}".format('Yes' if wf.singularity else 'No') +
-            "\n Output directory: {}".format(wf.outdir)
-        )
-
-    # Download the pipeline files
-    logging.info("Downloading workflow files from GitHub")
-    wf.download_wf_files()
-
-    # Download the singularity images
-    if singularity:
-        logging.info("Fetching container names for workflow")
-        wf.find_singularity_images()
-        if len(wf.containers) == 0:
-            logging.info("No container names found in workflow")
-        else:
-            os.mkdir(os.path.join(wf.outdir, 'singularity-images'))
-            for container in wf.containers:
-                wf.download_singularity_image(container)
-
 class DownloadWorkflow():
 
     def __init__(self, pipeline, release=None, singularity=False, outdir=None):
@@ -66,6 +29,40 @@ class DownloadWorkflow():
         self.wf_download_url = None
         self.config = dict()
         self.containers = list()
+
+    def download_workflow(self):
+        """ Main function to download a nf-core workflow """
+
+        # Get workflow details
+        if not self.get_workflow():
+            sys.exit(1)
+
+        # Check that the outdir doesn't already exist
+        if os.path.exists(self.outdir):
+            logging.error("Output directory '{}' already exists".format(self.outdir))
+            sys.exit(1)
+
+        logging.info(
+            "Saving {}".format(self.pipeline) +
+            "\n Pipeline release: {}".format(self.release) +
+            "\n Pull singularity containers: {}".format('Yes' if self.singularity else 'No') +
+            "\n Output directory: {}".format(self.outdir)
+        )
+
+        # Download the pipeline files
+        logging.info("Downloading workflow files from GitHub")
+        self.download_wf_files()
+
+        # Download the singularity images
+        if self.singularity:
+            logging.info("Fetching container names for workflow")
+            self.find_singularity_images()
+            if len(self.containers) == 0:
+                logging.info("No container names found in workflow")
+            else:
+                os.mkdir(os.path.join(self.outdir, 'singularity-images'))
+                for container in self.containers:
+                    self.download_singularity_image(container)
 
 
     def get_workflow(self):

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -163,15 +163,6 @@ class DownloadWorkflow():
         out_dir = os.path.abspath(os.path.join(self.outdir, 'singularity-images'))
         address = 'docker://{}'.format(container.replace('docker://', ''))
         singularity_command = ["singularity", "pull", "--name", os.path.join(out_dir, out_name), address]
-        docker_command = [
-            'docker', 'run',
-            '-v', '/var/run/docker.sock:/var/run/docker.sock',
-            '-v', '{}:/output'.format(out_dir),
-            '--privileged', '-t', '--rm',
-            'singularityware/docker2singularity',
-            '--name', out_name,
-            container
-        ]
 
         logging.info("Building singularity image '{}'".format(out_name))
         logging.debug("Singularity command: {}".format(' '.join(singularity_command)))
@@ -182,19 +173,7 @@ class DownloadWorkflow():
         except OSError as e:
             if e.errno == os.errno.ENOENT:
                 # Singularity is not installed
-                logging.debug('Singularity is not installed. Attempting to use Docker instead.')
-                logging.debug("Docker command: {}".format(' '.join(docker_command)))
-
-                # Try to use docker to use singularity to pull image
-                try:
-                    subprocess.call(docker_command)
-                except OSError as e:
-                    if e.errno == os.errno.ENOENT:
-                        # Docker is not installed
-                        logging.warn('Docker is not installed.')
-                    else:
-                        # Something else went wrong with docker command
-                        raise
+                logging.error('Singularity is not installed!')
             else:
                 # Something else went wrong with singularity command
-                raise
+                raise e

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+"""
+Common utility functions for the nf-core python package.
+"""
+
+import logging
+import os
+import subprocess
+
+def fetch_wf_config(wf_path):
+    """
+    Use nextflow to retrieve the nf configuration variables from a workflow
+    """
+
+    config = dict()
+    # Call `nextflow config` and pipe stderr to /dev/null
+    try:
+        with open(os.devnull, 'w') as devnull:
+            nfconfig_raw = subprocess.check_output(['nextflow', 'config', '-flat', wf_path], stderr=devnull)
+    except subprocess.CalledProcessError as e:
+        raise AssertionError("`nextflow config` returned non-zero error code: %s,\n   %s", e.returncode, e.output)
+    else:
+        for l in nfconfig_raw.splitlines():
+            ul = l.decode()
+            k, v = ul.split(' = ', 1)
+            config[k] = v
+    return config

--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -8,7 +8,7 @@ import sys
 import os
 
 import nf_core
-import nf_core.lint, nf_core.list, nf_core.release
+import nf_core.lint, nf_core.list, nf_core.download, nf_core.release
 
 import logging
 
@@ -56,6 +56,31 @@ def lint(pipeline_dir, release):
 def list(json):
     """ List nf-core pipelines with local info """
     nf_core.list.list_workflows(json)
+
+@nf_core_cli.command()
+@click.argument(
+    'pipeline',
+    required = True,
+    metavar = "<pipeline name>"
+)
+@click.option(
+    '-r', '--release',
+    type = str,
+    help = "Pipeline release"
+)
+@click.option(
+    '-s', '--singularity',
+    is_flag = True,
+    help = "Pull pipeline singularity containers"
+)
+@click.option(
+    '-o', '--outdir',
+    type = str,
+    help = "Output directory"
+)
+def download(pipeline, release, singularity, outdir):
+    """ Download a nf-core pipeline and singularity container """
+    nf_core.download.download_workflow(pipeline, release, singularity, outdir)
 
 @nf_core_cli.command()
 @click.argument(

--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -69,9 +69,10 @@ def list(json):
     help = "Pipeline release"
 )
 @click.option(
-    '-s', '--singularity',
-    is_flag = True,
-    help = "Pull pipeline singularity containers"
+    '-s/-n', '--singularity/--no-singularity',
+    default = None,
+    required = True,
+    help = "Pull / don't pull pipeline singularity containers"
 )
 @click.option(
     '-o', '--outdir',

--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -83,7 +83,8 @@ def list(json):
 )
 def download(pipeline, release, singularity, outdir):
     """ Download a pipeline and singularity container """
-    nf_core.download.download_workflow(pipeline, release, singularity, outdir)
+    dl = nf_core.download.DownloadWorkflow(pipeline, release, singularity, outdir)
+    dl.download_workflow()
 
 @nf_core_cli.command()
 @click.argument(

--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -70,11 +70,9 @@ def list(json):
 )
 @click.option(
     '-s', '--singularity',
-    type = click.BOOL,
-    metavar = "[y/n]",
-    default = None,
-    required = True,
-    help = "Download singularity containers?"
+    is_flag = True,
+    default = False,
+    help = "Download singularity containers"
 )
 @click.option(
     '-o', '--outdir',

--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -69,10 +69,12 @@ def list(json):
     help = "Pipeline release"
 )
 @click.option(
-    '-s/-n', '--singularity/--no-singularity',
+    '-s', '--singularity',
+    type = click.BOOL,
+    metavar = "[y/n]",
     default = None,
     required = True,
-    help = "Pull / don't pull pipeline singularity containers"
+    help = "Download singularity containers?"
 )
 @click.option(
     '-o', '--outdir',

--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -80,7 +80,7 @@ def list(json):
     help = "Output directory"
 )
 def download(pipeline, release, singularity, outdir):
-    """ Download a nf-core pipeline and singularity container """
+    """ Download a pipeline and singularity container """
     nf_core.download.download_workflow(pipeline, release, singularity, outdir)
 
 @nf_core_cli.command()


### PR DESCRIPTION
New subcommand to download a pipeline and its singularity containers.

* Validates pipeline input, fetches workflow details and release hash
* Download workflow files
* If `-s`is specified, downloads singularity images
  * Automatically finds container names from workflow config
  * Looks on the singularity hub API for a singularity image - downloads it if found
      * Includes md5 check
  * If not found, tries to pull singularity images using singularity
  * ~If singularity is not installed, tries using docker (with [`docker2singularity`](https://github.com/singularityware/docker2singularity))~
    * _removed due to configuration difficulties - may be possible to put back later with more investigation_

To do:

* [ ] Check that it works for other people
* [ ] Write tests!

Example usage:
```
$ nf-core download methylseq -s

                                          ,--./,-.
          ___     __   __   __   ___     /,-._.--~\
    |\ | |__  __ /  ` /  \ |__) |__         }  {
    | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                          `._,._,'


INFO: Saving to 'nf-core-methylseq-1.0'

INFO: Downloading workflow files from GitHub

INFO: Fetching container names for workflow

INFO: Building singularity image 'nfcore/methylseq:1.0', saving to /Users/ewels/GitHub/nf-core/testing/nf-core-methylseq-1.0/singularity-images/nf-core-methylseq-1.0.simg

WARNING: Singularity is not installed. Attempting to use Docker instead.
Size: 4720 MB for the singularity container
(1/9) Creating an empty image...
Creating a sparse image with a maximum size of 4720MiB...
Using given image size of 4720
Formatting image (/sbin/mkfs.ext3)
Done. Image can be found at: /tmp/nfcore_methylseq_1.0-2018-04-17-d18eb7142a18.img
(2/9) Importing filesystem...
(3/9) Bootstrapping...
(4/9) Adding run script...
(5/9) Setting ENV variables...
Singularity: sexec (U=0,P=143)> Command=exec, Container=/tmp/nfcore_methylseq_1.0-2018-04-17-d18eb7142a18.img, CWD=/, Arg1=/bin/sh
(6/9) Adding mount points...
Singularity: sexec (U=0,P=149)> Command=exec, Container=/tmp/nfcore_methylseq_1.0-2018-04-17-d18eb7142a18.img, CWD=/, Arg1=/bin/sh
(7/9) Fixing permissions...
Singularity: sexec (U=0,P=155)> Command=exec, Container=/tmp/nfcore_methylseq_1.0-2018-04-17-d18eb7142a18.img, CWD=/, Arg1=/bin/sh
Singularity: sexec (U=0,P=196)> Command=exec, Container=/tmp/nfcore_methylseq_1.0-2018-04-17-d18eb7142a18.img, CWD=/, Arg1=/bin/sh
Debian GNU/Linux 9 \n \l
We're not running on BusyBox/Buildroot
Singularity: sexec (U=0,P=202)> Command=exec, Container=/tmp/nfcore_methylseq_1.0-2018-04-17-d18eb7142a18.img, CWD=/, Arg1=/bin/sh
(8/9) Stopping and removing the container...
d18eb7142a18
d18eb7142a18
(9/9) Moving the image to the output folder...
  2,381,807,616  48%   10.97MB/s    0:03:48
```

Example output:

```
$ tree -L 3
.
└── nf-core-methylseq-1.0
    ├── singularity-images
    │   └── nf-core-methylseq-1.0.simg
    └── workflow
        ├── CHANGELOG.md
        ├── Dockerfile
        ├── LICENCE.md
        ├── README.md
        ├── assets
        ├── bin
        ├── conf
        ├── docs
        ├── environment.yml
        ├── main.nf
        ├── nextflow.config
        └── tests

9 directories, 7 files
```