### PR TITLE
Fix typo in tools readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 #### Syncing
 * Can now sync a targeted pipeline via command-line
 
+#### Other
+* Fix small typo in central readme of tools for future releases
+
 ## v1.6
 
 #### Syncing

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ The `create` subcommand makes a new workflow using the nf-core base template.
 With a given pipeline name, description and author, it makes a starter pipeline which follows nf-core best practices.
 
 After creating the files, the command initialises the folder as a git repository and makes an initial commit. This first "vanilla" commit which is identical to the output from the templating tool is important, as it allows us to keep your pipeline in sync with the base template in the future.
-See the [nf-core syncing docs](http://nf-co.re/sync) for more information.
+See the [nf-core syncing docs](https://nf-co.re/developers/sync) for more information.
 
 ```console
 $ nf-core create


### PR DESCRIPTION
Mini Typo fix in the readme.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated
