### PR TITLE
Always call nextflow config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 #### Tools helper code
 * New `nf-core launch` command to interactively launch nf-core pipelines from command-line
   * Works with a `parameters.settings.json` file shipped with each pipeline
+  * Discovers additional `params` from the pipeline dynamically
 * Drop Python 3.4 support
 * `nf-core list` now only shows a value for _"is local latest version"_ column if there is a local copy.
 * `nf-core lint` now properly searches for conda packages in default channels


### PR DESCRIPTION
* Always try to get extra params by calling `nextflow config` (instead of just when `parameters.settings.json` isn't found)
* Also search` main.nf` and config files for `params.something` values

We should probably refactor some of this code to make it more reusable elsewhere. For example, it would be good to use it in the linting to highlight if there are any `params` that are not in `parameters.settings.json`.