### PR TITLE
Updated tracedir path

### DIFF
--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
@@ -58,19 +58,19 @@ process.shell = ['/bin/bash', '-euo', 'pipefail']
 
 timeline {
   enabled = true
-  file = "${params.tracedir}/pipeline_info/{{ cookiecutter.name.replace(' ', '-') }}_timeline.html"
+  file = "${params.tracedir}/{{ cookiecutter.name.replace(' ', '-') }}_timeline.html"
 }
 report {
   enabled = true
-  file = "${params.tracedir}/pipeline_info/{{ cookiecutter.name.replace(' ', '-') }}_report.html"
+  file = "${params.tracedir}/{{ cookiecutter.name.replace(' ', '-') }}_report.html"
 }
 trace {
   enabled = true
-  file = "${params.tracedir}/pipeline_info/{{ cookiecutter.name.replace(' ', '-') }}_trace.txt"
+  file = "${params.tracedir}/{{ cookiecutter.name.replace(' ', '-') }}_trace.txt"
 }
 dag {
   enabled = true
-  file = "${params.tracedir}/pipeline_info/{{ cookiecutter.name.replace(' ', '-') }}_dag.svg"
+  file = "${params.tracedir}/{{ cookiecutter.name.replace(' ', '-') }}_dag.svg"
 }
 
 manifest {


### PR DESCRIPTION
Removed "pipeline_info" path for standard nextflow reports in nextflow.config since it has already been specified in tracedir parameter i.e. tracedir = "${params.outdir}/pipeline_info".