### PR TITLE
Provide unit-tests for 'download' subcommand

### DIFF
--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -39,7 +39,7 @@ class DownloadWorkflow():
 
         # Get workflow details
         try:
-            self.fetch_workflow_details()
+            self.fetch_workflow_details(nf_core.list.Workflows())
         except LookupError:
             sys.exit(1)
 
@@ -77,9 +77,12 @@ class DownloadWorkflow():
                         self.pull_singularity_image(container)
 
 
-    def fetch_workflow_details(self):
-        """ Fetch details of nf-core workflow to download """
-        wfs = nf_core.list.Workflows()
+    def fetch_workflow_details(self, wfs):
+        """ Fetch details of nf-core workflow to download 
+        
+        params:
+        - wfs   A nf_core.list.Workflows object
+        """
         wfs.get_remote_workflows()
 
         # Get workflow download details

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -76,7 +76,6 @@ class DownloadWorkflow():
                         # Try to build from dockerhub
                         self.pull_singularity_image(container)
 
-
     def fetch_workflow_details(self, wfs):
         """ Fetch details of nf-core workflow to download 
         
@@ -144,7 +143,6 @@ class DownloadWorkflow():
             logging.error("Not able to find pipeline '{}'".format(self.pipeline))
             logging.info("Available pipelines: {}".format(', '.join([w.name for w in wfs.remote_workflows])))
             raise LookupError("Not able to find pipeline '{}'".format(self.pipeline))
-
 
     def download_wf_files(self):
         """ Download workflow files from GitHub - save in outdir """

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -250,4 +250,4 @@ class DownloadWorkflow():
         if file_hash == expected:
             logging.debug('md5 sum of image matches expected: {}'.format(expected))
         else:
-            raise IOError ("{} md5 does not match remote: {} - {}".format(out_path, expected, file_hash))
+            raise IOError ("{} md5 does not match remote: {} - {}".format(fname, expected, file_hash))

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -59,3 +59,15 @@ class DownloadTest(unittest.TestCase):
         
         download_obj.fetch_workflow_details(mock_workflows)
 
+    @mock.patch('nf_core.list.RemoteWorkflow')
+    @mock.patch('nf_core.list.Workflows')
+    def test_fetch_workflow_details_for_unknown_workflow(self, mock_workflows, mock_workflow):
+        download_obj = DownloadWorkflow(
+            pipeline = "my-server.org/dummy",
+            release = "1.2.0"
+            )
+        mock_workflows.remote_workflows = []
+
+        download_obj.fetch_workflow_details(mock_workflows)
+
+        

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -29,7 +29,7 @@ class DownloadTest(unittest.TestCase):
     def test_fetch_workflow_details_for_dev_version(self, mock_workflows, mock_workflow):
         download_obj = DownloadWorkflow(pipeline = "dummy")
         mock_workflow.name = "dummy"
-        mock_workflow.releases = [{"tag_name": "1.0.0", "tag_sha": "n3v3rl4nd"}]
+        mock_workflow.releases = []
         mock_workflows.remote_workflows = [mock_workflow]
         
         download_obj.fetch_workflow_details(mock_workflows)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -8,6 +8,7 @@ from nf_core.download import DownloadWorkflow
 import hashlib
 import io
 import mock
+import os
 import pytest
 import requests
 import unittest
@@ -141,22 +142,30 @@ class DownloadTest(unittest.TestCase):
         mock_progressbar,
         mock_md5):
 
+        # we need this for the fake download
+        tmp_dir = "/tmp/singularity-images"
+        if not os.path.isdir(tmp_dir): os.mkdir(tmp_dir)
+
         download_obj = DownloadWorkflow(
             pipeline = "dummy",
             outdir = "/tmp")
 
-        
+        # simulauates the first response querying the API for the container
+        # information
         resp_shub = requests.Response()
         resp_shub.status_code = 200
         mock_json.side_effect = [{'image': 'my-container', 'version': 'h4sh'}]
 
-
+        # simulates the second response querying the
+        # container download stream
         resp_download = requests.Response()
         resp_download.status_code = 200
         resp_download.headers = {'content-length' : 1024}
         mock_content.side_effect = b"Awesome"
 
+        # assign the response order
         mock_request.side_effect = [resp_shub, resp_download]
+        # test
         download_obj.download_shub_image("awesome-container")
     
     #

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -168,6 +168,89 @@ class DownloadTest(unittest.TestCase):
         # test
         download_obj.download_shub_image("awesome-container")
     
+    @mock.patch('requests.get')
+    @pytest.mark.xfail(raises=RuntimeWarning)
+    def test_download_image_shub_without_hit(self,
+        mock_request):
+
+        # we need this for the fake download
+        tmp_dir = "/tmp/singularity-images"
+        if not os.path.isdir(tmp_dir): os.mkdir(tmp_dir)
+
+        download_obj = DownloadWorkflow(
+            pipeline = "dummy",
+            outdir = "/tmp")
+
+        # simulauates the first response querying the API for the container
+        # information
+        resp_shub = requests.Response()
+        resp_shub.status_code = 404
+
+        # assign the response order
+        mock_request.side_effect = [resp_shub]
+        
+        # test
+        download_obj.download_shub_image("awesome-container")
+
+    @mock.patch('requests.Response.json')
+    @mock.patch('requests.get')
+    @pytest.mark.xfail(raises=RuntimeWarning)
+    def test_download_image_shub_wrong_url(self,
+        mock_request,
+        mock_json):
+
+        # we need this for the fake download
+        tmp_dir = "/tmp/singularity-images"
+        if not os.path.isdir(tmp_dir): os.mkdir(tmp_dir)
+
+        download_obj = DownloadWorkflow(
+            pipeline = "dummy",
+            outdir = "/tmp")
+
+        # simulauates the first response querying the API for the container
+        # information
+        resp_shub = requests.Response()
+        resp_shub.status_code = 200
+        mock_json.side_effect = [{'image': 'my-container', 'version': 'h4sh'}]
+
+         # simulates the second response querying the
+        # container download stream
+        resp_download = requests.Response()
+        resp_download.status_code = 404
+
+        # assign the response order
+        mock_request.side_effect = [resp_shub, resp_download]
+        
+        # test
+        download_obj.download_shub_image("awesome-container")
+
+    @mock.patch('requests.Response.json')
+    @mock.patch('requests.get')
+    @pytest.mark.xfail(raises=ImportError)
+    def test_download_image_shub_unknown_response(self,
+        mock_request,
+        mock_json):
+
+        # we need this for the fake download
+        tmp_dir = "/tmp/singularity-images"
+        if not os.path.isdir(tmp_dir): os.mkdir(tmp_dir)
+
+        download_obj = DownloadWorkflow(
+            pipeline = "dummy",
+            outdir = "/tmp")
+
+        # simulauates the first response querying the API for the container
+        # information
+        resp_shub = requests.Response()
+        resp_shub.status_code = 301
+        mock_json.side_effect = [{'image': 'my-container', 'version': 'h4sh'}]
+
+        # assign the response order
+        mock_request.side_effect = [resp_shub]
+        
+        # test
+        download_obj.download_shub_image("awesome-container")
+
     #
     # Tests for 'validate_md5'
     #

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -108,3 +108,20 @@ class DownloadTest(unittest.TestCase):
         download_obj.wf_sha = "1.0"
         download_obj.wf_download_url = "https://github.com/nf-core/methylseq/archive/1.0.zip"
         download_obj.download_wf_files()
+
+    #
+    # Tests for 'find_singularity_images'
+    #
+    @mock.patch('nf_core.utils.fetch_wf_config')
+    def test_find_singularity_images(self, mock_fetch_wf_config):
+        download_obj = DownloadWorkflow(
+            pipeline = "dummy",
+            outdir = "/tmp")
+        mock_fetch_wf_config.return_value = {
+            'process.mapping.container': 'cutting-edge-container',
+            'process.nocontainer': 'not-so-cutting-edge'
+        }
+        download_obj.find_singularity_images()
+        assert len(download_obj.containers) == 1
+        assert download_obj.containers[0] == 'cutting-edge-container'
+        

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -124,4 +124,18 @@ class DownloadTest(unittest.TestCase):
         download_obj.find_singularity_images()
         assert len(download_obj.containers) == 1
         assert download_obj.containers[0] == 'cutting-edge-container'
-        
+    
+    #
+    # Tests for 'download_shub_image'
+    #
+    @mock.patch('requests.Response')
+    @mock.patch('requests.get')
+    def test_download_shub_image_on_sucess(self, mock_request, mock_response):
+        download_obj = DownloadWorkflow(
+            pipeline = "dummy",
+            outdir = "/tmp")
+
+        mock_response.status_code == 200
+        mock_response.side_effect = {'image': 'http://singularity-hub.org/whatever'}
+
+        mock_request.return_value = mock_response

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -59,11 +59,21 @@ class DownloadTest(unittest.TestCase):
         
         download_obj.fetch_workflow_details(mock_workflows)
 
-    @mock.patch('nf_core.list.RemoteWorkflow')
     @mock.patch('nf_core.list.Workflows')
-    def test_fetch_workflow_details_for_unknown_workflow(self, mock_workflows, mock_workflow):
+    def test_fetch_workflow_details_for_unknown_workflow(self, mock_workflows):
         download_obj = DownloadWorkflow(
-            pipeline = "my-server.org/dummy",
+            pipeline = "myorg/dummy",
+            release = "1.2.0"
+            )
+        mock_workflows.remote_workflows = []
+
+        download_obj.fetch_workflow_details(mock_workflows)
+
+    @mock.patch('nf_core.list.Workflows')
+    @pytest.mark.xfail(raises=LookupError)
+    def test_fetch_workflow_details_no_search_result(self, mock_workflows):
+        download_obj = DownloadWorkflow(
+            pipeline = "http://my-server.org/dummy",
             release = "1.2.0"
             )
         mock_workflows.remote_workflows = []

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -5,12 +5,17 @@
 import nf_core.list
 from nf_core.download import DownloadWorkflow
 
+import io
 import mock
 import pytest
+import requests
 import unittest
 
 class DownloadTest(unittest.TestCase):
 
+    #
+    # Tests for 'fetch_workflow_details()'
+    #
     @mock.patch('nf_core.list.RemoteWorkflow')
     @mock.patch('nf_core.list.Workflows')
     def test_fetch_workflow_details_for_release(self, mock_workflows, mock_workflow):
@@ -90,5 +95,16 @@ class DownloadTest(unittest.TestCase):
 
         download_obj.fetch_workflow_details(mock_workflows)
 
-
-        
+    #
+    # Tests for 'download_wf_files'  
+    #
+    def test_download_wf_files(self):
+        download_obj = DownloadWorkflow(
+            pipeline = "dummy",
+            release = "1.2.0",
+            outdir="/tmp"
+            )
+        download_obj.wf_name = "nf-core/methylseq"
+        download_obj.wf_sha = "1.0"
+        download_obj.wf_download_url = "https://github.com/nf-core/methylseq/archive/1.0.zip"
+        download_obj.download_wf_files()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -6,21 +6,45 @@ import nf_core.list
 from nf_core.download import DownloadWorkflow
 
 import mock
+import pytest
 import unittest
 
 class DownloadTest(unittest.TestCase):
 
     @mock.patch('nf_core.list.RemoteWorkflow')
     @mock.patch('nf_core.list.Workflows')
-    def test_fetch_workflow_details_of_release(self, mock_workflows, mock_workflow):
+    def test_fetch_workflow_details_for_release(self, mock_workflows, mock_workflow):
         download_obj = DownloadWorkflow(
             pipeline = "dummy",
-            release="1.0.0")
+            release="1.0.0"
+            )
         mock_workflow.name = "dummy"
         mock_workflow.releases = [{"tag_name": "1.0.0", "tag_sha": "n3v3rl4nd"}]
         mock_workflows.remote_workflows = [mock_workflow]
         
         download_obj.fetch_workflow_details(mock_workflows)
+    
+    @mock.patch('nf_core.list.RemoteWorkflow')
+    @mock.patch('nf_core.list.Workflows')
+    def test_fetch_workflow_details_for_dev_version(self, mock_workflows, mock_workflow):
+        download_obj = DownloadWorkflow(pipeline = "dummy")
+        mock_workflow.name = "dummy"
+        mock_workflow.releases = [{"tag_name": "1.0.0", "tag_sha": "n3v3rl4nd"}]
+        mock_workflows.remote_workflows = [mock_workflow]
         
+        download_obj.fetch_workflow_details(mock_workflows)
 
+    @mock.patch('nf_core.list.RemoteWorkflow')
+    @mock.patch('nf_core.list.Workflows')
+    @pytest.mark.xfail(raises=LookupError)
+    def test_fetch_workflow_details_for_unknown_release(self, mock_workflows, mock_workflow):
+        download_obj = DownloadWorkflow(
+            pipeline = "dummy",
+            release = "1.2.0"
+            )
+        mock_workflow.name = "dummy"
+        mock_workflow.releases = [{"tag_name": "1.0.0", "tag_sha": "n3v3rl4nd"}]
+        mock_workflows.remote_workflows = [mock_workflow]
+        
+        download_obj.fetch_workflow_details(mock_workflows)
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -36,6 +36,17 @@ class DownloadTest(unittest.TestCase):
 
     @mock.patch('nf_core.list.RemoteWorkflow')
     @mock.patch('nf_core.list.Workflows')
+    def test_fetch_workflow_details_and_autoset_release(self, mock_workflows, mock_workflow):
+        download_obj = DownloadWorkflow(pipeline = "dummy")
+        mock_workflow.name = "dummy"
+        mock_workflow.releases = [{"tag_name": "1.0.0", "tag_sha": "n3v3rl4nd"}]
+        mock_workflows.remote_workflows = [mock_workflow]
+        
+        download_obj.fetch_workflow_details(mock_workflows)
+        assert download_obj.release == "1.0.0"
+
+    @mock.patch('nf_core.list.RemoteWorkflow')
+    @mock.patch('nf_core.list.Workflows')
     @pytest.mark.xfail(raises=LookupError)
     def test_fetch_workflow_details_for_unknown_release(self, mock_workflows, mock_workflow):
         download_obj = DownloadWorkflow(

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+"""Tests for the download subcommand of nf-core tools
+"""
+
+import nf_core.list
+from nf_core.download import DownloadWorkflow
+
+import mock
+import unittest
+
+class DownloadTest(unittest.TestCase):
+
+    @mock.patch('nf_core.list.RemoteWorkflow')
+    @mock.patch('nf_core.list.Workflows')
+    def test_fetch_workflow_details_of_release(self, mock_workflows, mock_workflow):
+        download_obj = DownloadWorkflow(
+            pipeline = "dummy",
+            release="1.0.0")
+        mock_workflow.name = "dummy"
+        mock_workflow.releases = [{"tag_name": "1.0.0", "tag_sha": "n3v3rl4nd"}]
+        mock_workflows.remote_workflows = [mock_workflow]
+        
+        download_obj.fetch_workflow_details(mock_workflows)
+        
+
+

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -60,7 +60,7 @@ class DownloadTest(unittest.TestCase):
         download_obj.fetch_workflow_details(mock_workflows)
 
     @mock.patch('nf_core.list.Workflows')
-    def test_fetch_workflow_details_for_unknown_workflow(self, mock_workflows):
+    def test_fetch_workflow_details_for_github_ressource(self, mock_workflows):
         download_obj = DownloadWorkflow(
             pipeline = "myorg/dummy",
             release = "1.2.0"
@@ -68,6 +68,16 @@ class DownloadTest(unittest.TestCase):
         mock_workflows.remote_workflows = []
 
         download_obj.fetch_workflow_details(mock_workflows)
+
+    @mock.patch('nf_core.list.Workflows')
+    def test_fetch_workflow_details_for_github_ressource_take_master(self, mock_workflows):
+        download_obj = DownloadWorkflow(
+            pipeline = "myorg/dummy"
+            )
+        mock_workflows.remote_workflows = []
+
+        download_obj.fetch_workflow_details(mock_workflows)
+        assert download_obj.release == "master"
 
     @mock.patch('nf_core.list.Workflows')
     @pytest.mark.xfail(raises=LookupError)
@@ -79,5 +89,6 @@ class DownloadTest(unittest.TestCase):
         mock_workflows.remote_workflows = []
 
         download_obj.fetch_workflow_details(mock_workflows)
+
 
         

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -275,4 +275,12 @@ class DownloadTest(unittest.TestCase):
 
         download_obj.validate_md5("/tmp/test", val_hash)
 
-    
+    #
+    # Tests for 'pull_singularity_image'
+    #
+    @pytest.mark.xfail(raises=OSError)
+    def test_pull_singularity_image(self):
+        download_obj = DownloadWorkflow(
+            pipeline = "dummy",
+            outdir="/tmp")
+        download_obj.pull_singularity_image("a-container")

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -284,3 +284,21 @@ class DownloadTest(unittest.TestCase):
             pipeline = "dummy",
             outdir="/tmp")
         download_obj.pull_singularity_image("a-container")
+
+    #
+    # Tests for the main entry method 'download_workflow'
+    #
+    @mock.patch('nf_core.download.DownloadWorkflow.pull_singularity_image')
+    @mock.patch('nf_core.download.DownloadWorkflow.download_shub_image')
+    def test_download_workflow_with_success(self,
+        mock_download_shub,
+        mock_download_image):
+
+        download_obj = DownloadWorkflow(
+            pipeline = "nf-core/methylseq",
+            outdir="/tmp/testdir",
+            singularity=True)
+
+        mock_download_shub.side_effect = RuntimeWarning()
+
+        download_obj.download_workflow()


### PR DESCRIPTION
- Increase the test coverage for nf-core tool's sub-command `download`.
- Refactor class code, in order to make unit-test code easier to implement

