### PR TITLE
Docs redundancy

### DIFF
--- a/nf_core/pipeline-template/{{cookiecutter.pipeline_slug}}/docs/configuration/adding_your_own.md
+++ b/nf_core/pipeline-template/{{cookiecutter.pipeline_slug}}/docs/configuration/adding_your_own.md
@@ -68,12 +68,8 @@ To use the singularity image for a single run, use `-profile standard,singularit
 To specify singularity usage in your pipeline config file, add the following:
 
 ```nextflow
-singularity {
-  enabled = true
-}
-process {
-  container = "shub://$wf_container"
-}
+singularity.enabled = true
+process.container = {"shub://${params.container.replace('nfcore', 'nf-core')}"}
 ```
 
 If you intend to run the pipeline offline, nextflow will not be able to automatically download the singularity image for you. Instead, you'll have to do this yourself manually first, transfer the image file and then point to that.

--- a/nf_core/pipeline-template/{{cookiecutter.pipeline_slug}}/docs/configuration/adding_your_own.md
+++ b/nf_core/pipeline-template/{{cookiecutter.pipeline_slug}}/docs/configuration/adding_your_own.md
@@ -77,7 +77,7 @@ singularity {
   enabled = true
 }
 process {
-  container = "docker://$wf_container"
+  container = "shub://$wf_container"
 }
 ```
 
@@ -88,7 +88,7 @@ If you intend to run the pipeline offline, nextflow will not be able to automati
 First, pull the image file where you have an internet connection:
 
 ```bash
-singularity pull --name {{ cookiecutter.pipeline_slug }}.img docker://nf-core/{{ cookiecutter.pipeline_name }}
+singularity pull --name {{ cookiecutter.pipeline_slug }}.img shub://nfcore/{{ cookiecutter.pipeline_name }}
 ```
 
 Then transfer this file and run the pipeline with this path:

--- a/nf_core/pipeline-template/{{cookiecutter.pipeline_slug}}/docs/configuration/adding_your_own.md
+++ b/nf_core/pipeline-template/{{cookiecutter.pipeline_slug}}/docs/configuration/adding_your_own.md
@@ -110,12 +110,9 @@ bash Miniconda3-latest-Linux-x86_64.sh
 
 #### 2) Add the bioconda conda channel (and others)
 ```bash
-conda config --add channels anaconda
+conda config --add channels default
 conda config --add channels conda-forge
-conda config --add channels defaults
-conda config --add channels r
 conda config --add channels bioconda
-conda config --add channels salilab
 ```
 
 #### 3) Create a conda environment, with all necessary packages:

