### PR TITLE
List: local is latest only if pulled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # nf-core/tools: Changelog
 
+## v1.5dev
+
+#### Template pipeline
+_..nothing yet.._
+
+#### Tools helper code
+* `nf-core list` now only shows a value for _"is local latest version"_ column if there is a local copy.
+
 ## [v1.4](https://github.com/nf-core/tools/releases/tag/1.4) - 2018-12-12 Tantalum Butterfly
 
 #### Template pipeline

--- a/nf_core/list.py
+++ b/nf_core/list.py
@@ -148,13 +148,14 @@ class Workflows(object):
         # Build summary list to print
         summary = list()
         for wf in self.filtered_workflows():
-            rowdata = [
-                wf.full_name,
-                wf.releases[-1]['tag_name'] if len(wf.releases) > 0 else 'dev',
-                wf.releases[-1]['published_at_pretty'] if len(wf.releases) > 0 else '-',
-                wf.local_wf.last_pull_pretty if wf.local_wf is not None else '-',
-                'Yes' if wf.local_is_latest else 'No'
-            ]
+            version = wf.releases[-1]['tag_name'] if len(wf.releases) > 0 else 'dev'
+            published = wf.releases[-1]['published_at_pretty'] if len(wf.releases) > 0 else '-'
+            pulled = wf.local_wf.last_pull_pretty if wf.local_wf is not None else '-'
+            if wf.local_wf is not None:
+                is_latest = 'Yes' if wf.local_is_latest else 'No'
+            else:
+                is_latest = '-'
+            rowdata = [ wf.full_name, version, published, pulled, is_latest ]
             if self.sort_workflows == 'stars':
                 rowdata.insert(1, wf.stargazers_count)
             summary.append(rowdata)


### PR DESCRIPTION
`nf-core list` now shows `-` instead of `No` if a pipeline isn't pulled locally. Makes more sense and reduces visual clutter.

Before:
```
$ nf-core list

                                          ,--./,-.
          ___     __   __   __   ___     /,-._.--~\
    |\ | |__  __ /  ` /  \ |__) |__         }  {
    | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                          `._,._,'


Name                       Version    Published     Last Pulled     Default local is latest release?
-------------------------  ---------  ------------  --------------  ----------------------------------
nf-core/ampliseq           1.0.0      5 days ago    -               No
nf-core/eager              2.0.3      6 days ago    -               No
nf-core/rnaseq             1.2        6 days ago    just now        Yes
nf-core/hlatyping          1.1.2      6 days ago    -               No
nf-core/mhcquant           1.0.0      3 weeks ago   -               No
nf-core/deepvariant        1.0        4 weeks ago   -               No
nf-core/methylseq          1.1        4 months ago  25 seconds ago  No
nf-core/atacseq            dev        -             -               No
nf-core/bcellmagic         dev        -             -               No
nf-core/chipseq            dev        -             -               No
nf-core/ddamsproteomics    dev        -             -               No
nf-core/epitopeprediction  dev        -             -               No
nf-core/exoseq             dev        -             -               No
nf-core/lncpipe            dev        -             -               No
nf-core/mag                dev        -             -               No
nf-core/nascent            dev        -             -               No
nf-core/neutronstar        dev        -             -               No
nf-core/rnafusion          dev        -             -               No
nf-core/smrnaseq           dev        -             -               No
nf-core/vipr               dev        -             -               No
```

After:
```
$ nf-core list

                                          ,--./,-.
          ___     __   __   __   ___     /,-._.--~\
    |\ | |__  __ /  ` /  \ |__) |__         }  {
    | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                          `._,._,'


Name                       Version    Published     Last Pulled    Default local is latest release?
-------------------------  ---------  ------------  -------------  ----------------------------------
nf-core/ampliseq           1.0.0      5 days ago    -              -
nf-core/eager              2.0.3      6 days ago    -              -
nf-core/rnaseq             1.2        6 days ago    3 minutes ago  Yes
nf-core/hlatyping          1.1.2      6 days ago    -              -
nf-core/mhcquant           1.0.0      3 weeks ago   -              -
nf-core/deepvariant        1.0        4 weeks ago   -              -
nf-core/methylseq          1.1        4 months ago  4 minutes ago  No
nf-core/atacseq            dev        -             -              -
nf-core/bcellmagic         dev        -             -              -
nf-core/chipseq            dev        -             -              -
nf-core/ddamsproteomics    dev        -             -              -
nf-core/epitopeprediction  dev        -             -              -
nf-core/exoseq             dev        -             -              -
nf-core/lncpipe            dev        -             -              -
nf-core/mag                dev        -             -              -
nf-core/nascent            dev        -             -              -
nf-core/neutronstar        dev        -             -              -
nf-core/rnafusion          dev        -             -              -
nf-core/smrnaseq           dev        -             -              -
nf-core/vipr               dev        -             -              -
```