### PR TITLE
Requests caching - multi user fix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 #### Tools helper code
 * Make Travis CI tests fail on pull requests if the `CHANGELOG.md` file hasn't been updated
 * Minor bugfixing in Python code (eg. removing unused import statements)
+* Made the web requests caching work on multi-user installations
 
 ## [v1.3](https://github.com/nf-core/tools/releases/tag/1.3) - 2018-11-21
 * `nf-core create` command line interface updated

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -5,30 +5,20 @@ Tests Nextflow pipelines to check that they adhere to
 the nf-core community guidelines.
 """
 
-import datetime
 import logging
 import io
 import os
 import re
 import shlex
-import tempfile
 
 import click
 import requests
-import requests_cache
 import yaml
 
 import nf_core.utils
 
 # Set up local caching for requests to speed up remote queries
-cachedir = os.path.join(tempfile.gettempdir(), 'nfcore_cache')
-if not os.path.exists(cachedir):
-    os.mkdir(cachedir)
-requests_cache.install_cache(
-    os.path.join(cachedir, 'nfcore_cache'),
-    expire_after=datetime.timedelta(hours=1),
-    backend='sqlite',
-)
+nf_core.utils.setup_requests_cachedir()
 
 # Don't pick up debug logs from the requests package
 logging.getLogger("requests").setLevel(logging.WARNING)

--- a/nf_core/list.py
+++ b/nf_core/list.py
@@ -11,22 +11,15 @@ import os
 import re
 import subprocess
 import sys
-import tempfile
 
 import git
 import requests
-import requests_cache
 import tabulate
 
+import nf_core.utils
+
 # Set up local caching for requests to speed up remote queries
-cachedir = os.path.join(tempfile.gettempdir(), 'nfcore_cache')
-if not os.path.exists(cachedir):
-    os.mkdir(cachedir)
-requests_cache.install_cache(
-    os.path.join(cachedir, 'nfcore_cache'),
-    expire_after=datetime.timedelta(hours=1),
-    backend='sqlite',
-)
+nf_core.utils.setup_requests_cachedir()
 
 def list_workflows(sort='release', json=False, keywords=[]):
     """ Main function to list all nf-core workflows """

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -3,8 +3,10 @@
 Common utility functions for the nf-core python package.
 """
 
+import datetime
 import os
 import subprocess
+import tempfile
 
 def fetch_wf_config(wf_path):
     """
@@ -24,3 +26,24 @@ def fetch_wf_config(wf_path):
             k, v = ul.split(' = ', 1)
             config[k] = v
     return config
+
+
+def setup_requests_cachedir():
+    """
+    Set up local caching for requests to speed up remote queries
+    """
+
+    # Only import it if we need it
+    import requests_cache
+
+    cachedir = os.path.join(tempfile.gettempdir(), 'nfcore_cache')
+    if not os.path.exists(cachedir):
+        os.mkdir(cachedir)
+    requests_cache.install_cache(
+        os.path.join(cachedir, 'nfcore_cache'),
+        expire_after=datetime.timedelta(hours=1),
+        backend='sqlite',
+    )
+    # Make world-writeable so that multi-user installations work
+    os.chmod(cachedir, 0o777)
+    os.chmod(os.path.join(cachedir, 'nfcore_cache.sqlite'), 0o777)


### PR DESCRIPTION
As described in Slack, there is an error for a site-wide installation of the `nf-core` package due to the `requests` sqlite cache:

```python
Traceback (most recent call last):
 File "/usr/local/bin/nf-core", line 217, in <module>
   nf_core_cli()
 File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 722, in __call__
   return self.main(*args, **kwargs)
 File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 697, in main
   rv = self.invoke(ctx)
 File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
   return _process_result(sub_ctx.command.invoke(sub_ctx))
 File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 895, in invoke
   return ctx.invoke(self.callback, **ctx.params)
 File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 535, in invoke
   return callback(*args, **kwargs)
 File "/usr/local/bin/nf-core", line 71, in list
   nf_core.list.list_workflows(sort, json, keywords)
 File "/usr/local/lib/python2.7/dist-packages/nf_core/list.py", line 34, in list_workflows
   wfs.get_remote_workflows()
 File "/usr/local/lib/python2.7/dist-packages/nf_core/list.py", line 59, in get_remote_workflows
   response = requests.get(nfcore_url, timeout=10)
 File "/usr/local/lib/python2.7/dist-packages/requests/api.py", line 72, in get
   return request('get', url, params=params, **kwargs)
 File "/usr/local/lib/python2.7/dist-packages/requests/api.py", line 58, in request
   return session.request(method=method, url=url, **kwargs)
 File "/usr/local/lib/python2.7/dist-packages/requests_cache/core.py", line 134, in request
   self.cache.create_key(r.request), main_key
 File "/usr/local/lib/python2.7/dist-packages/requests_cache/backends/base.py", line 57, in add_key_mapping
   self.keys_map[new_key] = key_to_response
 File "/usr/local/lib/python2.7/dist-packages/requests_cache/backends/storage/dbdict.py", line 125, in __setitem__
   self.table_name, (key, item))
sqlite3.OperationalError: attempt to write a readonly database
```

This PR moves the duplicated requests cache code into a helper function and makes cache directory and sqlite file world-writeable.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated
