### PR TITLE
More linting

### DIFF
--- a/nf_core/release.py
+++ b/nf_core/release.py
@@ -24,7 +24,7 @@ def make_release(lint_obj, new_version):
     nfconfig_newstr = "version = '{}'".format(new_version)
     update_file_version("nextflow.config", lint_obj, nfconfig_pattern, nfconfig_newstr)
 
-    # Update Docker tag
+    # Update container tag
     docker_tag = 'latest'
     if new_version.replace('.', '').isdigit():
         docker_tag = new_version
@@ -34,6 +34,10 @@ def make_release(lint_obj, new_version):
     nfconfig_newstr = "container = 'nfcore/{}:{}'".format(lint_obj.pipeline_name.lower(), docker_tag)
     update_file_version("nextflow.config", lint_obj, nfconfig_pattern, nfconfig_newstr)
 
+    # Update Singularity version name
+    nfconfig_pattern = r"VERSION {}".format(current_version.replace('.','\.'))
+    nfconfig_newstr = "VERSION {}".format(new_version)
+    update_file_version("Singularity", lint_obj, nfconfig_pattern, nfconfig_newstr)
 
     if 'environment.yml' in lint_obj.files:
         # Update conda environment.yml
@@ -45,6 +49,11 @@ def make_release(lint_obj, new_version):
         nfconfig_pattern = r"ENV PATH /opt/conda/envs/nfcore-{}-{}/bin:\$PATH".format(lint_obj.pipeline_name.lower(), current_version.replace('.','\.'))
         nfconfig_newstr = "ENV PATH /opt/conda/envs/nfcore-{}-{}/bin:$PATH".format(lint_obj.pipeline_name.lower(), new_version)
         update_file_version("Dockerfile", lint_obj, nfconfig_pattern, nfconfig_newstr)
+
+        # Update Singularity file if based on conda
+        nfconfig_pattern = r"PATH=/opt/conda/envs/nfcore-{}-{}/bin:\$PATH".format(lint_obj.pipeline_name.lower(), current_version.replace('.','\.'))
+        nfconfig_newstr = "PATH=/opt/conda/envs/nfcore-{}-{}/bin:$PATH".format(lint_obj.pipeline_name.lower(), new_version)
+        update_file_version("Singularity", lint_obj, nfconfig_pattern, nfconfig_newstr)
 
 def update_file_version(filename, lint_obj, pattern, newstr):
     """ Update params.version in the nextflow config file """

--- a/tests/lint_examples/minimal_working_example/.travis.yml
+++ b/tests/lint_examples/minimal_working_example/.travis.yml
@@ -9,6 +9,10 @@ cache: pip
 matrix:
   fast_finish: true
 
+before_install:
+  # Pull the docker image first so the test doesn't wait for this
+  - docker pull nfcore/tools:0.4
+
 install:
   # Install Nextflow
   - mkdir /tmp/nextflow

--- a/tests/lint_examples/minimal_working_example/Singularity
+++ b/tests/lint_examples/minimal_working_example/Singularity
@@ -1,0 +1,18 @@
+From:nfcore/base
+Bootstrap:docker
+
+%labels
+    MAINTAINER Phil Ewels <phil.ewels@scilifelab.se>
+    DESCRIPTION Container image containing all requirements for the nf-core/tools pipeline
+    VERSION 0.4
+
+%environment
+    PATH=/opt/conda/envs/nfcore-tools-0.4/bin:$PATH
+    export PATH
+
+%files
+    environment.yml /
+
+%post
+    /opt/conda/bin/conda env create -f /environment.yml
+    /opt/conda/bin/conda clean -a

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -38,7 +38,7 @@ PATHS_WRONG_LICENSE_EXAMPLE = [pf(WD, 'lint_examples/wrong_license_example'),
     pf(WD, 'lint_examples/license_incomplete_example')]
 
 # The maximum sum of passed tests currently possible
-MAX_PASS_CHECKS = 54
+MAX_PASS_CHECKS = 57
 # The additional tests passed for releases
 ADD_PASS_RELEASE = 1
 
@@ -91,7 +91,7 @@ class TestLint(unittest.TestCase):
         """Tests for missing files like Dockerfile or LICENSE"""
         lint_obj = nf_core.lint.PipelineLint(PATH_FAILING_EXAMPLE)
         lint_obj.check_files_exist()
-        expectations = {"failed": 4, "warned": 2, "passed": len(listfiles(PATH_WORKING_EXAMPLE)) - 4 - 2}
+        expectations = {"failed": 5, "warned": 1, "passed": len(listfiles(PATH_WORKING_EXAMPLE)) - 5 - 2}
         self.assess_lint_status(lint_obj, **expectations)
 
     def test_mit_licence_example_pass(self):


### PR DESCRIPTION
Additional lint and release tools to deal with updates to pipeline styles:

* Require a `Singularity` build file
* Check it for building with conda in the same way as `Dockerfile`
* Update version numbers & check in `Singularity` file
* Check that the `.travis.yml` file pulls the docker image before the tests