### PR TITLE
Don't use params.container, just directly use process.container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Brought the logo to life
 * Change the default filenames for the pipeline trace files
 * Remote fetch of nf-core/configs profiles fails gracefully if offline
+* Remove `process.container` and just directly define `process.container` now.
 
 #### Tools helper code
 * New `nf-core launch` command to interactively launch nf-core pipelines from command-line
@@ -17,8 +18,6 @@
   * Discovers additional `params` from the pipeline dynamically
 * Drop Python 3.4 support
 * `nf-core list` now only shows a value for _"is local latest version"_ column if there is a local copy.
-* `nf-core lint` now properly searches for conda packages in default channels
-* Linting correctly validates version pinning for packages from PyPI
 * Lint markdown formatting in automated tests
   * Added `markdownlint-cli` for checking Markdown syntax in pipelines and tools repo
 * Syncing now reads from a `blacklist.json` in order to exclude pipelines from being synced if necessary.
@@ -31,6 +30,10 @@
 * `nf-core bump-version` now stops before making changes if the linting fails
 * Code test coverage
   * Introduced test for filtering remote workflows by keyword
+* Linting updates
+  * Now properly searches for conda packages in default channels
+  * Now correctly validates version pinning for packages from PyPI
+  * Updates for changes to `process.container` definition
 
 #### Other
 * Updated Conda Version on base container to 4.6.7

--- a/docs/lint_errors.md
+++ b/docs/lint_errors.md
@@ -85,7 +85,9 @@ The following variables throw warnings if missing:
   * The DAG file path should end with `.svg`
     * If Graphviz is not installed, Nextflow will generate a `.dot` file instead
 * `process.container`
-  * A single default container for use by all processes
+  * Dockerhub handle for a single default container for use by all processes.
+  * Must specify a tag that matches the pipeline version number if set.
+  * If the pipeline version number contains the string `dev`, the dockerhub tag must be `:dev`
 * `params.reads`
   * Input parameter to specify input data (typically FastQ files / pairs)
 * `params.singleEnd`
@@ -95,9 +97,11 @@ The following variables throw warnings if missing:
 The following variables are depreciated and fail the test if they are still present:
 
 * `params.version`
-  * The old method for specifying the pieline version. Replaced by `manifest.version`
+  * The old method for specifying the pipeline version. Replaced by `manifest.version`
 * `params.nf_required_version`
   * The old method for specifying the minimum Nextflow version. Replaced by `manifest.nextflowVersion`
+* `process.container`
+  * The old method for specifying the dockerhub container address. Replaced by `process.container`
 
 ## Error #5 - Continuous Integration configuration ## {#5}
 nf-core pipelines must have CI testing with Travis or Circle CI.

--- a/docs/lint_errors.md
+++ b/docs/lint_errors.md
@@ -100,7 +100,7 @@ The following variables are depreciated and fail the test if they are still pres
   * The old method for specifying the pipeline version. Replaced by `manifest.version`
 * `params.nf_required_version`
   * The old method for specifying the minimum Nextflow version. Replaced by `manifest.nextflowVersion`
-* `process.container`
+* `params.container`
   * The old method for specifying the dockerhub container address. Replaced by `process.container`
 
 ## Error #5 - Continuous Integration configuration ## {#5}
@@ -110,7 +110,7 @@ This test fails if the following happens:
 
 * `.travis.yml` does not contain the string `nf-core lint ${TRAVIS_BUILD_DIR}` under `script`
 * `.travis.yml` does not contain the string `docker pull <container>:dev` under `before_install`
-  * Where `<container>` is fetched from `params.container` in the `nextflow.config` file, without the docker tag _(if we have the tag the tests fail when making a release)_
+  * Where `<container>` is fetched from `process.container` in the `nextflow.config` file, without the docker tag _(if we have the tag the tests fail when making a release)_
 * `.travis.yml` does not test the Nextflow version specified in the pipeline as `manifest.nextflowVersion`
   * This is expected in the `env` section of the config, eg:
 
@@ -154,7 +154,7 @@ The `README.md` files for a project are very important and must meet some requir
 
 > This test only runs when `--release` is set or `$TRAVIS_BRANCH` is equal to `master`
 
