### PR TITLE
Add docker.runOptions to avoid memory swap error

### DIFF
--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
@@ -58,6 +58,11 @@ profiles {
   test { includeConfig 'conf/test.config' }
 }
 
+// Avoid this error:
+// WARNING: Your kernel does not support swap limit capabilities or the cgroup is not mounted. Memory limited without swap.
+// Thanks to: https://github.com/alesssia/YAMP/wiki/How-to-use-Docker
+docker.runOptions = '-u $(id -u):$(id -g)'
+
 // Load igenomes.config if required
 if(!params.igenomesIgnore){
   includeConfig 'conf/igenomes.config'


### PR DESCRIPTION
Hello! I had been running into some docker errors and tracked down some magic settings that made them go away. This PR adds those settings to the default nf-core created sample.

## PR checklist
 - [ ] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
