### PR TITLE
[FIX] Missing r-markdown dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
   an AWS S3 bucket as the `--outdir`.
 * Fix workflow.onComplete() message when finishing pipeline
 * Update URL for joining the nf-core slack to https://nf-co.re/join/slack
+* Added conda-forge::r-markdown=1.1 and conda-forge::r-base=3.6.1 to environment
 
 ### Other
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/environment.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/environment.yml
@@ -9,3 +9,4 @@ dependencies:
   # TODO nf-core: Add required software dependencies here
   - bioconda::fastqc=0.11.8
   - bioconda::multiqc=1.7
+  - conda-forge::r-markdown=0.9

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/environment.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/environment.yml
@@ -8,6 +8,6 @@ channels:
 dependencies:
   # TODO nf-core: Add required software dependencies here
   - bioconda::fastqc=0.11.8
-  - bioconda::multiqc=1. 
+  - bioconda::multiqc=1.7
   - conda-forge::r-markdown=1.1
   - conda-forge::r-base=3.6.1

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/environment.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/environment.yml
@@ -8,5 +8,6 @@ channels:
 dependencies:
   # TODO nf-core: Add required software dependencies here
   - bioconda::fastqc=0.11.8
-  - bioconda::multiqc=1.7
-  - conda-forge::r-markdown=0.9
+  - bioconda::multiqc=1. 
+  - conda-forge::r-markdown=1.1
+  - conda-forge::r-base=3.6.1


### PR DESCRIPTION
Hi,

I was just setting up syncing for guideseq and soon proteomicslfq.
Hence, I followed the instructions and recreated the template. Then, as a sanity check, I wanted to run the example boilerplate code of the template (fastqc and multiqc) and ran into the following:
 
```
ERROR ~ Error executing process > 'output_documentation (1)'

Caused by:
  Process `output_documentation (1)` terminated with an error exit status (127)

Command executed:

  markdown_to_html.r output.md results_description.html

Command exit status:
  127

Command output:
  (empty)

Command error:
  /usr/bin/env: 'Rscript': No such file or directory
```
I propose that nfcore create should always output a minimal working example. 

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 