### PR TITLE
Py3.7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - '2.7'
   - '3.5'
   - '3.6'
+  - '3.7'
 before_install:
   # PRs to master are only ok if coming from dev branch
   - '[ $TRAVIS_PULL_REQUEST = "false" ] || [ $TRAVIS_BRANCH != "master" ] || ([ $TRAVIS_PULL_REQUEST_SLUG = $TRAVIS_REPO_SLUG ] && [ $TRAVIS_PULL_REQUEST_BRANCH = "dev" ])'

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ after_success:
 jobs:
   include:
     - stage: docs generation
-      if: (branch = "master" OR branch = "dev") AND type = push
+      if: (branch = "master" OR branch = "dev") AND type = push AND repo = nf-core/tools
       script: bash ./bin/push.sh
 
 deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## v1.7dev
 
-### Pypi package description
+### PyPI package description
 
-* The readme should now be rendered properly on Pypi.
+* The readme should now be rendered properly on PyPI.
 
 ### Tools helper code
 
@@ -12,6 +12,7 @@
 * Fixed issue [379](https://github.com/nf-core/tools/issues/379)
 * nf-core launch now uses stable parameter schema version 0.1.0
 * Check that PR from patch or dev branch is acceptable by linting
+* Made code compatible with Python 3.7
 
 ### Syncing
 

--- a/bin/syncutils/utils.py
+++ b/bin/syncutils/utils.py
@@ -1,3 +1,4 @@
+import erro
 import os
 import requests
 import subprocess
@@ -13,7 +14,7 @@ def fetch_wf_config(wf_path):
         with open(os.devnull, 'w') as devnull:
             nfconfig_raw = subprocess.check_output(['nextflow', 'config', '-flat', wf_path], stderr=devnull)
     except OSError as e:
-        if e.errno == os.errno.ENOENT:
+        if e.errno == errno.ENOENT:
             raise AssertionError("It looks like Nextflow is not installed. It is required for most nf-core functions.")
     except subprocess.CalledProcessError as e:
         raise AssertionError("`nextflow config` returned non-zero error code: %s,\n   %s", e.returncode, e.output)
@@ -61,4 +62,3 @@ def repos_without_template_branch(pipeline_names):
             print("WARNING: nf-core/{} had no TEMPLATE branch!".format(pipeline))
 
     return pipelines_without_template
-

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -3,6 +3,7 @@
 
 from __future__ import print_function
 
+import errno
 from io import BytesIO
 import logging
 import hashlib
@@ -208,7 +209,7 @@ class DownloadWorkflow(object):
         try:
             subprocess.call(singularity_command)
         except OSError as e:
-            if e.errno == os.errno.ENOENT:
+            if e.errno == errno.ENOENT:
                 # Singularity is not installed
                 logging.error('Singularity is not installed!')
             else:

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from collections import OrderedDict
 
 import click
+import errno
 import jsonschema
 import logging
 import os
@@ -98,7 +99,7 @@ class Launch(object):
                 with open(os.devnull, 'w') as devnull:
                     subprocess.check_output(['nextflow', 'pull', self.workflow], stderr=devnull)
             except OSError as e:
-                if e.errno == os.errno.ENOENT:
+                if e.errno == errno.ENOENT:
                     raise AssertionError("It looks like Nextflow is not installed. It is required for most nf-core functions.")
             except subprocess.CalledProcessError as e:
                 raise AssertionError("`nextflow pull` returned non-zero error code: %s,\n   %s", e.returncode, e.output)

--- a/nf_core/list.py
+++ b/nf_core/list.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 
 import click
 import datetime
+import errno
 import json
 import logging
 import os
@@ -96,7 +97,7 @@ class Workflows(object):
                 with open(os.devnull, 'w') as devnull:
                     nflist_raw = subprocess.check_output(['nextflow', 'list'], stderr=devnull)
             except OSError as e:
-                if e.errno == os.errno.ENOENT:
+                if e.errno == errno.ENOENT:
                     raise AssertionError("It looks like Nextflow is not installed. It is required for most nf-core functions.")
             except subprocess.CalledProcessError as e:
                 raise AssertionError("`nextflow list` returned non-zero error code: %s,\n   %s", e.returncode, e.output)
@@ -287,7 +288,7 @@ class LocalWorkflow(object):
                     with open(os.devnull, 'w') as devnull:
                         nfinfo_raw = subprocess.check_output(['nextflow', 'info', '-d', self.full_name], stderr=devnull)
                 except OSError as e:
-                    if e.errno == os.errno.ENOENT:
+                    if e.errno == errno.ENOENT:
                         raise AssertionError("It looks like Nextflow is not installed. It is required for most nf-core functions.")
                 except subprocess.CalledProcessError as e:
                     raise AssertionError("`nextflow list` returned non-zero error code: %s,\n   %s", e.returncode, e.output)

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -4,10 +4,12 @@ Common utility functions for the nf-core python package.
 """
 
 import datetime
+import errno
 import json
 import logging
 import os
 import subprocess
+import sys
 
 def fetch_wf_config(wf_path, wf=None):
     """Uses Nextflow to retrieve the the configuration variables
@@ -47,7 +49,7 @@ def fetch_wf_config(wf_path, wf=None):
         with open(os.devnull, 'w') as devnull:
             nfconfig_raw = subprocess.check_output(['nextflow', 'config', '-flat', wf_path], stderr=devnull)
     except OSError as e:
-        if e.errno == os.errno.ENOENT:
+        if e.errno == errno.ENOENT:
             raise AssertionError("It looks like Nextflow is not installed. It is required for most nf-core functions.")
     except subprocess.CalledProcessError as e:
         raise AssertionError("`nextflow config` returned non-zero error code: %s,\n   %s", e.returncode, e.output)
@@ -74,9 +76,9 @@ def setup_requests_cachedir():
     """
     # Only import it if we need it
     import requests_cache
-    
 
-    cachedir = os.path.join(os.getenv("HOME"), os.path.join('.nfcore', 'cache'))
+    pyversion = '.'.join(str(v) for v in sys.version_info[0:3])
+    cachedir = os.path.join(os.getenv("HOME"), os.path.join('.nfcore', 'cache_'+pyversion))
     if not os.path.exists(cachedir):
         os.makedirs(cachedir)
     requests_cache.install_cache(

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -11,7 +11,6 @@ import pytest
 import time
 import unittest
 
-from nose.tools import raises
 from datetime import datetime
 
 class TestLint(unittest.TestCase):
@@ -38,7 +37,7 @@ class TestLint(unittest.TestCase):
         now_ts = time.mktime(now.timetuple())
         nf_core.list.pretty_date(now_ts)
 
-    @raises(AssertionError)
+    @pytest.mark.xfail(raises=AssertionError)
     def test_local_workflows_and_fail(self):
         """ Test the local workflow class and try to get local
         Nextflow workflow information """
@@ -67,7 +66,7 @@ class TestLint(unittest.TestCase):
         rwf_ex = nf_core.list.RemoteWorkflow(remote)
         rwf_ex.commit_sha = "aw3s0meh1sh"
         rwf_ex.releases = [{'tag_sha': "aw3s0meh1sh"}]
-    
+
 
         wfs.local_workflows.append(lwf_ex)
         wfs.remote_workflows.append(rwf_ex)
@@ -83,7 +82,7 @@ class TestLint(unittest.TestCase):
         wfs.compare_remote_local()
 
         rwf_ex.releases = None
-    
+
     @mock.patch('nf_core.list.LocalWorkflow')
     def test_parse_local_workflow_and_succeed(self, mock_local_wf):
         test_path = '/tmp/nxf/nf-core'
@@ -92,7 +91,7 @@ class TestLint(unittest.TestCase):
         if not os.environ.get('NXF_ASSETS'):
             os.environ['NXF_ASSETS'] = '/tmp/nxf'
         assert os.environ['NXF_ASSETS'] == '/tmp/nxf'
-        with open('/tmp/nxf/nf-core/dummy-wf', 'w') as f: 
+        with open('/tmp/nxf/nf-core/dummy-wf', 'w') as f:
             f.write('dummy')
         workflows_obj = nf_core.list.Workflows()
         workflows_obj.get_local_nf_workflows()
@@ -108,11 +107,11 @@ class TestLint(unittest.TestCase):
         mock_env.side_effect = '/tmp/nxf'
 
         assert os.environ['NXF_ASSETS'] == '/tmp/nxf'
-        with open('/tmp/nxf/nf-core/dummy-wf', 'w') as f: 
+        with open('/tmp/nxf/nf-core/dummy-wf', 'w') as f:
             f.write('dummy')
         workflows_obj = nf_core.list.Workflows()
         workflows_obj.get_local_nf_workflows()
-    
+
     @mock.patch('os.stat')
     @mock.patch('git.Repo')
     def test_local_workflow_investigation(self, mock_repo, mock_stat):
@@ -121,7 +120,7 @@ class TestLint(unittest.TestCase):
         mock_repo.head.commit.hexsha = 'h00r4y'
         mock_stat.st_mode = 1
         local_wf.get_local_nf_workflow_details()
-    
+
 
     def test_worflow_filter(self):
         workflows_obj = nf_core.list.Workflows(["rna", "myWF"])


### PR DESCRIPTION
Turns out that nf-core/tools wasn't working on Py3.7 - see https://github.com/nf-core/tools/issues/393

This PR resolves those issues. Namely:

- Don't use `os.errno` as this is gone in Python 3.7 (`import errno` instead)
- `requests_cache` cache is python version specific, so include version number in cache directory
- Remove single usage of `nose`

@sven1103 - the requests cache directory continues to provide entertainment!! 😅 

I also cleaned up a Travis bug where it tried to build and push the API docs, even on forks.

Travis should now test Py 3.7 as well, and _hopefully_ it'll be passing now....