### PR TITLE
KeyError safe dict key access

### DIFF
--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -356,7 +356,7 @@ class PipelineLint(object):
                 if self.config.get('params.container'):
                     docker_pull_cmd = 'docker pull {}'.format(self.config['params.container'].strip('"\''))
                     try:
-                        assert(docker_pull_cmd in ciconf['before_install'])
+                        assert(docker_pull_cmd in ciconf.get('before_install'))
                     except AssertionError:
                         self.failed.append((5, "CI is not pulling the correct docker image: {}".format(docker_pull_cmd)))
                     else:


### PR DESCRIPTION
Crashes if access is not safe, and results in a not so user-friendly `KeyError` when linting a pipeline.
This PR fixes this.