### PR TITLE
Renamed 'release' to 'bump-version' and other stuff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
-# nf-core/tools
+# nf-core/tools: Changelog
+
+## v1.2dev
+* Updated the `nf-core release` command
+    * Now called `nf-core bump-versions` instead
+    * New flag `--nextflow` to change the required nextflow version instead
+* Template updates
+    * Simpler installation of the `nf-core` helper tool, now directly from PyPI
+    * Bump minimum nextflow version to `0.31.1` (required for built in `manifest.nextflowVersion` check)
+* New lint tests
+    * `.travis.yml` test for PRs made against the `master` branch
+    * Automatic `--release` option not used if the travis repo is `nf-core/tools`
+* Updated PyPI deployment to  correctly parse the markdown readme (hopefully!)
 
 ## [v1.1](https://github.com/nf-core/tools/releases/tag/1.1) - 2018-08-14
 Very large release containing lots of work from the first nf-core hackathon, held in SciLifeLab Stockholm.

--- a/README.md
+++ b/README.md
@@ -179,17 +179,17 @@ WARNING: Test Warnings:
 ```
 
 
-## Making a pipeline release
+## Bumping a pipeline version number
 
-When releasing a new version of a nf-core pipeline, version numbers have to be updated in several different places. The helper command `nf-core release` automates this for you to avoid manual errors (and frustration!).
+When releasing a new version of a nf-core pipeline, version numbers have to be updated in several different places. The helper command `nf-core bump-version` automates this for you to avoid manual errors (and frustration!).
 
 The command uses results from the linting process, so will only work with workflows that pass these tests.
 
-Usage is `nf-core release <pipeline_dir> <new_version>`, eg:
+Usage is `nf-core bump-version <pipeline_dir> <new_version>`, eg:
 
 ```
 $ cd path/to/my_pipeline
-$ nf-core release . 1.3
+$ nf-core bump-version . 1.3
 
 
                                           ,--./,-.
@@ -227,3 +227,5 @@ INFO: Updating version in environment.yml
  - name: nfcore-methylseq-1.3dev
  + name: nfcore-methylseq-1.3
 ```
+
+To change the required version of Nextflow instead of the pipeline version number, use the flag `--nextflow`.

--- a/docs/lint_errors.md
+++ b/docs/lint_errors.md
@@ -111,6 +111,12 @@ This test fails if the following happens:
     ```
     * At least one of these `NXF_VER` variables must match the `manifest.nextflowVersion` version specified in the pipeline config
     * Other variables can be specified on these lines as long as they are space separated.
+* `.travis.yml` checks that pull requests are not opened directly to the `master` branch
+    * The following is expected in the `before_install` section:
+    ```yaml
+    before_install:
+      - '[ $TRAVIS_PULL_REQUEST = "false" ] || [ $TRAVIS_BRANCH != "master" ] || ([ $TRAVIS_PULL_REQUEST_SLUG = $TRAVIS_REPO_SLUG ] && [ $TRAVIS_PULL_REQUEST_BRANCH = "dev" ])'
+    ```
 
 ## Error #6 - Repository `README.md` tests ## {#6}
 The `README.md` files for a project are very important and must meet some requirements:

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -368,6 +368,15 @@ class PipelineLint(object):
             if os.path.isfile(fn):
                 with open(fn, 'r') as fh:
                     ciconf = yaml.load(fh)
+                # Check that we have the master branch protection
+                travisMasterCheck = '[ $TRAVIS_PULL_REQUEST = "false" ] || [ $TRAVIS_BRANCH != "master" ] || ([ $TRAVIS_PULL_REQUEST_SLUG = $TRAVIS_REPO_SLUG ] && [ $TRAVIS_PULL_REQUEST_BRANCH = "dev" ])'
+                try:
+                    assert(travisMasterCheck in ciconf['before_install'])
+                except AssertionError:
+                    print(ciconf['before_install'])
+                    self.failed.append((5, "Continuous integration must check for master branch PRs: '{}'".format(fn)))
+                else:
+                    self.passed.append((5, "Continuous integration checks for master branch PRs: '{}'".format(fn)))
                 # Check that the nf-core linting runs
                 try:
                     assert('nf-core lint ${TRAVIS_BUILD_DIR}' in ciconf['script'])

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -371,9 +371,8 @@ class PipelineLint(object):
                 # Check that we have the master branch protection
                 travisMasterCheck = '[ $TRAVIS_PULL_REQUEST = "false" ] || [ $TRAVIS_BRANCH != "master" ] || ([ $TRAVIS_PULL_REQUEST_SLUG = $TRAVIS_REPO_SLUG ] && [ $TRAVIS_PULL_REQUEST_BRANCH = "dev" ])'
                 try:
