### PR TITLE
specified conda channels in template (#333)

### DIFF
--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/environment.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/environment.yml
@@ -7,5 +7,5 @@ channels:
   - defaults
 dependencies:
   # TODO nf-core: Add required software dependencies here
-  - fastqc=0.11.8
-  - multiqc=1.7
+  - bioconda::fastqc=0.11.8
+  - bioconda::multiqc=1.7


### PR DESCRIPTION
The base template didn't specify channels for `conda` packages: `multiqc` and `fastqc`. Should be specified. 

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated