### PR TITLE
download: Make unzipped files executable. Fixes nf-core/tools#289

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 #### Tools helper code
 * Drop [nf-core/rnaseq](https://github.com/nf-core/rnaseq]) from `blacklist.json` to make template sync available
-* Fix bug in `nf-core download` so that it now fetches the latest release by default
+* Fix bugs in `nf-core download`
+    * The _latest_ release is now fetched by default if not specified
+    * Downloaded pipeline files are now properly executable
 
 ## [v1.5](https://github.com/nf-core/tools/releases/tag/1.5) - 2019-03-13 Iron Shark
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 #### Tools helper code
 * Drop [nf-core/rnaseq](https://github.com/nf-core/rnaseq]) from `blacklist.json` to make template sync available
 * Fix bugs in `nf-core download`
-    * The _latest_ release is now fetched by default if not specified
-    * Downloaded pipeline files are now properly executable
+  * The _latest_ release is now fetched by default if not specified
+  * Downloaded pipeline files are now properly executable
 
 ## [v1.5](https://github.com/nf-core/tools/releases/tag/1.5) - 2019-03-13 Iron Shark
 

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -170,6 +170,11 @@ class DownloadWorkflow(object):
         gh_name = '{}-{}'.format(self.wf_name, self.wf_sha).split('/')[-1]
         os.rename(os.path.join(self.outdir, gh_name), os.path.join(self.outdir, 'workflow'))
 
+        # Make downloaded files executable
+        for dirpath, subdirs, filelist in os.walk(os.path.join(self.outdir, 'workflow')):
+            for fname in filelist:
+                os.chmod(os.path.join(dirpath, fname), 0o775)
+
     def find_container_images(self):
         """ Find container image names for workflow """
 


### PR DESCRIPTION
`nf-core download` uses the Python `zipfile` module to unzip the downloaded pipeline scripts. This package strips all file permissions, so the files are no longer executable.

In this PR, the code just traverses the downloaded files and does a `chmod 775` to make them executable. It's a bit like swatting a fly with a hammer, but it should work..

x-ref https://github.com/nf-core/tools/issues/289