### PR TITLE
Update channel order for environment yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # nf-core/tools: Changelog
 
 ## v1.3dev
-_nothing yet.._
 * Updated channel order for bioconda/conda-forge channels in environment.yaml
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v1.3dev
 _nothing yet.._
+* Updated channel order for bioconda/conda-forge channels in environment.yaml
+
 
 ## [v1.2](https://github.com/nf-core/tools/releases/tag/1.2) - 2018-10-01
 * Updated the `nf-core release` command

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/environment.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/environment.yml
@@ -1,8 +1,8 @@
 name: {{ cookiecutter.name_noslash }}-{{ cookiecutter.version }}
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - defaults
 dependencies:
-  - fastqc=0.11.7
+  - fastqc=0.11.8
   - multiqc=1.6


### PR DESCRIPTION
This should address https://github.com/nf-core/tools/issues/160 by reversing the channel order of bioconda and conda-forge in the `environment.yaml`. 


## PR checklist
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [x] `CHANGELOG.md` is updated
