### PR TITLE
reverse conda env handling (fix for #114)

### DIFF
--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -359,6 +359,8 @@ class PipelineLint(object):
                         assert(docker_pull_cmd in ciconf.get('before_install'))
                     except AssertionError:
                         self.failed.append((5, "CI is not pulling the correct docker image: {}".format(docker_pull_cmd)))
+                    except TypeError:
+                        self.failed.append((5, "CI does not contain a before_install step that pulls the docker image"))
                     else:
                         self.passed.append((5, "CI is pulling the correct docker image: {}".format(docker_pull_cmd)))
 

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -557,7 +557,8 @@ class PipelineLint(object):
         expected_strings = [
             'FROM nfcore/base',
             'COPY environment.yml /',
-            'RUN conda env update -n root -f /environment.yml && conda clean -a'
+            'RUN conda env create -f /environment.yml && conda clean -a',
+            'ENV PATH /opt/conda/envs/{}/bin:$PATH'.format(self.conda_config['name'])
         ]
 
         difference = set(expected_strings) - set(self.dockerfile)
@@ -581,8 +582,10 @@ class PipelineLint(object):
             'From:nfcore/base',
             'Bootstrap:docker',
             'VERSION {}'.format(self.config['params.version'].strip(' \'"')),
+            'PATH=/opt/conda/envs/{}/bin:$PATH'.format(self.conda_config['name']),
+            'export PATH',
             'environment.yml /',
-            '/opt/conda/bin/conda env update -n root -f /environment.yml',
+            '/opt/conda/bin/conda env create -f /environment.yml',
             '/opt/conda/bin/conda clean -a',
         ]
 

--- a/tests/lint_examples/minimal_working_example/Dockerfile
+++ b/tests/lint_examples/minimal_working_example/Dockerfile
@@ -4,4 +4,5 @@ LABEL authors="phil.ewels@scilifelab.se" \
     description="Docker image containing all requirements for the nf-core tools pipeline"
 
 COPY environment.yml /
-RUN conda env update -n root -f /environment.yml && conda clean -a
+RUN conda env create -f /environment.yml && conda clean -a
+ENV PATH /opt/conda/envs/nfcore-tools-0.4/bin:$PATH

--- a/tests/lint_examples/minimal_working_example/Singularity
+++ b/tests/lint_examples/minimal_working_example/Singularity
@@ -6,9 +6,13 @@ Bootstrap:docker
     DESCRIPTION Container image containing all requirements for the nf-core/tools pipeline
     VERSION 0.4
 
+%environment
+    PATH=/opt/conda/envs/nfcore-tools-0.4/bin:$PATH
+    export PATH
+
 %files
     environment.yml /
 
 %post
-    /opt/conda/bin/conda env update -n root -f /environment.yml
+    /opt/conda/bin/conda env create -f /environment.yml
     /opt/conda/bin/conda clean -a

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -321,7 +321,7 @@ class TestLint(unittest.TestCase):
         lint_obj.conda_config['name'] = 'nfcore-tools-0.4'
         lint_obj.dockerfile = ['fubar']
         lint_obj.check_conda_dockerfile()
-        expectations = {"failed": 3, "warned": 0, "passed": 0}
+        expectations = {"failed": 4, "warned": 0, "passed": 0}
         self.assess_lint_status(lint_obj, **expectations)
 
     def test_conda_dockerfile_skip(self):


### PR DESCRIPTION
Recreating PR #122 by @HadrienG which I reverted after accidentally merging into `master`.

This PR goes to `dev` as it should do.