### PR TITLE
Cast ignoredCountFmt to Integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@
 #### Other
 * Fix small typo in central readme of tools for future releases
 
-####
-
 * Fix ignored failed jobs odd reporting behavior in `main.nf` template [#338](https://github.com/nf-core/tools/pull/338)
 
 ## v1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 #### Other
 * Fix small typo in central readme of tools for future releases
 
+####
+
+* Fix ignored failed jobs odd reporting behavior in `main.nf` template [#338](https://github.com/nf-core/tools/pull/338)
+
 ## v1.6
 
 #### Syncing

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
@@ -367,7 +367,7 @@ workflow.onComplete {
     c_green = params.monochrome_logs ? '' : "\033[0;32m";
     c_red = params.monochrome_logs ? '' : "\033[0;31m";
 
-    if (workflow.stats.ignoredCountFmt > 0 && workflow.success) {
+    if (workflow.stats.ignoredCountFmt as Integer > 0 && workflow.success) {
       log.info "${c_purple}Warning, pipeline completed, but with errored process(es) ${c_reset}"
       log.info "${c_red}Number of ignored errored process(es) : ${workflow.stats.ignoredCountFmt} ${c_reset}"
       log.info "${c_green}Number of successfully ran process(es) : ${workflow.stats.succeedCountFmt} ${c_reset}"


### PR DESCRIPTION
Fix odd behavior of ignore failed jobs reporting (#314) by casting ignoredCountFmt to Integer with 
`as Integer` 

`as Integer` is the Groovy replacement method for the outdated toInteger(). See [Groovy doc: coercion_operator](http://docs.groovy-lang.org/latest/html/documentation/#_coercion_operator) and [StackOverflow](https://stackoverflow.com/questions/1713481/groovy-string-to-int)

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated

**Learn more about contributing:** https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
