### PR TITLE
nf-core create: Refactor, add --outdir

### DIFF
--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -137,9 +137,15 @@ def release(pipeline_dir, new_version):
     default = False,
     help = "Overwrite output directory if it already exists"
 )
-def create(name, description, new_version, no_git, force):
+@click.option(
+    '-o', '--outdir',
+    type = str,
+    help = "Output directory for new pipeline (default: pipeline name)"
+)
+def create(name, description, new_version, no_git, force, outdir):
     """ Create a new pipeline using the nf-core template """
-    nf_core.create.init_pipeline(name, description, new_version, no_git, force)
+    create_obj = nf_core.create.PipelineCreate(name, description, new_version, no_git, force, outdir)
+    create_obj.init_pipeline()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add option for the `nf-core create` command to specify the output directory. This works by running cookiecutter in a temporary directory, then moving the contents to the specified directory (needed because the cookiecutter template annoying needs to produce files in a subdirectory).

I also refactored to use object-orientated style instead, which should make life easier for testing and other stuff.