### PR TITLE
Linting - don't reverse conda channel order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   * Sorting now works again
   * Output is partially coloured (better highlighting out of date pipelines)
   * Improved documentation
+* Fixed bugs in `nf-core lint`
+  * The order of conda channels is now correct, avoiding occasional erroneous errors that packages weren't found ([#207](https://github.com/nf-core/tools/issues/207))
 
 ## [v1.5](https://github.com/nf-core/tools/releases/tag/1.5) - 2019-03-13 Iron Shark
 

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -683,7 +683,7 @@ class PipelineLint(object):
         if '::' in depname:
             dep_channels = [depname.split('::')[0]]
             depname = depname.split('::')[1]
-        for ch in reversed(dep_channels):
+        for ch in dep_channels:
             anaconda_api_url = 'https://api.anaconda.org/package/{}/{}'.format(ch, depname)
             try:
                 response = requests.get(anaconda_api_url, timeout=10)
@@ -701,6 +701,8 @@ class PipelineLint(object):
                 elif response.status_code != 404:
                     self.warned.append((8, "Anaconda API returned unexpected response code '{}' for: {}\n{}".format(response.status_code, anaconda_api_url, response)))
                     raise ValueError
+                elif response.status_code == 404:
+                    logging.debug("Could not find {} in conda channel {}".format(dep, ch))
         else:
             # We have looped through each channel and had a 404 response code on everything
             self.failed.append((8, "Could not find Conda dependency using the Anaconda API: {}".format(dep)))

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -698,7 +698,7 @@ class PipelineLint(object):
                     dep_json = response.json()
                     self.conda_package_info[dep] = dep_json
                     return
-                else if response.status_code != 404:
+                elif response.status_code != 404:
                     self.warned.append((8, "Anaconda API returned unexpected response code '{}' for: {}\n{}".format(response.status_code, anaconda_api_url, response)))
                     raise ValueError
         else:


### PR DESCRIPTION
Not sure why this code was there, but for some reason we were going through the conda channel order in reverse.

When packages are only in one channel, this didn't have any negative effect (except for slower lint execution times and more API calls). However, when packages were in multiple channels with different version numbers, it could cause the linting to fail incorrectly (cf. https://github.com/nf-core/atacseq/pull/26)

Just removing the `reverse()` seems to fix this behaviour. Arguably we could extend the linting to check subsequent channels if the correct version isn't found in the first found, but I think it's very unlikely that this will happen so I can't be bothered now.

Phil