### PR TITLE
Bump version of Conda in base to 4.6.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
 * Add `Quick Start` section to main README of template
 * Fix [Docker RunOptions](https://github.com/nf-core/tools/pull/351) to get UID and GID set in the template
 
+#### Other
+
+* Bump `conda` to 4.6.14 in base nf-core Dockerfile
+
 ## v1.6
 
 #### Syncing

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM continuumio/miniconda:4.5.4
+FROM continuumio/miniconda:4.6.14
 LABEL authors="phil.ewels@scilifelab.se,alexander.peltzer@qbic.uni-tuebingen.de" \
       description="Docker image containing base requirements for the nfcore pipelines"
 
 # Install procps so that Nextflow can poll CPU usage
 RUN apt-get update && apt-get install -y procps && apt-get clean -y
-RUN conda install conda=4.6.7


### PR DESCRIPTION
This fixes some nasty behaviour, e.g. being unable to install conda post-link scripts such as `bioconductor-genomeinfodbdata` correctly, which has been addressed upstream in conda 4.6.X releases. I checked our current setup and we had 4.5.X installedd still, so the 4.6X update should also give us a significant speedup! 

https://github.com/conda/conda/issues/8306

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated
