### PR TITLE
Add exception handling (skipping) for linting mutiline parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Can now sync a targeted pipeline via command-line
 
 #### Singularity with Python Multiprocessing
-* Add a singularity option in `nextflow.config` to add support for python multiprocessing when using nf-core pipelines with singularity. 
+* Add a singularity option in `nextflow.config` to add support for python multiprocessing when using nf-core pipelines with singularity
 
 ## v1.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 #### Syncing
 * Can now sync a targeted pipeline via command-line
 
-#### Singularity with Python Multiprocessing
-* Add a singularity option in `nextflow.config` to add support for python multiprocessing when using nf-core pipelines with singularity
+#### Add exception handling (skipping) for mutiline parameters
+In `utils.py` when encountering parameters spanning accross mutliple lines.
 
 ## v1.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 #### Syncing
 * Can now sync a targeted pipeline via command-line
 
+#### Singularity with Python Multiprocessing
+* Add a singularity option in `nextflow.config` to add support for python multiprocessing when using nf-core pipelines with singularity. 
+
 ## v1.6
 
 #### Syncing

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
@@ -54,7 +54,10 @@ profiles {
   conda { process.conda = "$baseDir/environment.yml" }
   debug { process.beforeScript = 'echo $HOSTNAME' }
   docker { docker.enabled = true }
-  singularity { singularity.enabled = true }
+  singularity { 
+    singularity.enabled = true
+    singularity.runOptions = '-B /run/shm:/run/shm'
+  }
   test { includeConfig 'conf/test.config' }
 }
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
@@ -54,10 +54,7 @@ profiles {
   conda { process.conda = "$baseDir/environment.yml" }
   debug { process.beforeScript = 'echo $HOSTNAME' }
   docker { docker.enabled = true }
-  singularity { 
-    singularity.enabled = true
-    singularity.runOptions = '-B /run/shm:/run/shm'
-  }
+  singularity { singularity.enabled = true }
   test { includeConfig 'conf/test.config' }
 }
 

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -55,9 +55,12 @@ def fetch_wf_config(wf_path, wf=None):
     else:
         for l in nfconfig_raw.splitlines():
             ul = l.decode('utf-8')
-            k, v = ul.split(' = ', 1)
-            config[k] = v
-
+            try:
+                k, v = ul.split(' = ', 1)
+                config[k] = v
+            except ValueError:
+                print('Encountered multiline config parameter')
+                continue
     # If we can, save a cached copy
     if cache_path:
         logging.debug("Saving config cache: {}".format(cache_path))


### PR DESCRIPTION
`nf-core lint` would fail when parsing the output of `nextflow config -flat` because of some parameters spanning over multiple lines.

```bash
  File "/Users/borry/miniconda3/envs/nf-core/lib/python3.7/site-packages/nf_core-1.6-py3.7.egg/nf_core/utils.py", line 58, in fetch_wf_config
    k, v = ul.split(' = ', 1)
ValueError: not enough values to unpack (expected 2, got 1)
```
Proposed fix:
```python
try:
  k, v = ul.split(' = ', 1)
  config[k] = v
except ValueError:
  print('Encountered multiline config parameter')
  continue
```

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated

**Learn more about contributing:** https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
