### PR TITLE
Adding in vim and nano to base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix [189](https://github.com/nf-core/tools/issues/189): Check for given conda and PyPi package dependencies, if their versions exist
 * Added profiles for `cfc` and `binac` that can be synced across pipelines
 * Added `pip install --upgrade pip` to `.travis.yml` to update pip in the Travis CI environment
+* Added `vim` and `nano` to base docker image for all containers
 
 ## [v1.2](https://github.com/nf-core/tools/releases/tag/1.2) - 2018-10-01
 * Updated the `nf-core release` command

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ LABEL authors="phil.ewels@scilifelab.se,alexander.peltzer@qbic.uni-tuebingen.de"
       description="Docker image containing base requirements for the nfcore pipelines"
 
 # Install procps so that Nextflow can poll CPU usage
-RUN apt-get update && apt-get install -y procps && apt-get clean -y 
+RUN apt-get update && apt-get install -y procps vim nano && apt-get clean -y 
 RUN conda install conda=4.5.11


### PR DESCRIPTION
This adds two editors to our base image: `vim` and `nano`. 

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated