### PR TITLE
Fix template / get rid of singularity hub

### DIFF
--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
@@ -52,7 +52,6 @@ profiles {
   }
   singularity {
     singularity.enabled = true
-    process.container = {"shub://${params.container.replace('nfcore', 'nf-core')}"}
   }
   test { includeConfig 'conf/test.config' }
 }


### PR DESCRIPTION
This removes the singularity hub pulling part and instead uses Docker Hub for pulling.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
