### PR TITLE
Add check to lint for deprecated syntax

### DIFF
--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -309,6 +309,11 @@ class PipelineLint(object):
                 self.passed.append((4, "Config variable found: {}".format(cf)))
             else:
                 self.warned.append((4, "Config variable not found: {}".format(cf)))
+        
+        # Check and warn if the process configuration is done with deprecated syntax
+        process_with_deprecated_syntax = list(set([re.search('^(process\.\$.*?)\.+.*$', ck).group(1) for ck in self.config.keys() if re.match(r'^(process\.\$.*?)\.+.*$', ck)]))
+        for pd in process_with_deprecated_syntax:
+            self.warned.append((4, "Process configuration is done with deprecated_syntax: {}".format(pd)))
 
         # Check the variables that should be set to 'true'
         for k in ['timeline.enabled', 'report.enabled', 'trace.enabled', 'dag.enabled']:

--- a/tests/lint_examples/failing_example/nextflow.config
+++ b/tests/lint_examples/failing_example/nextflow.config
@@ -1,3 +1,10 @@
 manifest.homePage = 'http://nf-co.re/pipelines'
 
 dag.file = "dag.html"
+
+process {
+    $deprecatedSyntax {
+        cpu = 1
+    }
+}
+

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -119,7 +119,7 @@ class TestLint(unittest.TestCase):
         """Tests that config variable existence test fails with bad pipeline example"""
         bad_lint_obj = nf_core.lint.PipelineLint(PATH_FAILING_EXAMPLE)
         bad_lint_obj.check_nextflow_config()
-        expectations = {"failed": 17, "warned": 8, "passed": 2}
+        expectations = {"failed": 17, "warned": 9, "passed": 2}
         self.assess_lint_status(bad_lint_obj, **expectations)
 
     @pytest.mark.xfail(raises=AssertionError)


### PR DESCRIPTION
`nextflow` had an update in syntax for process specific configuration. Idea is to encourage the new syntax (`withName: processName`) as it is more flexible. So point out the deprecated syntax (`$processName`) in *warning* while linting.

It is fairly easy now (thanks to how `nextflow` lists the current user defined configuration).  For instance

##### With deprecated syntax:
```
[u'process.$makeHISATindex.cpus', u'process.$workflow_summary_mqc.cache', u'process.$makeSTARindex.time', u'process.$star.time', u'process.$hisat2Align.time']
```

##### With cool new syntax:
```
[u"process. 'withName:makeHISATindex'.cpus", u"process. 'withName:workflow_summary_mqc'.cache", u"process. 'withName:makeSTARindex'.time", u"process. 'withName:star'.time", u"process. 'withName:hisat2Align'.time"]
```