### PR TITLE
Add PIP testing

### DIFF
--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.travis.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.travis.yml
@@ -21,6 +21,7 @@ install:
   - wget -qO- get.nextflow.io | bash
   - sudo ln -s /tmp/nextflow/nextflow /usr/local/bin/nextflow
   # Install nf-core/tools
+  - pip install --upgrade pip 
   - pip install nf-core
   # Reset
   - mkdir ${TRAVIS_BUILD_DIR}/tests && cd ${TRAVIS_BUILD_DIR}/tests


### PR DESCRIPTION
This adds `pip upgrade` to update the outdated pip version in the TravisCI build automatically to the template. 
