### PR TITLE
Prints warning in dev mode for unequal container name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Removed `chipseq` from Blacklist of synced pipelines
 * Fixed issue [#314](https://github.com/nf-core/tools/issues/314)
 
+#### Linting
+* If the container slug does not contain the nf-core organisation (for example during development on a fork), linting will raise a warning, and an error with release mode on
+
 #### Other
 * Fix small typo in central readme of tools for future releases
 * Switched to yaml.safe_load() to fix PyYAML warning that was thrown because of a possible [exploit](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation)

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -434,7 +434,7 @@ class PipelineLint(object):
                 if self.release_mode:
                     self.failed.append((4, "Config variable process.container looks wrong. Should be '{}' but is '{}'".format(container_name, self.config.get('process.container', '').strip("'"))))
                 else:
-                    self.warned.append((4, "Config variable process.container looks wrong. Should be '{}' but is '{}'".format(container_name, self.config.get('process.container', '').strip("'"))))
+                    self.warned.append((4, "Config variable process.container looks wrong. Should be '{}' but is '{}'. Fix this before you make a release of your pipeline!".format(container_name, self.config.get('process.container', '').strip("'"))))
             else:
                 self.passed.append((4, "Config variable process.container looks correct: '{}'".format(container_name)))
 

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -431,7 +431,10 @@ class PipelineLint(object):
             try:
                 assert self.config.get('process.container', '').strip("'") == container_name
             except AssertionError:
-                self.failed.append((4, "Config variable process.container looks wrong. Should be '{}' but is '{}'".format(container_name, self.config.get('process.container', '').strip("'"))))
+                if self.release_mode:
+                    self.failed.append((4, "Config variable process.container looks wrong. Should be '{}' but is '{}'".format(container_name, self.config.get('process.container', '').strip("'"))))
+                else:
+                    self.warned.append((4, "Config variable process.container looks wrong. Should be '{}' but is '{}'".format(container_name, self.config.get('process.container', '').strip("'"))))
             else:
                 self.passed.append((4, "Config variable process.container looks correct: '{}'".format(container_name)))
 


### PR DESCRIPTION
Working on a fork of a pipeline with an own temp. container reference will raise an error during linting, as the container slug does not contain `nf-core`.

Whilst this is technically correct, we should not let linting raise an error during development, but a warning instead. During `release mode` of nf-core tools, the container definitions must reference a container slug within the nf-core community on Dockerhub, which is the case for a pipeline release.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
