### PR TITLE
nf-core launch: new subcommand

### DIFF
--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -8,7 +8,7 @@ import sys
 import os
 
 import nf_core
-import nf_core.lint, nf_core.list, nf_core.download, nf_core.licences, nf_core.bump_version, nf_core.create
+import nf_core.bump_version, nf_core.create, nf_core.download, nf_core.launch, nf_core.licences, nf_core.lint, nf_core.list
 
 import logging
 
@@ -113,6 +113,16 @@ def download(pipeline, release, singularity, outdir):
     """ Download a pipeline and singularity container """
     dl = nf_core.download.DownloadWorkflow(pipeline, release, singularity, outdir)
     dl.download_workflow()
+
+@nf_core_cli.command()
+@click.argument(
+    'pipeline',
+    required = True,
+    metavar = "<pipeline name>"
+)
+def launch(pipeline):
+    """ Interactively build a nextflow command and launch a pipeline """
+    nf_core.launch.launch_pipeline(pipeline)
 
 @nf_core_cli.command('bump-version')
 @click.argument(


### PR DESCRIPTION
New subcommand to interactively prompt the user to set workflow flags before launching.

For example:

```
$  nf-core launch methylseq

                                          ,--./,-.
          ___     __   __   __   ___     /,-._.--~\
    |\ | |__  __ /  ` /  \ |__) |__         }  {
    | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                          `._,._,'


INFO: Launching nf-core/methylseq


INFO: Main nextflow options:

Config profile to use [standard]:
Unique name for this nextflow run [False]: Phil's test run
Work directory for intermediate files [work]:
Resume a previous workflow run [False]: true
Release / revision to use [False]: 1.0

INFO: Pipeline specific parameters:

--mindepth [0]:
--nodedup [false]: true
--reads ['data/*_R{1,2}.fastq.gz']:
--numMismatches [0.6]:
--igenomes_base ['s3://ngi-igenomes/igenomes/']:
--container ['nfcore/methylseq:1.0']:
--notrim [false]: false
--max_memory ['128 GB']: 64 GB
--version ['1.0']:
--saveReference [false]:
--unmapped [false]: false
--max_cpus [16]:
--saveTrimmed [false]:
--non_directional [false]:
--comprehensive [false]:
--aligner ['bismark']:
--outdir ['./results']:
--relaxMismatches [false]:
--singleEnd [false]:
--saveAlignedIntermediates [false]:
--nf_required_version ['0.27.6']:
--ignoreFlags [false]:
--max_time ['10d']:
--multiqc_config ['/Users/ewels/.nextflow/assets/nf-core/methylseq/conf/multiqc_config.yaml']:

INFO: Nextflow command:
  nextflow run nf-core/methylseq -name "Phil's test run" -resume -r "1.0" --nodedup --max_memory "64 GB"


Do you want to run this command now? [y/N]: y

INFO: Launching!
```

This is a WIP - need to fill in the PR checklist still. It's a little crude, so any feedback welcome!

NB:  This only works with local paths or workflows that have already been pulled (see https://github.com/nextflow-io/nextflow/issues/889). For anything else, it does not ask for any `params` and just builds the basic command. This should probably be handled in a better way (a warning at least).

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated