### PR TITLE
Add fixed conda version for nf-core tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,4 @@ LABEL authors="phil.ewels@scilifelab.se,alexander.peltzer@qbic.uni-tuebingen.de"
 
 # Install procps so that Nextflow can poll CPU usage
 RUN apt-get update && apt-get install -y procps && apt-get clean -y 
+RUN conda install conda=4.5.11


### PR DESCRIPTION
Hi! 

this should resolve #159 . 
I've added a simple statement updating the base conda to 4.5.11 and keeping that until conda 4.6.0 is out. Then we can update for each nf-core/tools release accordingly as discussed in #159. 

If there is stuff missing/ideas/comments, let me know!
 
