### PR TITLE
Drop Rnaseq from blacklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v1.6dev
 
 _..nothing yet.._
+#### Syncing Functionality
+* Drop [nf-core/rnaseq](https://github.com/nf-core/rnaseq]) from `blacklist.json` to make template sync available
 
 ## [v1.5](https://github.com/nf-core/tools/releases/tag/1.5) - 2019-03-13 Iron Shark
 

--- a/bin/blacklist.json
+++ b/bin/blacklist.json
@@ -7,7 +7,6 @@
     "exoseq",
     "nascent",
     "neutronstar", 
-    "rnaseq",
     "smrnaseq",
     "vipr"
   ]


### PR DESCRIPTION
This removes rnaseq https://github.com/nf-core/rnaseq/pull/170 from the blacklist. 

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated
