### PR TITLE
Refactors the syncing script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## v1.6dev
 
+#### Syncing
+* Code refactoring to make the script more readable
+* No travis build failure anymore on sync errors
+* More verbose logging
+
 #### Template pipeline
 * awsbatch `work-dir` checking moved to nextflow itself. Removed unsatisfiable check in main.nf template.
 * Fixed markdown linting

--- a/bin/sync
+++ b/bin/sync
@@ -19,6 +19,8 @@ GITHUB_PR_URL_TEMPL = "https://api.github.com/repos/nf-core/{pipeline}/pulls"
 # Current script dir
 PATH_PARENT_DIR = os.path.dirname(os.path.realpath(__file__))
 
+sync_errors = []
+pr_errors = []
 
 
 def create_pullrequest(pipeline, origin="dev", template="TEMPLATE", token="", user="nf-core"):
@@ -50,64 +52,71 @@ def filter_blacklisted_pipelines_from_list(pipelines, blacklisted_pipelines):
     return filtered_pipelines
 
 
+def fetch_black_listed_pipelines_from_file(file_path):
+    with open(file_path) as fh:
+        blacklist = json.load(fh)
+    return blacklist
+
+
+def fetch_nfcore_workflows_from_website(url):
+    try:
+        res = requests.get(url)
+        pipelines = res.json().get('remote_workflows')
+    except Exception as e:
+        print("Could not get remote workflows. Reason was: {}".format(e))
+        pipelines = []
+    return pipelines
+
+
+def update_template_branch_for_pipeline(pipeline):
+    try:
+        syncutils.template.NfcoreTemplate(
+            pipeline['name'],
+            branch=DEF_TEMPLATE_BRANCH,
+            repo_url=GH_BASE_URL.format(token=os.environ["NF_CORE_BOT"], pipeline=pipeline['name'])
+        ).sync()
+    except Exception as e:
+        sync_errors.append((pipeline['name'], e))
+
+
+def create_pullrequest_if_update_sucessful(pipeline):
+    name = pipeline.get('name')
+    for errored_pipeline, _ in sync_errors:
+        if name == errored_pipeline:
+            return
+    response = create_pullrequest(name, token=os.environ["NF_CORE_BOT"])
+    if response.status_code != 201:
+        pr_errors.append((name, response.status_code, response.content))
+    else:
+        print("Created pull-request for pipeline \'{pipeline}\' successfully."
+              .format(pipeline=name))
+
+
 def main():
-    # Check that the commit event is a GitHub tag event
     assert os.environ['TRAVIS_TAG']
     assert os.environ['NF_CORE_BOT']
 
-    # Catch exceptions in lists, and list them at the end
-    sync_errors = []
-    pr_errors = []
+    blacklisted_pipeline_names = fetch_black_listed_pipelines_from_file(PATH_PARENT_DIR + "/blacklist.json")
 
-    # Get blacklisted pipelines, that should be excluded from sync
-    with open(PATH_PARENT_DIR + "/blacklist.json") as fh:
-        blacklist = json.load(fh)
+    pipelines = fetch_nfcore_workflows_from_website(NF_CORE_PIPELINE_INFO)
 
-    # Get nf-core pipelines info
-    res = requests.get(NF_CORE_PIPELINE_INFO)
-    pipelines = res.json().get('remote_workflows')
-    if not pipelines:
-        print("Pipeline information was empty!")
+    filtered_pipelines = filter_blacklisted_pipelines_from_list(pipelines, blacklisted_pipeline_names)
 
-    pipelines_without_template = syncutils.utils.repos_without_template_branch(
-        pipeline["name"] for pipeline in pipelines)
-
-    # Exclude blacklisted pipelines
-    pipelines = filter_blacklisted_pipelines_from_list(pipelines, blacklist)
-
-    # Update the template branch of each pipeline repo
-    for pipeline in pipelines:
+    for pipeline in filtered_pipelines:
         print("Update template branch for pipeline '{pipeline}'... ".format(pipeline=pipeline['name']))
-        try:
-            syncutils.template.NfcoreTemplate(
-                pipeline['name'],
-                branch=DEF_TEMPLATE_BRANCH,
-                repo_url=GH_BASE_URL.format(token=os.environ["NF_CORE_BOT"], pipeline=pipeline['name'])
-            ).sync()
-        except Exception as e:
-            sync_errors.append((pipeline['name'], e))
-
-    # Create a pull request from each template branch to the origin branch
-    for pipeline in pipelines:
+        update_template_branch_for_pipeline(pipeline)
         print("Trying to open pull request for pipeline {}...".format(pipeline['name']))
-        response = create_pullrequest(pipeline['name'], token=os.environ["NF_CORE_BOT"])
-        if response.status_code != 201:
-            pr_errors.append((pipeline['name'], response.status_code, response.content))
-        else:
-            print("Created pull-request for pipeline \'{pipeline}\' successfully."
-                .format(pipeline=pipeline["name"]))
+        create_pullrequest_if_update_sucessful(pipeline)
 
     for pipeline, exception in sync_errors:
-        print("Sync for pipeline {name} failed.".format(name=pipeline))
+        print("WARNING!!!! Sync for pipeline {name} failed.".format(name=pipeline))
         print(exception)
 
     for pipeline, return_code, content in pr_errors:
-        print("Pull-request for pipeline \'{pipeline}\' failed,"
-                " got return code {return_code}."
-                .format(pipeline=pipeline, return_code=return_code))
+        print("WARNING!!!! Pull-request for pipeline \'{pipeline}\' failed,"
+              " got return code {return_code}."
+              .format(pipeline=pipeline, return_code=return_code))
         print(content)
-
-    if pr_errors or sync_errors: sys.exit(1)
 
     sys.exit(0)
 

--- a/bin/sync
+++ b/bin/sync
@@ -39,6 +39,17 @@ def create_pullrequest(pipeline, origin="dev", template="TEMPLATE", token="", us
                          auth=HTTPBasicAuth(user, token))
 
 
+def filter_blacklisted_pipelines_from_list(pipelines, blacklisted_pipelines):
+    filtered_pipelines = []
+    for pipeline in pipelines:
+        if not pipeline.get('name'):
+            print("No attribute \'name\' for pipeline found: {}".format(pipeline))
+        else:
+            filtered_pipelines.append(pipeline) if pipeline.get('name') not in blacklisted_pipelines \
+                else filtered_pipelines
+    return filtered_pipelines
+
+
 def main():
     # Check that the commit event is a GitHub tag event
     assert os.environ['TRAVIS_TAG']
@@ -62,7 +73,7 @@ def main():
         pipeline["name"] for pipeline in pipelines)
 
     # Exclude blacklisted pipelines
-    pipelines = [pipeline for pipeline in pipelines if pipeline['name'] not in blacklist['pipelines']]
+    pipelines = filter_blacklisted_pipelines_from_list(pipelines, blacklist)
 
     # Update the template branch of each pipeline repo
     for pipeline in pipelines:


### PR DESCRIPTION
The syncing was not very verbose, I changed it, made some refactoring of the code to make it more descriptive (hopefully), and let the script NOT fail, even if errors occured.

The errors will be cought and printed on the travis log though, so we can track issues. But I see no reason to let the travis build fail on a nf-core tools release because of that.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