--- a/nf_core/pipeline-template/{{cookiecutter.pipeline_slug}}/docs/configuration/adding_your_own.md
+++ b/nf_core/pipeline-template/{{cookiecutter.pipeline_slug}}/docs/configuration/adding_your_own.md
@@ -63,7 +63,7 @@ process {
 
 The variable `wf_container` is defined dynamically and automatically specifies the image tag if Nextflow is running with `-r`.
 
-A test profile comes with the pipeline and is used by the Travis continuous integration (CI) service to test the pipeline for potential errors. Typically, this downloads a small test dataset from [test data repository](https://github.com/nf-core/test-datasets/) and runs the pipeline automatically using docker using [Travis](https://travis-ci.org/nf-core/{{ cookiecutter.pipeline_name }}/) whenever changes are made to the pipeline.
+A test profile comes with the pipeline and is used by the Travis continuous integration (CI) service to test the pipeline for potential errors. Typically, this downloads a small test dataset from [test data repository](https://github.com/nf-core/test-datasets/) and runs the pipeline automatically using docker using [Travis](https://travis-ci.org/nf-core/{{ cookiecutter.pipeline_name }}/) whenever changes are made to the pipeline. Further information on how to add your own test data for a new pipeline can be found at the link mentioned above. 
 
 ### Singularity image
 Many HPC environments are not able to run Docker due to security issues. [Singularity](http://singularity.lbl.gov/) is a tool designed to run on such HPC systems which is very similar to Docker. Even better, it can use create images directly from dockerhub.

--- a/nf_core/pipeline-template/{{cookiecutter.pipeline_slug}}/docs/configuration/adding_your_own.md
+++ b/nf_core/pipeline-template/{{cookiecutter.pipeline_slug}}/docs/configuration/adding_your_own.md
@@ -68,7 +68,7 @@ A test profile comes with the pipeline and is used by the Travis continuous inte
 ### Singularity image
 Many HPC environments are not able to run Docker due to security issues. [Singularity](http://singularity.lbl.gov/) is a tool designed to run on such HPC systems which is very similar to Docker. Even better, it can use create images directly from dockerhub.
 
-To use the singularity image for a single run, use `-with-singularity 'docker://nf-core/{{ cookiecutter.pipeline_name }}'`. This will download the docker container from dockerhub and create a singularity image for you dynamically.
+To use the singularity image for a single run, use `-with-singularity 'shub://nf-core/{{ cookiecutter.pipeline_name }}'`. This will download the Singularity container from Singularity Hub.
 
 To specify singularity usage in your pipeline config file, add the following:
 

--- a/nf_core/pipeline-template/{{cookiecutter.pipeline_slug}}/docs/configuration/adding_your_own.md
+++ b/nf_core/pipeline-template/{{cookiecutter.pipeline_slug}}/docs/configuration/adding_your_own.md
@@ -63,7 +63,7 @@ process {
 
 The variable `wf_container` is defined dynamically and automatically specifies the image tag if Nextflow is running with `-r`.
 
-A test suite for docker comes with the pipeline, and can be run by moving to the [`tests` directory](https://github.com/nf-core/{{ cookiecutter.pipeline_name }}/tree/master/tests) and running `./run_test.sh`. This will download a small yeast genome and some data, and attempt to run the pipeline through docker on that small dataset. This is automatically run using [Travis](https://travis-ci.org/nf-core/{{ cookiecutter.pipeline_name }}/) whenever changes are made to the pipeline.
+A test profile comes with the pipeline and is used by the Travis continuous integration (CI) service to test the pipeline for potential errors. Typically, this downloads a small test dataset from [test data repository](https://github.com/nf-core/test-datasets/) and runs the pipeline automatically using docker using [Travis](https://travis-ci.org/nf-core/{{ cookiecutter.pipeline_name }}/) whenever changes are made to the pipeline.
 
 ### Singularity image
 Many HPC environments are not able to run Docker due to security issues. [Singularity](http://singularity.lbl.gov/) is a tool designed to run on such HPC systems which is very similar to Docker. Even better, it can use create images directly from dockerhub.

--- a/nf_core/pipeline-template/{{cookiecutter.pipeline_slug}}/docs/configuration/adding_your_own.md
+++ b/nf_core/pipeline-template/{{cookiecutter.pipeline_slug}}/docs/configuration/adding_your_own.md
@@ -88,7 +88,7 @@ If you intend to run the pipeline offline, nextflow will not be able to automati
 First, pull the image file where you have an internet connection:
 
 ```bash
-singularity pull --name {{ cookiecutter.pipeline_slug }}.img shub://nfcore/{{ cookiecutter.pipeline_name }}
+singularity pull --name {{ cookiecutter.pipeline_slug }}.img shub://nf-core/{{ cookiecutter.pipeline_name }}
 ```
 
 Then transfer this file and run the pipeline with this path:

--- a/nf_core/pipeline-template/{{cookiecutter.pipeline_slug}}/docs/configuration/local.md
+++ b/nf_core/pipeline-template/{{cookiecutter.pipeline_slug}}/docs/configuration/local.md
@@ -25,18 +25,18 @@ The public docker images are tagged with the same version numbers as the code, w
 ## Singularity image
 Many HPC environments are not able to run Docker due to security issues. [Singularity](http://singularity.lbl.gov/) is a tool designed to run on such HPC systems which is very similar to Docker. Even better, it can use create images directly from dockerhub.
 
-To use the singularity image for a single run, use `-with-singularity 'docker://{{ cookiecutter.pipeline_slug }}'`. This will download the docker container from dockerhub and create a singularity image for you dynamically.
+To use the singularity image for a single run, use `-with-singularity 'shub://{{ cookiecutter.pipeline_slug }}'`. This will download the docker container from dockerhub and create a singularity image for you dynamically.
 
 If you intend to run the pipeline offline, nextflow will not be able to automatically download the singularity image for you. Instead, you'll have to do this yourself manually first, transfer the image file and then point to that.
 
 First, pull the image file where you have an internet connection:
 
 ```bash
-singularity pull --name {{ cookiecutter.pipeline_slug }}.img docker://{{ cookiecutter.pipeline_slug }}
+singularity pull --name {{ cookiecutter.pipeline_slug }}.simg shub://{{ cookiecutter.pipeline_slug }}
 ```
 
 Then transfer this file and run the pipeline with this path:
 
 ```bash
-nextflow run /path/to/{{ cookiecutter.pipeline_name }} -with-singularity /path/to/{{ cookiecutter.pipeline_slug }}.img
+nextflow run /path/to/{{ cookiecutter.pipeline_name }} -with-singularity /path/to/{{ cookiecutter.pipeline_slug }}.simg
 ```


### PR DESCRIPTION
This should make some points mentioned in https://github.com/nf-core/tools/issues/97 more clear.

I was wrong with the redundancy I think: One document describes more in detail how you can add your own profile in here, whereas the other one describes how to use Docker/Singularity with the specific pipeline, which is something different. 

However, I took the time to update the docs a bit, adding in some more up2data ways how we normally run testcases now (adding a test.config profile for example) and removing the `./tests` directory. 
