### PR TITLE
Specify yaml Loader argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Other
 * Fix small typo in central readme of tools for future releases
+* Added yaml `Loader=` parameter to fix PyYAML warning that was thrown because of a possible [exploit](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation)
 
 ## v1.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 #### Other
 * Fix small typo in central readme of tools for future releases
-* Added yaml `Loader=` parameter to fix PyYAML warning that was thrown because of a possible [exploit](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation)
+* Switched to yaml.safe_load() to fix PyYAML warning that was thrown because of a possible [exploit](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation)
 
 ## v1.6
 

--- a/nf_core/licences.py
+++ b/nf_core/licences.py
@@ -44,7 +44,7 @@ class WorkflowLicences(object):
             raise LookupError("Couldn't find pipeline nf-core/{}".format(self.pipeline))
 
         lint_obj = nf_core.lint.PipelineLint(self.pipeline)
-        lint_obj.conda_config = yaml.load(response.text)
+        lint_obj.conda_config = yaml.load(response.text, Loader=yaml.BaseLoader)
         # Check conda dependency list
         for dep in lint_obj.conda_config.get('dependencies', []):
             try:

--- a/nf_core/licences.py
+++ b/nf_core/licences.py
@@ -44,7 +44,7 @@ class WorkflowLicences(object):
             raise LookupError("Couldn't find pipeline nf-core/{}".format(self.pipeline))
 
         lint_obj = nf_core.lint.PipelineLint(self.pipeline)
-        lint_obj.conda_config = yaml.load(response.text, Loader=yaml.BaseLoader)
+        lint_obj.conda_config = yaml.safe_load(response.text)
         # Check conda dependency list
         for dep in lint_obj.conda_config.get('dependencies', []):
             try:

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -261,7 +261,7 @@ class PipelineLint(object):
         # Load and parse files for later
         if 'environment.yml' in self.files:
             with open(os.path.join(self.path, 'environment.yml'), 'r') as fh:
-                self.conda_config = yaml.load(fh, Loader=yaml.BaseLoader)
+                self.conda_config = yaml.safe_load(fh)
 
     def check_docker(self):
         """Checks that Dockerfile contains the string ``FROM``."""
@@ -446,7 +446,7 @@ class PipelineLint(object):
             fn = os.path.join(self.path, cf)
             if os.path.isfile(fn):
                 with open(fn, 'r') as fh:
-                    ciconf = yaml.load(fh, Loader=yaml.BaseLoader)
+                    ciconf = yaml.safe_load(fh)
                 # Check that we have the master branch protection
                 travisMasterCheck = '[ $TRAVIS_PULL_REQUEST = "false" ] || [ $TRAVIS_BRANCH != "master" ] || ([ $TRAVIS_PULL_REQUEST_SLUG = $TRAVIS_REPO_SLUG ] && [ $TRAVIS_PULL_REQUEST_BRANCH = "dev" ])'
                 try:

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -261,7 +261,7 @@ class PipelineLint(object):
         # Load and parse files for later
         if 'environment.yml' in self.files:
             with open(os.path.join(self.path, 'environment.yml'), 'r') as fh:
-                self.conda_config = yaml.load(fh)
+                self.conda_config = yaml.load(fh, Loader=yaml.BaseLoader)
 
     def check_docker(self):
         """Checks that Dockerfile contains the string ``FROM``."""
@@ -446,7 +446,7 @@ class PipelineLint(object):
             fn = os.path.join(self.path, cf)
             if os.path.isfile(fn):
                 with open(fn, 'r') as fh:
-                    ciconf = yaml.load(fh)
+                    ciconf = yaml.load(fh, Loader=yaml.BaseLoader)
                 # Check that we have the master branch protection
                 travisMasterCheck = '[ $TRAVIS_PULL_REQUEST = "false" ] || [ $TRAVIS_BRANCH != "master" ] || ([ $TRAVIS_PULL_REQUEST_SLUG = $TRAVIS_REPO_SLUG ] && [ $TRAVIS_PULL_REQUEST_BRANCH = "dev" ])'
                 try:

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -260,7 +260,7 @@ class TestLint(unittest.TestCase):
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         lint_obj.files = ['environment.yml']
         with open(os.path.join(PATH_WORKING_EXAMPLE, 'environment.yml'), 'r') as fh:
-            lint_obj.conda_config = yaml.load(fh, Loader=yaml.BaseLoader)
+            lint_obj.conda_config = yaml.safe_load(fh)
         lint_obj.pipeline_name = 'tools'
         lint_obj.config['manifest.version'] = '0.4'
         lint_obj.check_conda_env_yaml()
@@ -272,7 +272,7 @@ class TestLint(unittest.TestCase):
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         lint_obj.files = ['environment.yml']
         with open(os.path.join(PATH_WORKING_EXAMPLE, 'environment.yml'), 'r') as fh:
-            lint_obj.conda_config = yaml.load(fh, Loader=yaml.BaseLoader)
+            lint_obj.conda_config = yaml.safe_load(fh)
         lint_obj.conda_config['dependencies'] = ['fastqc', 'multiqc=0.9', 'notapackaage=0.4']
         lint_obj.pipeline_name = 'not_tools'
         lint_obj.config['manifest.version'] = '0.23'

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -260,7 +260,7 @@ class TestLint(unittest.TestCase):
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         lint_obj.files = ['environment.yml']
         with open(os.path.join(PATH_WORKING_EXAMPLE, 'environment.yml'), 'r') as fh:
-            lint_obj.conda_config = yaml.load(fh)
+            lint_obj.conda_config = yaml.load(fh, Loader=yaml.BaseLoader)
         lint_obj.pipeline_name = 'tools'
         lint_obj.config['manifest.version'] = '0.4'
         lint_obj.check_conda_env_yaml()
@@ -272,7 +272,7 @@ class TestLint(unittest.TestCase):
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         lint_obj.files = ['environment.yml']
         with open(os.path.join(PATH_WORKING_EXAMPLE, 'environment.yml'), 'r') as fh:
-            lint_obj.conda_config = yaml.load(fh)
+            lint_obj.conda_config = yaml.load(fh, Loader=yaml.BaseLoader)
         lint_obj.conda_config['dependencies'] = ['fastqc', 'multiqc=0.9', 'notapackaage=0.4']
         lint_obj.pipeline_name = 'not_tools'
         lint_obj.config['manifest.version'] = '0.23'


### PR DESCRIPTION
Since PyYAML 5.1, a warning is thrown when yaml.load() is called without a loader argument.
More info:
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

Many thanks to contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated

**Learn more about contributing:** https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
