### PR TITLE
Handle running offline when we can't fetch nf-core/configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Changed default container tag from latest to dev
 * Brought the logo to life
 * Change the default filenames for the pipeline trace files
+* Remote fetch of nf-core/configs profiles fails gracefully if offline
 
 #### Tools helper code
 * New `nf-core launch` command to interactively launch nf-core pipelines from command-line

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
@@ -241,6 +241,23 @@ Provide git commit id for custom Institutional configs hosted at `nf-core/config
 --custom_config_version d52db660777c4bf36546ddb188ec530c3ada1b96
 ```
 
+### `--custom_config_base`
+If you're running offline, nextflow will not be able to fetch the institutional config files
+from the internet. If you don't need them, then this is not a problem. If you do need them,
+you should download the files from the repo and tell nextflow where to find them with the
+`custom_config_base` option. For example:
+
+```bash
+## Download and unizp the config files
+cd /path/to/my/configs
+wget https://github.com/nf-core/configs/archive/master.zip
+unzip master.zip
+
+## Run the pipeline
+cd /path/to/my/data
+nextflow run /path/to/pipeline/ --custom_config_base /path/to/my/configs/configs-master/
+```
+
 ### `--max_memory`
 Use to set a top-limit for the default memory requirement for each process.
 Should be a string in the format integer-unit. eg. `--max_memory '8.GB'`

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
@@ -248,7 +248,7 @@ you should download the files from the repo and tell nextflow where to find them
 `custom_config_base` option. For example:
 
 ```bash
-## Download and unizp the config files
+## Download and unzip the config files
 cd /path/to/my/configs
 wget https://github.com/nf-core/configs/archive/master.zip
 unzip master.zip
@@ -257,6 +257,9 @@ unzip master.zip
 cd /path/to/my/data
 nextflow run /path/to/pipeline/ --custom_config_base /path/to/my/configs/configs-master/
 ```
+
+> Note that the nf-core/tools helper package has a `download` command to download all required pipeline
+> files + singularity containers + institutional configs in one go for you, to make this process easier.
 
 ### `--max_memory`
 Use to set a top-limit for the default memory requirement for each process.

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
@@ -41,7 +41,11 @@ params {
 includeConfig 'conf/base.config'
 
 // Load nf-core custom profiles from different Institutions
-includeConfig "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}/nfcore_custom.config"
+try {
+  includeConfig "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}/nfcore_custom.config"
+} catch (Exception e) {
+  System.err.println("WARNING: Could not download remote nf-core/config profiles")
+}
 
 profiles {
   awsbatch { includeConfig 'conf/awsbatch.config' }

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
@@ -35,6 +35,7 @@ params {
   awsregion = 'eu-west-1'
   igenomesIgnore = false
   custom_config_version = 'master'
+  custom_config_base = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
 }
 
 // Load base.config by default for all pipelines
@@ -42,9 +43,9 @@ includeConfig 'conf/base.config'
 
 // Load nf-core custom profiles from different Institutions
 try {
-  includeConfig "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}/nfcore_custom.config"
+  includeConfig "${params.custom_config_base}/nfcore_custom.config"
 } catch (Exception e) {
-  System.err.println("WARNING: Could not download remote nf-core/config profiles")
+  System.err.println("WARNING: Could not load nf-core/config profiles: ${params.custom_config_base}/nfcore_custom.config")
 }
 
 profiles {


### PR DESCRIPTION
Catch the error if we're offline and trying to load remote config files. See nf-core/configs#1 and https://github.com/nf-core/atacseq/pull/22