### PR TITLE
Get the latest release with nf-core download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Tools helper code
 * Drop [nf-core/rnaseq](https://github.com/nf-core/rnaseq]) from `blacklist.json` to make template sync available
+* Fix bug in `nf-core download` so that it now fetches the latest release by default
 
 ## [v1.5](https://github.com/nf-core/tools/releases/tag/1.5) - 2019-03-13 Iron Shark
 

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -103,6 +103,8 @@ class DownloadWorkflow(object):
 
                 # Find latest release hash
                 if self.release is None and len(wf.releases) > 0:
+                    # Sort list of releases so that most recent is first
+                    wf.releases = sorted(wf.releases, key=lambda k: k['published_at_timestamp'], reverse=True)
                     self.release = wf.releases[0]['tag_name']
                     self.wf_sha = wf.releases[0]['tag_sha']
                     logging.debug("No release specified. Using latest release: {}".format(self.release))

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -104,7 +104,7 @@ class DownloadWorkflow(object):
                 # Find latest release hash
                 if self.release is None and len(wf.releases) > 0:
                     # Sort list of releases so that most recent is first
-                    wf.releases = sorted(wf.releases, key=lambda k: k['published_at_timestamp'], reverse=True)
+                    wf.releases = sorted(wf.releases, key=lambda k: k.get('published_at_timestamp', 0), reverse=True)
                     self.release = wf.releases[0]['tag_name']
                     self.wf_sha = wf.releases[0]['tag_sha']
                     logging.debug("No release specified. Using latest release: {}".format(self.release))


### PR DESCRIPTION
@orzechoj spotted that using `nf-core download` without a specific release would not pull the latest release by default. In fact, it just grabs the first in the list, which is probably the oldest.

This PR just sorts the list of releases by release date, so it now gets the most recent release instead 👍 