### PR TITLE
nf-core download: Get nf-core/configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * nf-core launch now uses stable parameter schema version 0.1.0
 * Check that PR from patch or dev branch is acceptable by linting
 * Made code compatible with Python 3.7
+* The `download` command now also fetches institutional configs from nf-core/configs
 
 ### Syncing
 

--- a/tests/lint_examples/minimal_working_example/nextflow.config
+++ b/tests/lint_examples/minimal_working_example/nextflow.config
@@ -3,6 +3,8 @@ params {
   outdir = './results'
   reads = "data/*.fastq"
   singleEnd = false
+  custom_config_version = 'master'
+  custom_config_base = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
 }
 
 process {

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -3,6 +3,7 @@
 """
 
 import nf_core.list
+import nf_core.utils
 from nf_core.download import DownloadWorkflow
 
 import hashlib
@@ -14,6 +15,8 @@ import requests
 import shutil
 import tempfile
 import unittest
+
+PATH_WORKING_EXAMPLE = os.path.join(os.path.dirname(__file__), 'lint_examples/minimal_working_example')
 
 class DownloadTest(unittest.TestCase):
 
@@ -112,6 +115,36 @@ class DownloadTest(unittest.TestCase):
         download_obj.wf_sha = "1.0"
         download_obj.wf_download_url = "https://github.com/nf-core/methylseq/archive/1.0.zip"
         download_obj.download_wf_files()
+
+    #
+    # Tests for 'download_configs'
+    #
+    def test_download_configs(self):
+        download_obj = DownloadWorkflow(
+            pipeline = "dummy",
+            release = "1.2.0",
+            outdir = tempfile.mkdtemp()
+            )
+        download_obj.download_configs()
+
+    #
+    # Tests for 'wf_use_local_configs'
+    #
+    def test_wf_use_local_configs(self):
+        # Get a workflow and configs
+        test_outdir = tempfile.mkdtemp()
+        download_obj = DownloadWorkflow(
+            pipeline = "dummy",
+            release = "1.2.0",
+            outdir = test_outdir
+            )
+        shutil.copytree(PATH_WORKING_EXAMPLE, os.path.join(test_outdir, 'workflow'))
+        download_obj.download_configs()
+
+        # Test the function
+        download_obj.wf_use_local_configs()
+        wf_config = nf_core.utils.fetch_wf_config(os.path.join(test_outdir, 'workflow'))
+        assert wf_config['params.custom_config_base'] == "'../configs/'"
 
     #
     # Tests for 'find_container_images'


### PR DESCRIPTION
Added to the `nf-core download` command so that it also fetches the configs repo.

1. Downloads and extracts a zip file of the configs master
2. Edits the downloaded pipeline `nextflow.config` file so that `https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}` is switched with `../configs/`

Doing this means that the pipeline is automatically configured to use the downloaded configs, so institutional profiles continue to work offline.

@sven1103 - I even added some tests!!

Phil