### PR TITLE
Cope with edge versions when linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
   * Improved documentation
 * Fixed bugs in `nf-core lint`
   * The order of conda channels is now correct, avoiding occasional erroneous errors that packages weren't found ([#207](https://github.com/nf-core/tools/issues/207))
+  * Allow edge versions in nf-core pipelines
 * Add reporting of ignored errored process
   * As a solution for [#103](https://github.com/nf-core/tools/issues/103))
 

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -419,7 +419,11 @@ class PipelineLint(object):
             if self.config.get('manifest.nextflowVersion', '').strip('"\'').startswith('>='):
                 self.passed.append((4, "Config variable 'manifest.nextflowVersion' started with >="))
                 # Save self.minNextflowVersion for convenience
-                self.minNextflowVersion = re.sub(r'[^0-9\.]', '', self.config.get('manifest.nextflowVersion', ''))
+                nextflowVersionMatch = re.search(r'[0-9\.]+(-edge)?', self.config.get('manifest.nextflowVersion', ''))
+                if nextflowVersionMatch:
+                    self.minNextflowVersion = nextflowVersionMatch.group(0)
+                else:
+                    self.minNextflowVersion = None
             else:
                 self.failed.append((4, "Config variable 'manifest.nextflowVersion' did not start with '>=' : '{}'".format(self.config.get('manifest.nextflowVersion', '')).strip('"\'')))
 


### PR DESCRIPTION
## PR checklist
 - [x] This comment contains a description of changes (with reason)

When testing edge versions the current regex removes the `-edge`  string. This changes copes with this eventuality.

PR against dev