-                    assert(travisMasterCheck in ciconf['before_install'])
+                    assert(travisMasterCheck in ciconf.get('before_install', {}))
                 except AssertionError:
-                    print(ciconf['before_install'])
                     self.failed.append((5, "Continuous integration must check for master branch PRs: '{}'".format(fn)))
                 else:
                     self.passed.append((5, "Continuous integration checks for master branch PRs: '{}'".format(fn)))

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.travis.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.travis.yml
@@ -1,10 +1,8 @@
 sudo: required
 language: python
 jdk: openjdk8
-services:
-  - docker
-python:
-  - '3.6'
+services: docker
+python: '3.6'
 cache: pip
 matrix:
   fast_finish: true
@@ -19,19 +17,17 @@ before_install:
 
 install:
   # Install Nextflow
-  - mkdir /tmp/nextflow
-  - cd /tmp/nextflow
+  - mkdir /tmp/nextflow && cd /tmp/nextflow
   - wget -qO- get.nextflow.io | bash
   - sudo ln -s /tmp/nextflow/nextflow /usr/local/bin/nextflow
   # Install nf-core/tools
   - pip install nf-core
   # Reset
-  - mkdir ${TRAVIS_BUILD_DIR}/tests
-  - cd ${TRAVIS_BUILD_DIR}/tests
+  - mkdir ${TRAVIS_BUILD_DIR}/tests && cd ${TRAVIS_BUILD_DIR}/tests
 
 env:
   - NXF_VER='0.31.1' # Specify a minimum NF version that should be tested and work
-  - NXF_VER='' # Plus: get the latest NF version and check, that it works
+  - NXF_VER='' # Plus: get the latest NF version and check that it works
 
 script:
   # Lint the pipeline code

--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -8,7 +8,7 @@ import sys
 import os
 
 import nf_core
-import nf_core.lint, nf_core.list, nf_core.download, nf_core.release, nf_core.create
+import nf_core.lint, nf_core.list, nf_core.download, nf_core.bump_version, nf_core.create
 
 import logging
 
@@ -84,7 +84,7 @@ def download(pipeline, release, singularity, outdir):
     dl = nf_core.download.DownloadWorkflow(pipeline, release, singularity, outdir)
     dl.download_workflow()
 
