### PR TITLE
Fix logic bug in automatic --release for linting

### DIFF
--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -35,7 +35,7 @@ def nf_core_cli(verbose):
 @click.option(
     '--release',
     is_flag = True,
-    default = os.environ.get('TRAVIS_BRANCH') == 'master' and os.environ.get('TRAVIS_REPO_SLUG', '').startswith('nf-core/') and not os.environ.get('TRAVIS_REPO_SLUG', 'nf-core/tools'),
+    default = os.environ.get('TRAVIS_BRANCH') == 'master' and os.environ.get('TRAVIS_REPO_SLUG', '').startswith('nf-core/') and not os.environ.get('TRAVIS_REPO_SLUG', '') == 'nf-core/tools',
     help = "Execute additional checks for release-ready workflows."
 )
 def lint(pipeline_dir, release):


### PR DESCRIPTION
I noticed that the lint tests in https://github.com/nf-core/rnaseq/pull/61 should be running with `--release` automatically, and failing. But they weren't.

That led me to notice this error in the logic for that block. Now fixed.