### PR TITLE
lint fails more gracefully in travis doesn't have before_install

### DIFF
--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -359,6 +359,8 @@ class PipelineLint(object):
                         assert(docker_pull_cmd in ciconf.get('before_install'))
                     except AssertionError:
                         self.failed.append((5, "CI is not pulling the correct docker image: {}".format(docker_pull_cmd)))
+                    except TypeError:
+                        self.failed.append((5, "CI does not contain a before_install step that pulls the docker image"))
                     else:
                         self.passed.append((5, "CI is pulling the correct docker image: {}".format(docker_pull_cmd)))
 


### PR DESCRIPTION
Previous behaviour:

```python
Traceback (most recent call last):
  File "/usr/local/bin/nf-core", line 117, in <module>
    nf_core_cli()
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/bin/nf-core", line 45, in lint
    lint_obj = nf_core.lint.run_linting(pipeline_dir, release)
  File "/usr/local/lib/python3.7/site-packages/nf_core/lint.py", line 45, in run_linting
    lint_obj.lint_pipeline(release)
  File "/usr/local/lib/python3.7/site-packages/nf_core/lint.py", line 127, in lint_pipeline
    getattr(self, fname)()
  File "/usr/local/lib/python3.7/site-packages/nf_core/lint.py", line 359, in check_ci_config
    assert(docker_pull_cmd in ciconf.get('before_install'))
TypeError: argument of type 'NoneType' is not iterable
```

New behaviour:

```
ERROR: Test Failures:
  http://nf-co.re/errors#5: CI does not contain a before_install step that pulls the docker image

ERROR: Sorry, some tests failed - exiting with a non-zero error code...
```