### PR TITLE
Lint pip version fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,25 +2,17 @@
 
 ## v1.5dev
 
-#### CI
-* Build API docs
-
-#### Documentation
-* Added nf-core tools API description to assist developers with the classes and functions available.
-
-#### Code coverage
-* Introduced test for filtering remote workflows by keyword
-
-#### Syncing
-* Syncing now reads from a `blacklist.json` in order to exclude
-pipelines from being synced if necessary.
-
 #### Template pipeline
 * Template logs cluster profiles of nf-core/configs in the nextflow logfile
 
 #### Tools helper code
 * `nf-core list` now only shows a value for _"is local latest version"_ column if there is a local copy.
 * `nf-core lint` now properly searches for conda packages in default channels
+* Linting correctly validates version pinning for packages from PyPI
+* Syncing now reads from a `blacklist.json` in order to exclude pipelines from being synced if necessary.
+* Added nf-core tools API description to assist developers with the classes and functions available.
+  * Docs are automatically built by Travis CI and updated on the nf-co.re website.
+* Introduced test for filtering remote workflows by keyword
 
 ## [v1.4](https://github.com/nf-core/tools/releases/tag/1.4) - 2018-12-12 Tantalum Butterfly
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v1.5dev
 
 #### Template pipeline
-* Template logs cluster profiles of nf-core/configs in the nextflow logfile
+* Summary now logs details of the cluster profile used if from [nf-core/configs](https://github.com/nf-core/configs)
 
 #### Tools helper code
 * `nf-core list` now only shows a value for _"is local latest version"_ column if there is a local copy.

--- a/docs/lint_errors.md
+++ b/docs/lint_errors.md
@@ -177,6 +177,8 @@ Each dependency can have the following lint failures and warnings:
 * (Test failure) The package version cannot be found on anaconda cloud (or on PyPi, for `pip` dependencies)
 * (Test warning) A newer version of the package is available
 
+> NB: Conda package versions should be pinned with one equals sign (`toolname=1.1`), pip with two (`toolname==1.2`)
+
 ## Error #9 - Dockerfile for use with Conda environments ## {#9}
 
 > This test only runs if there is both `environment.yml`

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -646,7 +646,7 @@ class PipelineLint(object):
                         self.passed.append((8, "Pip dependency had pinned version number: {}".format(pip_dep)))
 
                         try:
-                            pip_depname, pip_depver = pip_dep.split('=', 1)
+                            pip_depname, pip_depver = pip_dep.split('==', 1)
                             self.check_pip_package(pip_dep)
                         except ValueError:
                             pass

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -639,7 +639,7 @@ class PipelineLint(object):
                 for pip_dep in dep.get('pip', []):
                     # Check that each pip dependency has a version number
                     try:
-                        assert pip_dep.count('=') == 1
+                        assert pip_dep.count('=') == 2
                     except AssertionError:
                         self.failed.append((8, "Pip dependency did not have pinned version number: {}".format(pip_dep)))
                     else:

--- a/tests/lint_examples/minimal_working_example/environment.yml
+++ b/tests/lint_examples/minimal_working_example/environment.yml
@@ -9,4 +9,4 @@ dependencies:
   - conda-forge::openjdk=8.0.144
   - fastqc=0.11.7
   - pip:
-    - multiqc=1.4
+    - multiqc==1.4

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -343,7 +343,7 @@ class TestLint(unittest.TestCase):
         lint_obj.files = ['environment.yml']
         lint_obj.pipeline_name = 'tools'
         lint_obj.config['manifest.version'] = '0.4'
-        lint_obj.conda_config = {'name': 'nf-core-tools-0.4', 'dependencies': [{'pip': ['multiqc=1.4']}]}
+        lint_obj.conda_config = {'name': 'nf-core-tools-0.4', 'dependencies': [{'pip': ['multiqc==1.4']}]}
         lint_obj.check_conda_env_yaml()
         expectations = {"failed": 0, "warned": 1, "passed": 2}
         self.assess_lint_status(lint_obj, **expectations)
@@ -359,7 +359,7 @@ class TestLint(unittest.TestCase):
         lint_obj.files = ['environment.yml']
         lint_obj.pipeline_name = 'tools'
         lint_obj.config['manifest.version'] = '0.4'
-        lint_obj.conda_config = {'name': 'nf-core-tools-0.4', 'dependencies': [{'pip': ['multiqc=1.5']}]}
+        lint_obj.conda_config = {'name': 'nf-core-tools-0.4', 'dependencies': [{'pip': ['multiqc==1.5']}]}
         lint_obj.check_conda_env_yaml()
         expectations = {"failed": 0, "warned": 1, "passed": 2}
         self.assess_lint_status(lint_obj, **expectations)
@@ -375,7 +375,7 @@ class TestLint(unittest.TestCase):
         lint_obj.files = ['environment.yml']
         lint_obj.pipeline_name = 'tools'
         lint_obj.config['manifest.version'] = '0.4'
-        lint_obj.conda_config = {'name': 'nf-core-tools-0.4', 'dependencies': [{'pip': ['multiqc=1.5']}]}
+        lint_obj.conda_config = {'name': 'nf-core-tools-0.4', 'dependencies': [{'pip': ['multiqc==1.5']}]}
         lint_obj.check_conda_env_yaml()
         expectations = {"failed": 0, "warned": 1, "passed": 2}
         self.assess_lint_status(lint_obj, **expectations)
@@ -386,7 +386,7 @@ class TestLint(unittest.TestCase):
         lint_obj.files = ['environment.yml']
         lint_obj.pipeline_name = 'tools'
         lint_obj.config['manifest.version'] = '0.4'
-        lint_obj.conda_config = {'name': 'nf-core-tools-0.4', 'dependencies': [{'pip': ['notpresent=1.5']}]}
+        lint_obj.conda_config = {'name': 'nf-core-tools-0.4', 'dependencies': [{'pip': ['notpresent==1.5']}]}
         lint_obj.check_conda_env_yaml()
         expectations = {"failed": 1, "warned": 0, "passed": 2}
         self.assess_lint_status(lint_obj, **expectations)
@@ -412,7 +412,7 @@ class TestLint(unittest.TestCase):
         lint_obj.files = ['environment.yml']
         lint_obj.pipeline_name = 'tools'
         lint_obj.config['manifest.version'] = '0.4'
-        lint_obj.conda_config = {'name': 'nf-core-tools-0.4', 'dependencies': [{'pip': ['multiqc=0.0']}]}
+        lint_obj.conda_config = {'name': 'nf-core-tools-0.4', 'dependencies': [{'pip': ['multiqc==0.0']}]}
         lint_obj.check_conda_env_yaml()
         expectations = {"failed": 1, "warned": 0, "passed": 2}
         self.assess_lint_status(lint_obj, **expectations)


### PR DESCRIPTION
The linting tested that pip packages should contain a single equals sign, instead of two (this is a difference between conda and pip syntax). Updated, along with a new mention of this in the lint error docs.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated