### PR TITLE
Make linting check manifest.version instead of workflow.manifest.version

### DIFF
--- a/nf_core/bump_version.py
+++ b/nf_core/bump_version.py
@@ -14,12 +14,12 @@ def bump_pipeline_version(lint_obj, new_version):
     """ Function to bump a pipeline version number. Called by the main script """
 
     # Collect the old and new version numbers
-    current_version = lint_obj.config.get('workflow.manifest.version', '').strip(' \'"')
+    current_version = lint_obj.config.get('manifest.version', '').strip(' \'"')
     if new_version.startswith('v'):
         logging.warn("Stripping leading 'v' from new version number")
         new_version = new_version[1:]
     if not current_version:
-        logging.error("Could not find config variable workflow.manifest.version")
+        logging.error("Could not find config variable manifest.version")
         sys.exit(1)
     logging.info("Changing version number:\n  Current version number is '{}'\n  New version number will be '{}'".format(current_version, new_version))
 
@@ -92,7 +92,7 @@ def bump_nextflow_version(lint_obj, new_version):
     update_file_version("README.md", lint_obj, nfconfig_pattern, nfconfig_newstr, True)
 
 def update_file_version(filename, lint_obj, pattern, newstr, allow_multiple=False):
-    """ Update workflow.manifest.version in the nextflow config file """
+    """ Update version number in the requested file """
 
     # Load the file
     fn = os.path.join(lint_obj.path, filename)

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -16,7 +16,7 @@ def test_working_bump_pipeline_version(datafiles):
     """ Test that making a release with the working example files works """
     lint_obj = nf_core.lint.PipelineLint(str(datafiles))
     lint_obj.pipeline_name = 'tools'
-    lint_obj.config['workflow.manifest.version'] = '0.4'
+    lint_obj.config['manifest.version'] = '0.4'
     lint_obj.files = ['nextflow.config', 'Dockerfile', 'environment.yml']
     nf_core.bump_version.bump_pipeline_version(lint_obj, '1.1')
 
@@ -25,7 +25,7 @@ def test_dev_bump_pipeline_version(datafiles):
     """ Test that making a release works with a dev name and a leading v """
     lint_obj = nf_core.lint.PipelineLint(str(datafiles))
     lint_obj.pipeline_name = 'tools'
-    lint_obj.config['workflow.manifest.version'] = '0.4'
+    lint_obj.config['manifest.version'] = '0.4'
     lint_obj.files = ['nextflow.config', 'Dockerfile', 'environment.yml']
     nf_core.bump_version.bump_pipeline_version(lint_obj, 'v1.2dev')
 
@@ -35,7 +35,7 @@ def test_pattern_not_found(datafiles):
     """ Test that making a release raises and error if a pattern isn't found """
     lint_obj = nf_core.lint.PipelineLint(str(datafiles))
     lint_obj.pipeline_name = 'tools'
-    lint_obj.config['workflow.manifest.version'] = '0.5'
+    lint_obj.config['manifest.version'] = '0.5'
     lint_obj.files = ['nextflow.config', 'Dockerfile', 'environment.yml']
     nf_core.bump_version.bump_pipeline_version(lint_obj, '1.2dev')
 
@@ -45,8 +45,8 @@ def test_multiple_patterns_found(datafiles):
     """ Test that making a release raises if a version number is found twice """
     lint_obj = nf_core.lint.PipelineLint(str(datafiles))
     with open(os.path.join(str(datafiles), 'nextflow.config'), "a") as nfcfg:
-        nfcfg.write("workflow.manifest.version = '0.4'")
+        nfcfg.write("manifest.version = '0.4'")
     lint_obj.pipeline_name = 'tools'
-    lint_obj.config['workflow.manifest.version'] = '0.4'
+    lint_obj.config['manifest.version'] = '0.4'
     lint_obj.files = ['nextflow.config', 'Dockerfile', 'environment.yml']
     nf_core.bump_version.bump_pipeline_version(lint_obj, '1.2dev')

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -38,7 +38,7 @@ PATHS_WRONG_LICENSE_EXAMPLE = [pf(WD, 'lint_examples/wrong_license_example'),
     pf(WD, 'lint_examples/license_incomplete_example')]
 
 # The maximum sum of passed tests currently possible
-MAX_PASS_CHECKS = 63
+MAX_PASS_CHECKS = 62
 # The additional tests passed for releases
 ADD_PASS_RELEASE = 1
 
@@ -58,7 +58,7 @@ class TestLint(unittest.TestCase):
         This should not result in any exception for the minimal
         working example"""
         lint_obj = nf_core.lint.run_linting(PATH_WORKING_EXAMPLE, False)
-        expectations = {"failed": 0, "warned": 1, "passed": MAX_PASS_CHECKS}
+        expectations = {"failed": 0, "warned": 2, "passed": MAX_PASS_CHECKS}
         self.assess_lint_status(lint_obj, **expectations)
 
     @pytest.mark.xfail(raises=AssertionError)
@@ -73,7 +73,7 @@ class TestLint(unittest.TestCase):
         """Test the main execution function of PipelineLint when running with --release"""
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         lint_obj.lint_pipeline(release=True)
-        expectations = {"failed": 0, "warned": 1, "passed": MAX_PASS_CHECKS + ADD_PASS_RELEASE}
+        expectations = {"failed": 0, "warned": 2, "passed": MAX_PASS_CHECKS + ADD_PASS_RELEASE}
         self.assess_lint_status(lint_obj, **expectations)
 
     def test_failing_dockerfile_example(self):
@@ -264,7 +264,7 @@ class TestLint(unittest.TestCase):
         lint_obj.pipeline_name = 'tools'
         lint_obj.config['manifest.version'] = '0.4'
         lint_obj.check_conda_env_yaml()
-        expectations = {"failed": 0, "warned": 1, "passed": 6}
+        expectations = {"failed": 0, "warned": 2, "passed": 5}
         self.assess_lint_status(lint_obj, **expectations)
 
     def test_conda_env_fail(self):


### PR DESCRIPTION
The nextflow scripts access this variable at `workflow.manifest.version`, but the nextflow config has it just at `manifest.version` (so that's what `nextflow config` returns)