### PR TITLE
nf-core list: Fix release sorting and plurals

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
 
 A python package with helper tools for the nf-core community.
 
+## Table of contents
+
+* [Installation](#installation)
+* [Listing pipelines](#listing-pipelines) (`nf-core list`)
+* [Downloading pipelines for offline use](#downloading-pipelines-for-offline-use) (`nf-core download`)
+* [Creating a new workflow](#creating-a-new-workflow) (`nf-core create`)
+* [Linting a workflow](#linting-a-workflow) (`nf-core lint`)
+* [Bumping a pipeline version number](#bumping-a-pipeline-version-number) (`nf-core bump-version`)
+
 ## Installation
 
 You can install `nf-core/tools` from [PyPI](https://pypi.python.org/pypi/nf-core/) using pip as follows:
@@ -125,11 +134,14 @@ $ nf-core create -n nextbigthing -d "This pipeline analyses data from the next b
                                           `._,._,'
 
 
-INFO: Creating new nf-core pipeline: nextbigthing
+INFO: Creating new nf-core pipeline: nf-core/nextbigthing
 
 INFO: Initialising pipeline git repository
 
-INFO: Done. Remember to add a remote and push to GitHub!
+INFO: Done. Remember to add a remote and push to GitHub:
+  cd /path/to/nf-core-nextbigthing
+  git remote add origin git@github.com:USERNAME/REPO_NAME.git
+  git push
 ```
 
 Once you have run the command, create a new empty repository on GitHub under your username (not the `nf-core` organisation, yet).
@@ -189,8 +201,7 @@ Usage is `nf-core bump-version <pipeline_dir> <new_version>`, eg:
 
 ```
 $ cd path/to/my_pipeline
-$ nf-core bump-version . 1.3
-
+$ nf-core bump-version . 1.0
 
                                           ,--./,-.
           ___     __   __   __   ___     /,-._.--~\
@@ -205,27 +216,39 @@ Running pipeline tests  [####################################]  100%  None
 INFO: ===========
  LINTING RESULTS
 =================
-  74 tests passed   0 tests had warnings   0 tests failed
+  96 tests passed   0 tests had warnings   0 tests failed
 
 INFO: Changing version number:
-  Current version number is '1.3dev'
-  New version number will be '1.3'
+  Current version number is '1.0dev'
+  New version number will be '1.0'
 
 INFO: Updating version in nextflow.config
- - version = '1.3dev'
- + version = '1.3'
+ - pipelineVersion = '1.0dev'
+ + pipelineVersion = '1.0'
 
 INFO: Updating version in nextflow.config
- - container = 'nfcore/methylseq:latest'
- + container = 'nfcore/methylseq:1.3'
+ - container = 'nfcore/mypipeline:latest'
+ + container = 'nfcore/mypipeline:1.0'
+
+INFO: Updating version in .travis.yml
+ - docker tag nfcore/mypipeline nfcore/mypipeline:latest
+ + docker tag nfcore/mypipeline nfcore/mypipeline:1.0
 
 INFO: Updating version in Singularity
- - VERSION 1.3dev
- + VERSION 1.3
+ - VERSION 1.0dev
+ + VERSION 1.0
 
 INFO: Updating version in environment.yml
- - name: nfcore-methylseq-1.3dev
- + name: nfcore-methylseq-1.3
+ - name: nf-core-mypipeline-1.0dev
+ + name: nf-core-mypipeline-1.0
+
+INFO: Updating version in Dockerfile
+ - PATH /opt/conda/envs/nf-core-mypipeline-1.0dev/bin:$PATH
+ + PATH /opt/conda/envs/nf-core-mypipeline-1.0/bin:\$PATH
+
+INFO: Updating version in Singularity
+ - PATH=/opt/conda/envs/nf-core-mypipeline-1.0dev/bin:$PATH
+ + PATH=/opt/conda/envs/nf-core-mypipeline-1.0/bin:\$PATH
 ```
 
 To change the required version of Nextflow instead of the pipeline version number, use the flag `--nextflow`.

--- a/nf_core/list.py
+++ b/nf_core/list.py
@@ -251,17 +251,17 @@ def pretty_date(time):
     pretty_msg[0] = [(float('inf'), 1, 'from the future')]
     pretty_msg[1] = [
             (10, 1, "just now"),
-            (60, 1, "{sec:.0g} seconds ago"),
+            (60, 1, "{sec:.0f} seconds ago"),
             (120, 1, "a minute ago"),
-            (3600, 60, "{sec:.0g} minutes ago"),
+            (3600, 60, "{sec:.0f} minutes ago"),
             (7200, 1, "an hour ago"),
-            (86400, 3600, "{sec:.0g} hours ago")
+            (86400, 3600, "{sec:.0f} hours ago")
         ]
     pretty_msg[2] = [(float('inf'), 1, 'yesterday')]
-    pretty_msg[7] = [(float('inf'), 1, '{days:.0g} day{day_s} ago')]
-    pretty_msg[31] = [(float('inf'), 7, '{days:.0g} week{day_s} ago')]
-    pretty_msg[365] = [(float('inf'), 30, '{days:.0g} months ago')]
-    pretty_msg[float('inf')] = [(float('inf'), 365, '{days:.0g} year{day_s} ago')]
+    pretty_msg[7] = [(float('inf'), 1, '{days:.0f} day{day_s} ago')]
+    pretty_msg[31] = [(float('inf'), 7, '{days:.0f} week{day_s} ago')]
+    pretty_msg[365] = [(float('inf'), 30, '{days:.0f} months ago')]
+    pretty_msg[float('inf')] = [(float('inf'), 365, '{days:.0f} year{day_s} ago')]
 
     for days, seconds in pretty_msg.items():
         if day_diff < days:


### PR DESCRIPTION
The releases are sorted in date order, so the command nf-core list only showed the first release. It now shows the latest release.

Pretty printing the date sometimes gave weird results on py2.7 as it wasn't an ordered dictionary. Addressed.

Plurals are now handled better when listing pipelines.