### PR TITLE
Add create to TEMPLATE setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v1.7dev
 
+#### Tools helper code
+* The tools `create` command now sets up a TEMPLATE branch for syncing
+
 #### Syncing
 * Can now sync a targeted pipeline via command-line
 * Updated Blacklist of synced pipelines

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -100,6 +100,9 @@ class PipelineCreate(object):
         """
         logging.info("Initialising pipeline git repository")
         repo = git.Repo.init(self.outdir)
-        repo.git.add(A=True)
+        repo.git.add(A=True)        
         repo.index.commit("initial template build from nf-core/tools, version {}".format(nf_core.__version__))
-        logging.info("Done. Remember to add a remote and push to GitHub:\n  cd {}\n  git remote add origin git@github.com:USERNAME/REPO_NAME.git\n  git push".format(self.outdir))
+        #Add TEMPLATE branch to git repository
+        repo.git.branch('TEMPLATE')
+        logging.info("Done. Remember to add a remote and push to GitHub:\n  cd {}\n  git remote add origin git@github.com:USERNAME/REPO_NAME.git\n  git push --all origin".format(self.outdir))
+        logging.info("This will also push your newly created TEMPLATE branch for syncing.")

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 import sys
 
-version = '1.6'
+version = '1.7dev'
 
 with open('README.md') as f:
     readme = f.read()


### PR DESCRIPTION
This adds the ability to the `create` command to automatically set up the TEMPLATE branch required for syncing pipelines. 

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated


Demo:
<img width="1210" alt="Bildschirmfoto 2019-05-06 um 09 52 30" src="https://user-images.githubusercontent.com/2359510/57212649-b025ba80-6fe4-11e9-8ece-a4f723465e86.png">
