### PR TITLE
Changed logic for reporting custom config logging

### DIFF
--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
@@ -144,28 +144,26 @@ summary['Data Type']        = params.singleEnd ? 'Single-End' : 'Paired-End'
 summary['Max Memory']       = params.max_memory
 summary['Max CPUs']         = params.max_cpus
 summary['Max Time']         = params.max_time
-summary['Output dir']       = params.outdir
-summary['Working dir']      = workflow.workDir
+summary['Output Dir']       = params.outdir
+summary['Working Dir']      = workflow.workDir
 summary['Container Engine'] = workflow.containerEngine
 if(workflow.containerEngine) summary['Container'] = workflow.container
-summary['Current home']     = "$HOME"
-summary['Current user']     = "$USER"
-summary['Current path']     = "$PWD"
-summary['Working dir']      = workflow.workDir
-summary['Output dir']       = params.outdir
-summary['Script dir']       = workflow.projectDir
-summary['Config Profile']   = workflow.profile
-if(params.config_profile_description){
-  summary['Config Profile Description'] = params.config_profile_description
-  summary['Config Profile Contact']     = params.config_profile_contact
-  summary['Config Profile URL']         = params.config_profile_url
-}
+summary['Current Home']     = "$HOME"
+summary['Current User']     = "$USER"
+summary['Current Path']     = "$PWD"
+summary['Working Dir']      = workflow.workDir
+summary['Output Dir']       = params.outdir
+summary['Script Dir']       = workflow.projectDir
+summary['Config']   = workflow.profile
+if(params.config_profile_description) summary['Config Description'] = params.config_profile_description
+if(params.config_profile_contact)     summary['Config Contact']     = params.config_profile_contact
+if(params.config_profile_url)         summary['Config URL']         = params.config_profile_url
 if(workflow.profile == 'awsbatch'){
    summary['AWS Region'] = params.awsregion
    summary['AWS Queue']  = params.awsqueue
 }
 if(params.email) summary['E-mail Address'] = params.email
-log.info summary.collect { k,v -> "${k.padRight(26)}: $v" }.join("\n")
+log.info summary.collect { k,v -> "${k.padRight(18)}: $v" }.join("\n")
 log.info "========================================="
 
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
@@ -134,36 +134,38 @@ log.info """=======================================================
 {{ cookiecutter.name }} v${workflow.manifest.version}"
 ======================================================="""
 def summary = [:]
-summary['Pipeline Name']  = '{{ cookiecutter.name }}'
+summary['Pipeline Name']    = '{{ cookiecutter.name }}'
 summary['Pipeline Version'] = workflow.manifest.version
-summary['Run Name']     = custom_runName ?: workflow.runName
+summary['Run Name']         = custom_runName ?: workflow.runName
 // TODO nf-core: Report custom parameters here
-summary['Reads']        = params.reads
-summary['Fasta Ref']    = params.fasta
-summary['Data Type']    = params.singleEnd ? 'Single-End' : 'Paired-End'
-summary['Max Memory']   = params.max_memory
-summary['Max CPUs']     = params.max_cpus
-summary['Max Time']     = params.max_time
-summary['Output dir']   = params.outdir
-summary['Working dir']  = workflow.workDir
+summary['Reads']            = params.reads
+summary['Fasta Ref']        = params.fasta
+summary['Data Type']        = params.singleEnd ? 'Single-End' : 'Paired-End'
+summary['Max Memory']       = params.max_memory
+summary['Max CPUs']         = params.max_cpus
+summary['Max Time']         = params.max_time
+summary['Output dir']       = params.outdir
+summary['Working dir']      = workflow.workDir
 summary['Container Engine'] = workflow.containerEngine
 if(workflow.containerEngine) summary['Container'] = workflow.container
-summary['Current home']   = "$HOME"
-summary['Current user']   = "$USER"
-summary['Current path']   = "$PWD"
-summary['Working dir']    = workflow.workDir
-summary['Output dir']     = params.outdir
-summary['Script dir']     = workflow.projectDir
-summary['Config Profile'] = workflow.profile
-params.config_profile_description ? summary['Config Profile Description'] = params.config_profile_description
-params.config_profile_contact ? summary['Config Profile Contact'] = params.config_profile_contact
-params.config_profile_url ? summary['Config Profile URL'] = params.config_profile_url
+summary['Current home']     = "$HOME"
+summary['Current user']     = "$USER"
+summary['Current path']     = "$PWD"
+summary['Working dir']      = workflow.workDir
+summary['Output dir']       = params.outdir
+summary['Script dir']       = workflow.projectDir
+summary['Config Profile']   = workflow.profile
+if(params.config_profile_description){
+  summary['Config Profile Description'] = params.config_profile_description
+  summary['Config Profile Contact']     = params.config_profile_contact
+  summary['Config Profile URL']         = params.config_profile_url
+}
 if(workflow.profile == 'awsbatch'){
    summary['AWS Region'] = params.awsregion
-   summary['AWS Queue'] = params.awsqueue
+   summary['AWS Queue']  = params.awsqueue
 }
 if(params.email) summary['E-mail Address'] = params.email
-log.info summary.collect { k,v -> "${k.padRight(15)}: $v" }.join("\n")
+log.info summary.collect { k,v -> "${k.padRight(26)}: $v" }.join("\n")
 log.info "========================================="
 
 


### PR DESCRIPTION
Many thanks to contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

## PR checklist
 - [X] This comment contains a description of changes (with reason)
 - [X] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md

Custom config logging in `main.nf` was failing due to
```
ERROR ~ expecting ':', found 'params' @ line 337, column 1.
   params.config_profile_contact ? summary['Config Profile Contact'] = params.config_profile_contact
   ^
```

Added an `if` statement to only report these variables if `params.config_profile_description == true`.

Also, adjusted some of the spacing for easier readability.


