### PR TITLE
Fixed list, documented sort, better order of command in --help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@
 
 #### Tools helper code
 * Drop [nf-core/rnaseq](https://github.com/nf-core/rnaseq]) from `blacklist.json` to make template sync available
+* Updated main help command to sort the subcommands in a more logical order
+* Updated readme to describe the new `nf-core launch` command
 * Fix bugs in `nf-core download`
   * The _latest_ release is now fetched by default if not specified
   * Downloaded pipeline files are now properly executable.
+* Fixed bugs in `nf-core list`
+  * Sorting now works again
+  * Output is partially coloured (better highlighting out of date pipelines)
+  * Improved documentation
 
 ## [v1.5](https://github.com/nf-core/tools/releases/tag/1.5) - 2019-03-13 Iron Shark
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ A python package with helper tools for the nf-core community.
 
 * [`nf-core` tools installation](#installation)
 * [`nf-core list` - List available pipelines](#listing-pipelines)
+* [`nf-core launch` - Run a pipeline with interactive parameter prompts](#launch-a-pipeline)
 * [`nf-core download` - Download pipeline for offline use](#downloading-pipelines-for-offline-use)
 * [`nf-core licences` - List software licences in a pipeline](#pipeline-software-licences)
 * [`nf-core create` - Create a new workflow from the nf-core template](#creating-a-new-workflow)
 * [`nf-core lint` - Check pipeline code against nf-core guidelines](#linting-a-workflow)
-* [`nf-core bump-version` - Change a pipeline version number](#bumping-a-pipeline-version-number)
+* [`nf-core bump-version` - Update nf-core pipeline version number](#bumping-a-pipeline-version-number)
 
 
 The nf-core tools package is written in Python and can be imported and used within other packages.
@@ -70,23 +71,27 @@ $ nf-core list
                                           `._,._,'
 
 
-Name               Version    Published    Last Pulled    Default local is latest release?
------------------  ---------  -----------  -------------  ----------------------------------
-nf-core/hlatyping  1.1.0      5 days ago   9 minutes ago  Yes
-nf-core/methylseq  1.1        1 week ago   2 months ago   No
-nf-core/chipseq    dev        -            -              No
-nf-core/eager      dev        -            -              No
-nf-core/exoseq     dev        -            -              No
-nf-core/mag        dev        -            -              No
-nf-core/rnaseq     dev        -            -              No
-nf-core/smrnaseq   dev        -            -              No
-nf-core/vipr       dev        -            -              No
+Name                       Version    Released      Last Pulled     Have latest release?
+-------------------------  ---------  ------------  --------------  ----------------------
+nf-core/rnaseq             1.3        4 days ago    27 minutes ago  Yes
+nf-core/hlatyping          1.1.4      3 weeks ago   1 months ago    No
+nf-core/eager              2.0.6      3 weeks ago   -               -
+nf-core/mhcquant           1.2.6      3 weeks ago   -               -
+nf-core/rnafusion          1.0        1 months ago  -               -
+nf-core/methylseq          1.3        1 months ago  3 months ago    No
+nf-core/ampliseq           1.0.0      3 months ago  -               -
+nf-core/deepvariant        1.0        4 months ago  -               -
+nf-core/atacseq            dev        -             1 months ago    No
+nf-core/bacass             dev        -             -               -
+nf-core/bcellmagic         dev        -             -               -
+nf-core/chipseq            dev        -             1 months ago    No
+nf-core/clinvap            dev        -             -               -
 ```
 
 To narrow down the list, supply one or more additional keywords to filter the pipelines based on matches in titles, descriptions and topics:
 
 ```txt
-nf-core list rna rna-seq
+$ nf-core list rna rna-seq
 
                                           ,--./,-.
           ___     __   __   __   ___     /,-._.--~\
@@ -95,15 +100,108 @@ nf-core list rna rna-seq
                                           `._,._,'
 
 
-Name              Version    Published     Last Pulled    Default local is latest release?
-----------------  ---------  ------------  -------------  ----------------------------------
-nf-core/rnaseq    1.0        20 hours ago  -              No
-nf-core/smrnaseq  dev        -             -              No
+Name               Version    Released      Last Pulled     Have latest release?
+-----------------  ---------  ------------  --------------  ----------------------
+nf-core/rnaseq     1.3        4 days ago    28 minutes ago  Yes
+nf-core/rnafusion  1.0        1 months ago  -               -
+nf-core/lncpipe    dev        -             -               -
+nf-core/smrnaseq   dev        -             -               -
 ```
 
-You can sort the results by latest release (default), name (alphabetical) or number of GitHub stars using the `-s`/`--stars` option.
+You can sort the results by latest release (`-s release`, default),
+when you last pulled a local copy (`-s pulled`),
+alphabetically (`-s name`),
+or number of GitHub stars (`-s stars`).
+
+```txt
+$ nf-core list -s stars
+
+                                          ,--./,-.
+          ___     __   __   __   ___     /,-._.--~\
+    |\ | |__  __ /  ` /  \ |__) |__         }  {
+    | \| |       \__, \__/ |  \ |___     \`-._,-`-,
+                                          `._,._,'
+
+
+Name                         Stargazers  Version    Released      Last Pulled     Have latest release?
+-------------------------  ------------  ---------  ------------  --------------  ----------------------
+nf-core/rnaseq                       81  1.3        4 days ago    30 minutes ago  Yes
+nf-core/methylseq                    22  1.3        1 months ago  3 months ago    No
+nf-core/ampliseq                     21  1.0.0      3 months ago  -               -
+nf-core/chipseq                      20  dev        -             1 months ago    No
+nf-core/deepvariant                  15  1.0        4 months ago  -               -
+nf-core/eager                        14  2.0.6      3 weeks ago   -               -
+nf-core/rnafusion                    14  1.0        1 months ago  -               -
+nf-core/lncpipe                       9  dev        -             -               -
+nf-core/exoseq                        8  dev        -             -               -
+nf-core/mag                           8  dev        -             -               -
+```
 
 Finally, to return machine-readable JSON output, use the `--json` flag.
+
+## Launch a pipeline
+Some nextflow pipelines have a considerable number of command line flags that can be used.
+To help with this, the `nf-core launch` command uses an interactive command-line wizard tool to prompt you for
+values for running nextflow and the pipeline parameters.
+
+If the pipeline in question has a `parameters.settings.json` schema, parameters will be grouped and have associated description text and variable typing.
+
+Nextflow `params` variables are saved in to a JSON file called `nfx-params.json` and used by nextflow with the `-params-file` flag.
+This makes it easier to reuse these in the future.
+
+It is not essential to run the pipeline - the wizard will ask you if you want to launch the command at the end.
+If not, you finish with the `params` JSON file and a nextflow command that you can copy and paste.
+
+```
+$ nf-core launch rnaseq
+
+                                          ,--./,-.
+          ___     __   __   __   ___     /,-._.--~\
+    |\ | |__  __ /  ` /  \ |__) |__         }  {
+    | \| |       \__, \__/ |  \ |___     \`-._,-`-,
+                                          `._,._,'
+
+
+INFO: Launching nf-core/rnaseq
+Main nextflow options
+
+Config profile to use
+ -profile [standard]: docker
+
+Unique name for this nextflow run
+ -name [None]: test_run
+
+Work directory for intermediate files
+ -w [./work]:
+
+Resume a previous workflow run
+ -resume [y/N]:
+
+Release / revision to use
+ -r [None]: 1.3
+
+
+Parameter group: Main options
+Do you want to change the group's defaults? [y/N]: y
+
+Input files
+Specify the location of your input FastQ files.
+ --reads ['data/*{1,2}.fastq.gz']: '/path/to/reads_*{R1,R2}.fq.gz'
+
+[..truncated..]
+
+Nextflow command:
+  nextflow run nf-core/rnaseq -profile "docker" -name "test_run" -r "1.3" --params-file "/Users/ewels/testing/nfx-params.json"
+
+
+Do you want to run this command now? [y/N]: y
+
+INFO: Launching workflow!
+N E X T F L O W  ~  version 19.01.0
+Launching `nf-core/rnaseq` [evil_engelbart] - revision: 37f260d360 [master]
+
+[..truncated..]
+```
 
 
 ## Downloading pipelines for offline use

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The command `nf-core list` shows all available nf-core pipelines along with thei
 
 An example of the output from the command is as follows:
 
-```txt
+```console
 $ nf-core list
 
                                           ,--./,-.
@@ -90,7 +90,7 @@ nf-core/clinvap            dev        -             -               -
 
 To narrow down the list, supply one or more additional keywords to filter the pipelines based on matches in titles, descriptions and topics:
 
-```txt
+```console
 $ nf-core list rna rna-seq
 
                                           ,--./,-.
@@ -113,7 +113,7 @@ when you last pulled a local copy (`-s pulled`),
 alphabetically (`-s name`),
 or number of GitHub stars (`-s stars`).
 
-```txt
+```console
 $ nf-core list -s stars
 
                                           ,--./,-.
@@ -152,7 +152,7 @@ This makes it easier to reuse these in the future.
 It is not essential to run the pipeline - the wizard will ask you if you want to launch the command at the end.
 If not, you finish with the `params` JSON file and a nextflow command that you can copy and paste.
 
-```txt
+```console
 $ nf-core launch rnaseq
 
                                           ,--./,-.
@@ -211,7 +211,7 @@ To make this process easier and ensure accurate retrieval of correctly versioned
 
 By default, the pipeline will just download the pipeline code. If you specify the flag `--singularity`, it will also download any singularity image files that are required.
 
-```txt
+```console
 $ nf-core download methylseq --singularity
 
                                           ,--./,-.
@@ -232,7 +232,7 @@ INFO: Downloading 1 singularity container
 nf-core-methylseq-1.0.simg [762.28MB]  [####################################]  780573/780572
 ```
 
-```txt
+```console
 $ tree -L 2 nf-core-methylseq-1.0/
 
 nf-core-methylseq-1.0/
@@ -258,7 +258,7 @@ nf-core-methylseq-1.0/
 ## Pipeline software licences
 Sometimes it's useful to see the software licences of the tools used in a pipeline. You can use the `licences` subcommand to fetch and print the software licence from each conda / PyPI package used in an nf-core pipeline.
 
-```txt
+```console
 $ nf-core licences rnaseq
 
                                           ,--./,-.
@@ -299,7 +299,7 @@ With a given pipeline name, description and author, it makes a starter pipeline 
 After creating the files, the command initialises the folder as a git repository and makes an initial commit. This first "vanilla" commit which is identical to the output from the templating tool is important, as it allows us to keep your pipeline in sync with the base template in the future.
 See the [nf-core syncing docs](http://nf-co.re/sync) for more information.
 
-```txt
+```console
 $ nf-core create
 
                                           ,--./,-.
@@ -325,7 +325,7 @@ INFO: Done. Remember to add a remote and push to GitHub:
 Once you have run the command, create a new empty repository on GitHub under your username (not the `nf-core` organisation, yet).
 On your computer, add this repository as a git remote and push to it:
 
-```txt
+```console
 git remote add origin https://github.com/ewels/nf-core-nextbigthing.git
 git push --set-upstream origin master
 ```
@@ -343,7 +343,7 @@ This is the same test that is used on the automated continuous integration tests
 
 For example, the current version looks something like this:
 
-```txt
+```console
 $ cd path/to/my_pipeline
 $ nf-core lint .
 
@@ -376,7 +376,7 @@ The command uses results from the linting process, so will only work with workfl
 
 Usage is `nf-core bump-version <pipeline_dir> <new_version>`, eg:
 
-```txt
+```console
 $ cd path/to/my_pipeline
 $ nf-core bump-version . 1.0
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ This makes it easier to reuse these in the future.
 It is not essential to run the pipeline - the wizard will ask you if you want to launch the command at the end.
 If not, you finish with the `params` JSON file and a nextflow command that you can copy and paste.
 
-```
+```txt
 $ nf-core launch rnaseq
 
                                           ,--./,-.

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -698,7 +698,11 @@ class PipelineLint(object):
                     dep_json = response.json()
                     self.conda_package_info[dep] = dep_json
                     return
+                else if response.status_code != 404:
+                    self.warned.append((8, "Anaconda API returned unexpected response code '{}' for: {}\n{}".format(response.status_code, anaconda_api_url, response)))
+                    raise ValueError
         else:
+            # We have looped through each channel and had a 404 response code on everything
             self.failed.append((8, "Could not find Conda dependency using the Anaconda API: {}".format(dep)))
             raise ValueError
 

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -698,7 +698,7 @@ class PipelineLint(object):
                     dep_json = response.json()
                     self.conda_package_info[dep] = dep_json
                     return
-                else if response.status_code != 404:
+                elif response.status_code != 404:
                     self.warned.append((8, "Anaconda API returned unexpected response code '{}' for: {}\n{}".format(response.status_code, anaconda_api_url, response)))
                     raise ValueError
         else:

--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -13,7 +13,35 @@ import nf_core.bump_version, nf_core.create, nf_core.download, nf_core.launch, n
 
 import logging
 
-@click.group()
+# Customise the order of subcommands for --help
+# https://stackoverflow.com/a/47984810/713980
+class CustomHelpOrder(click.Group):
+    def __init__(self, *args, **kwargs):
+        self.help_priorities = {}
+        super(CustomHelpOrder, self).__init__(*args, **kwargs)
+
+    def get_help(self, ctx):
+        self.list_commands = self.list_commands_for_help
+        return super(CustomHelpOrder, self).get_help(ctx)
+
+    def list_commands_for_help(self, ctx):
+        """reorder the list of commands when listing the help"""
+        commands = super(CustomHelpOrder, self).list_commands(ctx)
+        return (c[1] for c in sorted((self.help_priorities.get(command, 1000), command) for command in commands))
+
+    def command(self, *args, **kwargs):
+        """Behaves the same as `click.Group.command()` except capture
+        a priority for listing command names in help.
+        """
+        help_priority = kwargs.pop('help_priority', 1000)
+        help_priorities = self.help_priorities
+        def decorator(f):
+            cmd = super(CustomHelpOrder, self).command(*args, **kwargs)(f)
+            help_priorities[cmd.name] = help_priority
+            return cmd
+        return decorator
+
+@click.group(cls=CustomHelpOrder)
 @click.version_option(nf_core.__version__)
 @click.option(
     '-v', '--verbose',
@@ -27,28 +55,8 @@ def nf_core_cli(verbose):
     else:
         logging.basicConfig(level=logging.INFO, format="\n%(levelname)s: %(message)s")
 
-@nf_core_cli.command()
-@click.argument(
-    'pipeline_dir',
-    type = click.Path(exists=True),
-    required = True,
-    metavar = "<pipeline directory>"
-)
-@click.option(
-    '--release',
-    is_flag = True,
-    default = os.environ.get('TRAVIS_BRANCH') == 'master' and os.environ.get('TRAVIS_REPO_SLUG', '').startswith('nf-core/') and not os.environ.get('TRAVIS_REPO_SLUG', '') == 'nf-core/tools',
-    help = "Execute additional checks for release-ready workflows."
-)
-def lint(pipeline_dir, release):
-    """ Check pipeline against nf-core guidelines """
-
-    # Run the lint tests!
-    lint_obj = nf_core.lint.run_linting(pipeline_dir, release)
-    if len(lint_obj.failed) > 0:
-        sys.exit(1)
-
-@nf_core_cli.command()
+# nf-core list
+@nf_core_cli.command(help_priority=1)
 @click.argument(
     'keywords',
     required = False,
@@ -57,7 +65,7 @@ def lint(pipeline_dir, release):
 )
 @click.option(
     '-s', '--sort',
-    type = click.Choice(['release', 'name', 'stars']),
+    type = click.Choice(['release', 'pulled', 'name', 'stars']),
     default = 'release',
     help = "How to sort listed pipelines"
 )
@@ -67,29 +75,33 @@ def lint(pipeline_dir, release):
     default = False,
     help = "Print full output as JSON"
 )
-def list(sort, json, keywords):
+def list(keywords, sort, json):
     """ List nf-core pipelines with local info """
-    nf_core.list.list_workflows(sort, json, keywords)
+    nf_core.list.list_workflows(keywords, sort, json)
 
-@nf_core_cli.command()
+# nf-core launch
+@nf_core_cli.command(help_priority=2)
 @click.argument(
     'pipeline',
     required = True,
     metavar = "<pipeline name>"
 )
 @click.option(
-    '--json',
-    is_flag = True,
-    default = False,
-    help = "Print output in JSON"
+    '-p', '--params',
+    type = str,
+    help = "Local parameter settings file in JSON."
 )
-def licences(pipeline, json):
-    """ List software licences for a given workflow """
-    lic = nf_core.licences.WorkflowLicences(pipeline)
-    lic.fetch_conda_licences()
-    lic.print_licences(as_json=json)
+@click.option(
+    '-d', '--direct',
+    is_flag = True,
+    help = "Uses given values from the parameter file directly."
+)
+def launch(pipeline, params, direct):
+    """ Run pipeline, interactive parameter prompts """
+    nf_core.launch.launch_pipeline(pipeline, params, direct)
 
-@nf_core_cli.command()
+# nf-core download
+@nf_core_cli.command(help_priority=3)
 @click.argument(
     'pipeline',
     required = True,
@@ -116,60 +128,26 @@ def download(pipeline, release, singularity, outdir):
     dl = nf_core.download.DownloadWorkflow(pipeline, release, singularity, outdir)
     dl.download_workflow()
 
-@nf_core_cli.command()
+# nf-core licences
+@nf_core_cli.command(help_priority=4)
 @click.argument(
     'pipeline',
     required = True,
     metavar = "<pipeline name>"
 )
 @click.option(
-    '-p', '--params',
-    type = str,
-    help = "Local parameter settings file in JSON."
-)
-@click.option(
-    '-d', '--direct',
-    is_flag = True,
-    help = "Uses given values from the parameter file directly."
-)
-def launch(pipeline, params, direct):
-    """ Interactively build a nextflow command and launch a pipeline """
-    nf_core.launch.launch_pipeline(pipeline, params, direct)
-
-@nf_core_cli.command('bump-version')
-@click.argument(
-    'pipeline_dir',
-    type = click.Path(exists=True),
-    required = True,
-    metavar = "<pipeline directory>"
-)
-@click.argument(
-    'new_version',
-    required = True,
-    metavar = "<new version>"
-)
-@click.option(
-    '-n', '--nextflow',
+    '--json',
     is_flag = True,
     default = False,
-    help = "Bump required nextflow version instead of pipeline version"
+    help = "Print output in JSON"
 )
-def bump_version(pipeline_dir, new_version, nextflow):
-    """ Update nf-core pipeline version number """
+def licences(pipeline, json):
+    """ List software licences for a given workflow """
+    lic = nf_core.licences.WorkflowLicences(pipeline)
+    lic.fetch_conda_licences()
+    lic.print_licences(as_json=json)
 
-    # First, lint the pipeline to check everything is in order
-    logging.info("Running nf-core lint tests")
-    lint_obj = nf_core.lint.run_linting(pipeline_dir, False)
-    if len(lint_obj.failed) > 0:
-        logging.error("Please fix lint errors before bumping versions")
-        return
-
-    # Bump the pipeline version number
-    if not nextflow:
-        nf_core.bump_version.bump_pipeline_version(lint_obj, new_version)
-    else:
-        nf_core.bump_version.bump_nextflow_version(lint_obj, new_version)
-
+# nf-core create
 def validate_wf_name_prompt(ctx, opts, value):
     """ Force the workflow name to meet the nf-core requirements """
     if not re.match(r'^[a-z]+$', value):
@@ -177,8 +155,7 @@ def validate_wf_name_prompt(ctx, opts, value):
         value = click.prompt(opts.prompt)
         return validate_wf_name_prompt(ctx, opts, value)
     return value
-
-@nf_core_cli.command()
+@nf_core_cli.command(help_priority=5)
 @click.option(
     '-n', '--name',
     prompt = 'Workflow Name',
@@ -228,6 +205,63 @@ def create(name, description, author, new_version, no_git, force, outdir):
     """ Create a new pipeline using the template """
     create_obj = nf_core.create.PipelineCreate(name, description, author, new_version, no_git, force, outdir)
     create_obj.init_pipeline()
+
+@nf_core_cli.command(help_priority=6)
+@click.argument(
+    'pipeline_dir',
+    type = click.Path(exists=True),
+    required = True,
+    metavar = "<pipeline directory>"
+)
+@click.option(
+    '--release',
+    is_flag = True,
+    default = os.environ.get('TRAVIS_BRANCH') == 'master' and os.environ.get('TRAVIS_REPO_SLUG', '').startswith('nf-core/') and not os.environ.get('TRAVIS_REPO_SLUG', '') == 'nf-core/tools',
+    help = "Execute additional checks for release-ready workflows."
+)
+def lint(pipeline_dir, release):
+    """ Check pipeline against nf-core guidelines """
+
+    # Run the lint tests!
+    lint_obj = nf_core.lint.run_linting(pipeline_dir, release)
+    if len(lint_obj.failed) > 0:
+        sys.exit(1)
+
+
+@nf_core_cli.command('bump-version', help_priority=7)
+@click.argument(
+    'pipeline_dir',
+    type = click.Path(exists=True),
+    required = True,
+    metavar = "<pipeline directory>"
+)
+@click.argument(
+    'new_version',
+    required = True,
+    metavar = "<new version>"
+)
+@click.option(
+    '-n', '--nextflow',
+    is_flag = True,
+    default = False,
+    help = "Bump required nextflow version instead of pipeline version"
+)
+def bump_version(pipeline_dir, new_version, nextflow):
+    """ Update nf-core pipeline version number """
+
+    # First, lint the pipeline to check everything is in order
+    logging.info("Running nf-core lint tests")
+    lint_obj = nf_core.lint.run_linting(pipeline_dir, False)
+    if len(lint_obj.failed) > 0:
+        logging.error("Please fix lint errors before bumping versions")
+        return
+
+    # Bump the pipeline version number
+    if not nextflow:
+        nf_core.bump_version.bump_pipeline_version(lint_obj, new_version)
+    else:
+        nf_core.bump_version.bump_nextflow_version(lint_obj, new_version)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I found a few bugs and things to tidy up..

1. `nf-core --help` now sorts the commands in a more logical order. 
    * User commands are first, developer commands are second
    * `bump-version` is no longer the first command you see!
2. I realised that the sorting functionality of `nf-core list` had been broken
    * Fixed it, so that `-s` flags work again
    * Fixed it so that the default is release again, instead of name
    * Added `-s pulled` to sort by the most recently pulled to local
    * I added a fair bit more to the readme as the docs were a bit lackign.
3. The new `nf-core launch` command wasn't documented at all. So I added that to the readme.