-These tests look at `params.container`, `process.container` and `$TRAVIS_TAG`, only
+These tests look at `process.container` and `$TRAVIS_TAG`, only
 if they are set.
 
 * Container name must have a tag specified (eg. `nfcore/pipeline:version`)

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -4,12 +4,10 @@
 from __future__ import print_function
 
 from io import BytesIO
-import click
 import logging
 import hashlib
 import os
 import requests
-import requests_cache
 import subprocess
 import sys
 from zipfile import ZipFile
@@ -83,7 +81,7 @@ class DownloadWorkflow(object):
                         logging.error("Not able to pull image. Service might be down or internet connection is dead.")
                         raise r
 
-                        
+
 
     def fetch_workflow_details(self, wfs):
         """Fetches details of a nf-core workflow to download.

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.travis.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.travis.yml
@@ -13,6 +13,7 @@ before_install:
   # Pull the docker image first so the test doesn't wait for this
   - docker pull {{ cookiecutter.name_docker }}:dev
   # Fake the tag locally so that the pipeline runs properly
+  # Looks weird when this is :dev to :dev, but makes sense when testing code for a release (:dev to :1.0.1)
   - docker tag {{ cookiecutter.name_docker }}:dev {{ cookiecutter.name_docker }}:dev
 
 install:

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/conf/base.config
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/conf/base.config
@@ -11,8 +11,6 @@
 
 process {
 
-  container = params.container
-
   // TODO nf-core: Check the defaults for all processes
   cpus = { check_max( 1 * task.attempt, 'cpus' ) }
   memory = { check_max( 8.GB * task.attempt, 'memory' ) }

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
@@ -11,10 +11,6 @@
 // Global default params, used in configs
 params {
 
-  // Container slug. Stable releases should specify release tag!
-  // Developmental code should specify :dev
-  container = '{{ cookiecutter.name_docker }}:dev'
-
   // Workflow flags
   // TODO nf-core: Specify your pipeline's command line flags
   reads = "data/*{1,2}.fastq.gz"
@@ -38,6 +34,10 @@ params {
   custom_config_base = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
 }
 
+// Container slug. Stable releases should specify release tag!
+// Developmental code should specify :dev
+process.container = '{{ cookiecutter.name_docker }}:dev'
+
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
 
@@ -52,13 +52,8 @@ profiles {
   awsbatch { includeConfig 'conf/awsbatch.config' }
   conda { process.conda = "$baseDir/environment.yml" }
   debug { process.beforeScript = 'echo $HOSTNAME' }
-  docker {
-    docker.enabled = true
-    process.container = params.container
-  }
-  singularity {
-    singularity.enabled = true
-  }
+  docker { docker.enabled = true }
+  singularity { singularity.enabled = true }
   test { includeConfig 'conf/test.config' }
 }
 

--- a/tests/lint_examples/failing_example/nextflow.config
+++ b/tests/lint_examples/failing_example/nextflow.config
@@ -4,9 +4,10 @@ manifest.nextflowVersion = '0.30.1'
 
 dag.file = "dag.html"
 
+params.container = 'pipelines:latest'
+
 process {
     $deprecatedSyntax {
         cpu = 1
     }
 }
-

--- a/tests/lint_examples/minimal_working_example/nextflow.config
+++ b/tests/lint_examples/minimal_working_example/nextflow.config
@@ -1,14 +1,12 @@
 
 params {
-  // Container slug. Tag for releases
-  container = 'nfcore/tools:0.4'
   outdir = './results'
   reads = "data/*.fastq"
   singleEnd = false
 }
 
 process {
-  container = params.container
+  container = 'nfcore/tools:0.4'
   cpus = 1
   memory = 2.GB
   time = 14.h

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -38,7 +38,7 @@ PATHS_WRONG_LICENSE_EXAMPLE = [pf(WD, 'lint_examples/wrong_license_example'),
     pf(WD, 'lint_examples/license_incomplete_example')]
 
 # The maximum sum of passed tests currently possible
-MAX_PASS_CHECKS = 58
+MAX_PASS_CHECKS = 57
 # The additional tests passed for releases
 ADD_PASS_RELEASE = 1
 
@@ -112,14 +112,14 @@ class TestLint(unittest.TestCase):
         """Tests that config variable existence test works with good pipeline example"""
         good_lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         good_lint_obj.check_nextflow_config()
-        expectations = {"failed": 0, "warned": 0, "passed": 32}
+        expectations = {"failed": 0, "warned": 0, "passed": 33}
         self.assess_lint_status(good_lint_obj, **expectations)
 
     def test_config_variable_example_with_failed(self):
         """Tests that config variable existence test fails with bad pipeline example"""
         bad_lint_obj = nf_core.lint.PipelineLint(PATH_FAILING_EXAMPLE)
         bad_lint_obj.check_nextflow_config()
-        expectations = {"failed": 18, "warned": 9, "passed": 6}
+        expectations = {"failed": 19, "warned": 8, "passed": 6}
         self.assess_lint_status(bad_lint_obj, **expectations)
 
     @pytest.mark.xfail(raises=AssertionError)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -38,7 +38,7 @@ PATHS_WRONG_LICENSE_EXAMPLE = [pf(WD, 'lint_examples/wrong_license_example'),
     pf(WD, 'lint_examples/license_incomplete_example')]
 
 # The maximum sum of passed tests currently possible
-MAX_PASS_CHECKS = 57
+MAX_PASS_CHECKS = 59
 # The additional tests passed for releases
 ADD_PASS_RELEASE = 1
 
@@ -201,7 +201,7 @@ class TestLint(unittest.TestCase):
         """Tests the workflow version and container version sucessfully"""
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         lint_obj.config["manifest.version"] = "0.4"
-        lint_obj.config["params.container"] = "nfcore/tools:0.4"
+        lint_obj.config["process.container"] = "nfcore/tools:0.4"
         lint_obj.check_version_consistency()
         expectations = {"failed": 0, "warned": 0, "passed": 1}
         self.assess_lint_status(lint_obj, **expectations)
@@ -213,7 +213,7 @@ class TestLint(unittest.TestCase):
         os.environ["TRAVIS_REPO_SLUG"] = "nf-core/testpipeline"
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         lint_obj.config["manifest.version"] = "0.4"
-        lint_obj.config["params.container"] = "nfcore/tools:0.4"
+        lint_obj.config["process.container"] = "nfcore/tools:0.4"
         lint_obj.config["process.container"] = "nfcore/tools:0.4"
         lint_obj.check_version_consistency()
         expectations = {"failed": 1, "warned": 0, "passed": 0}
@@ -226,7 +226,7 @@ class TestLint(unittest.TestCase):
         os.environ["TRAVIS_REPO_SLUG"] = "nf-core/testpipeline"
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         lint_obj.config["manifest.version"] = "0.4"
-        lint_obj.config["params.container"] = "nfcore/tools:0.4"
+        lint_obj.config["process.container"] = "nfcore/tools:0.4"
         lint_obj.check_version_consistency()
         expectations = {"failed": 1, "warned": 0, "passed": 0}
         self.assess_lint_status(lint_obj, **expectations)
@@ -238,7 +238,7 @@ class TestLint(unittest.TestCase):
         os.environ["TRAVIS_REPO_SLUG"] = "nf-core/testpipeline"
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         lint_obj.config["manifest.version"] = "0.4"
-        lint_obj.config["params.container"] = "nfcore/tools"
+        lint_obj.config["process.container"] = "nfcore/tools"
         lint_obj.check_version_consistency()
         expectations = {"failed": 1, "warned": 0, "passed": 0}
         self.assess_lint_status(lint_obj, **expectations)
@@ -250,7 +250,7 @@ class TestLint(unittest.TestCase):
         os.environ["TRAVIS_REPO_SLUG"] = "nf-core/testpipeline"
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         lint_obj.config["manifest.version"] = "0.4"
-        lint_obj.config["params.container"] = "nfcore/tools:0.4"
+        lint_obj.config["process.container"] = "nfcore/tools:0.4"
         lint_obj.check_version_consistency()
         expectations = {"failed": 0, "warned": 0, "passed": 1}
         self.assess_lint_status(lint_obj, **expectations)


### PR DESCRIPTION
Update the template and linting to remove `params.container` and just directly define `process.container`. Linting now also checks for and warns if `params.container` is still present.