### PR TITLE
Fix bump-version backslashes

### DIFF
--- a/nf_core/bump_version.py
+++ b/nf_core/bump_version.py
@@ -55,12 +55,12 @@ def bump_pipeline_version(lint_obj, new_version):
 
         # Update Dockerfile PATH
         nfconfig_pattern = r"PATH\s+/opt/conda/envs/nf-core-{}-{}/bin:\$PATH".format(lint_obj.pipeline_name.lower(), current_version.replace('.','\.'))
-        nfconfig_newstr = "PATH /opt/conda/envs/nf-core-{}-{}/bin:\$PATH".format(lint_obj.pipeline_name.lower(), new_version)
+        nfconfig_newstr = "PATH /opt/conda/envs/nf-core-{}-{}/bin:$PATH".format(lint_obj.pipeline_name.lower(), new_version)
         update_file_version("Dockerfile", lint_obj, nfconfig_pattern, nfconfig_newstr)
 
         # Update Singularity PATH
         nfconfig_pattern = r"PATH=/opt/conda/envs/nf-core-{}-{}/bin:\$PATH".format(lint_obj.pipeline_name.lower(), current_version.replace('.','\.'))
-        nfconfig_newstr = "PATH=/opt/conda/envs/nf-core-{}-{}/bin:\$PATH".format(lint_obj.pipeline_name.lower(), new_version)
+        nfconfig_newstr = "PATH=/opt/conda/envs/nf-core-{}-{}/bin:$PATH".format(lint_obj.pipeline_name.lower(), new_version)
         update_file_version("Singularity", lint_obj, nfconfig_pattern, nfconfig_newstr)
 
 def bump_nextflow_version(lint_obj, new_version):


### PR DESCRIPTION
Carry-over from the regular expressions meant that the bump-versions command was accidentally adding in backslashes to the Docker and Singularity scripts. This removes that.