-@nf_core_cli.command()
+@nf_core_cli.command('bump-version')
 @click.argument(
     'pipeline_dir',
     type = click.Path(exists=True),
@@ -94,17 +94,26 @@ def download(pipeline, release, singularity, outdir):
 @click.argument(
     'new_version',
     required = True,
-    metavar = "<new version number>"
+    metavar = "<new version>"
 )
-def release(pipeline_dir, new_version):
+@click.option(
+    '-n', '--nextflow',
+    is_flag = True,
+    default = False,
+    help = "Bump required nextflow version instead of pipeline version"
+)
+def bump_version(pipeline_dir, new_version, nextflow):
     """ Update nf-core pipeline version number """
 
     # First, lint the pipeline to check everything is in order
     logging.info("Running nf-core lint tests")
     lint_obj = nf_core.lint.run_linting(pipeline_dir, False)
 
-    # Bump the version number in relevant files
-    nf_core.release.make_release(lint_obj, new_version)
+    # Bump the pipeline version number
+    if not nextflow:
+        nf_core.bump_version.bump_pipeline_version(lint_obj, new_version)
+    else:
+        nf_core.bump_version.bump_nextflow_version(lint_obj, new_version)
 
 @nf_core_cli.command()
 @click.option(

--- a/tests/lint_examples/minimal_working_example/.travis.yml
+++ b/tests/lint_examples/minimal_working_example/.travis.yml
@@ -10,6 +10,8 @@ matrix:
   fast_finish: true
 
 before_install:
+  # PRs made to 'master' branch should always orginate from another repo or the 'dev' branch
+  - '[ $TRAVIS_PULL_REQUEST = "false" ] || [ $TRAVIS_BRANCH != "master" ] || ([ $TRAVIS_PULL_REQUEST_SLUG = $TRAVIS_REPO_SLUG ] && [ $TRAVIS_PULL_REQUEST_BRANCH = "dev" ])'
   # Pull the docker image first so the test doesn't wait for this
   - docker pull nfcore/tools
   # Fake the tag locally so that the pipeline runs properly

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -1,33 +1,33 @@
 #!/usr/bin/env python
-"""Some tests covering the release code.
+"""Some tests covering the bump_version code.
 """
 import os
 import pytest
 import shutil
 import unittest
-import nf_core.lint, nf_core.release
+import nf_core.lint, nf_core.bump_version
 
 WD = os.path.dirname(__file__)
 PATH_WORKING_EXAMPLE = os.path.join(WD, 'lint_examples/minimal_working_example')
 
 
 @pytest.mark.datafiles(PATH_WORKING_EXAMPLE)
-def test_working_release(datafiles):
+def test_working_bump_pipeline_version(datafiles):
     """ Test that making a release with the working example files works """
     lint_obj = nf_core.lint.PipelineLint(str(datafiles))
     lint_obj.pipeline_name = 'tools'
     lint_obj.config['manifest.pipelineVersion'] = '0.4'
     lint_obj.files = ['nextflow.config', 'Dockerfile', 'environment.yml']
-    nf_core.release.make_release(lint_obj, '1.1')
+    nf_core.bump_version.bump_pipeline_version(lint_obj, '1.1')
 
 @pytest.mark.datafiles(PATH_WORKING_EXAMPLE)
-def test_dev_release(datafiles):
+def test_dev_bump_pipeline_version(datafiles):
     """ Test that making a release works with a dev name and a leading v """
     lint_obj = nf_core.lint.PipelineLint(str(datafiles))
     lint_obj.pipeline_name = 'tools'
     lint_obj.config['manifest.pipelineVersion'] = '0.4'
     lint_obj.files = ['nextflow.config', 'Dockerfile', 'environment.yml']
-    nf_core.release.make_release(lint_obj, 'v1.2dev')
+    nf_core.bump_version.bump_pipeline_version(lint_obj, 'v1.2dev')
 
 @pytest.mark.datafiles(PATH_WORKING_EXAMPLE)
 @pytest.mark.xfail(raises=SyntaxError)
@@ -37,7 +37,7 @@ def test_pattern_not_found(datafiles):
     lint_obj.pipeline_name = 'tools'
     lint_obj.config['manifest.pipelineVersion'] = '0.5'
     lint_obj.files = ['nextflow.config', 'Dockerfile', 'environment.yml']
-    nf_core.release.make_release(lint_obj, '1.2dev')
+    nf_core.bump_version.bump_pipeline_version(lint_obj, '1.2dev')
 
 @pytest.mark.datafiles(PATH_WORKING_EXAMPLE)
 @pytest.mark.xfail(raises=SyntaxError)
@@ -49,4 +49,4 @@ def test_multiple_patterns_found(datafiles):
     lint_obj.pipeline_name = 'tools'
     lint_obj.config['manifest.pipelineVersion'] = '0.4'
     lint_obj.files = ['nextflow.config', 'Dockerfile', 'environment.yml']
-    nf_core.release.make_release(lint_obj, '1.2dev')
+    nf_core.bump_version.bump_pipeline_version(lint_obj, '1.2dev')

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -279,7 +279,7 @@ class DownloadTest(unittest.TestCase):
         download_obj.validate_md5(tmpfile[1], val_hash)
 
         # Clean up
-        os.remove(tmpfile)
+        os.remove(tmpfile[1])
 
     @pytest.mark.xfail(raises=IOError)
     def test_mismatching_md5sums(self):

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -38,7 +38,7 @@ PATHS_WRONG_LICENSE_EXAMPLE = [pf(WD, 'lint_examples/wrong_license_example'),
     pf(WD, 'lint_examples/license_incomplete_example')]
 
 # The maximum sum of passed tests currently possible
-MAX_PASS_CHECKS = 60
+MAX_PASS_CHECKS = 61
 # The additional tests passed for releases
 ADD_PASS_RELEASE = 1
 
@@ -133,7 +133,7 @@ class TestLint(unittest.TestCase):
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         lint_obj.minNextflowVersion = '0.27.0'
         lint_obj.check_ci_config()
-        expectations = {"failed": 0, "warned": 0, "passed": 2}
+        expectations = {"failed": 0, "warned": 0, "passed": 3}
         self.assess_lint_status(lint_obj, **expectations)
 
     def test_ci_conf_fail_wrong_nf_version(self):
@@ -141,7 +141,7 @@ class TestLint(unittest.TestCase):
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         lint_obj.minNextflowVersion = '0.28.0'
         lint_obj.check_ci_config()
-        expectations = {"failed": 1, "warned": 0, "passed": 1}
+        expectations = {"failed": 1, "warned": 0, "passed": 2}
         self.assess_lint_status(lint_obj, **expectations)
 
     def test_ci_conf_fail(self):


### PR DESCRIPTION
* Renamed the somewhat confusing `nf-core release` to `nf-core bump-version`
* Updated the above to have a `--nextflow`/`-n` flag to bump the required nextflow version
* Added a lint test for the new Travis `before_install` branch name check