### PR TITLE
Download tar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Check that PR from patch or dev branch is acceptable by linting
 * Made code compatible with Python 3.7
 * The `download` command now also fetches institutional configs from nf-core/configs
+* The `download` command can now compress files into a single archive
 
 ### Syncing
 

--- a/nf_core/bump_version.py
+++ b/nf_core/bump_version.py
@@ -20,7 +20,7 @@ def bump_pipeline_version(lint_obj, new_version):
     # Collect the old and new version numbers
     current_version = lint_obj.config.get('manifest.version', '').strip(' \'"')
     if new_version.startswith('v'):
-        logging.warn("Stripping leading 'v' from new version number")
+        logging.warning("Stripping leading 'v' from new version number")
         new_version = new_version[1:]
     if not current_version:
         logging.error("Could not find config variable manifest.version")

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -62,7 +62,7 @@ class PipelineCreate(object):
         # Check if the output directory exists
         if os.path.exists(self.outdir):
             if self.force:
-                logging.warn("Output directory '{}' exists - continuing as --force specified".format(self.outdir))
+                logging.warning("Output directory '{}' exists - continuing as --force specified".format(self.outdir))
             else:
                 logging.error("Output directory '{}' exists!".format(self.outdir))
                 logging.info("Use -f / --force to overwrite existing files")

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -151,7 +151,7 @@ class DownloadWorkflow(object):
                 elif not self.release:
                     self.release = 'dev'
                     self.wf_sha = 'master' # Cheating a little, but GitHub download link works
-                    logging.warn("Pipeline is in development - downloading current code on master branch.\n" +
+                    logging.warning("Pipeline is in development - downloading current code on master branch.\n" +
                         "This is likely to change soon should not be considered fully reproducible.")
 
                 # Set outdir name if not defined
@@ -167,7 +167,7 @@ class DownloadWorkflow(object):
         # If we got this far, must not be a nf-core pipeline
         if self.pipeline.count('/') == 1:
             # Looks like a GitHub address - try working with this repo
-            logging.warn("Pipeline name doesn't match any nf-core workflows")
+            logging.warning("Pipeline name doesn't match any nf-core workflows")
             logging.info("Pipeline name looks like a GitHub address - attempting to download anyway")
             self.wf_name = self.pipeline
             if not self.release:

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -361,7 +361,7 @@ class Launch(object):
                 if val:
                     self.nextflow_cmd = "{} {}".format(self.nextflow_cmd, flag)
                 else:
-                    logging.warn("TODO: Can't set false boolean flags currently.")
+                    logging.warning("TODO: Can't set false boolean flags currently.")
             # String values
             else:
                 self.nextflow_cmd = '{} {} "{}"'.format(self.nextflow_cmd, flag, val.replace('"', '\\"'))

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -803,6 +803,6 @@ class PipelineLint(object):
         if len(self.passed) > 0:
             logging.debug("{}\n  {}".format(click.style("Test Passed:", fg='green'), "\n  ".join(["http://nf-co.re/errors#{}: {}".format(eid, msg) for eid, msg in self.passed])))
         if len(self.warned) > 0:
-            logging.warn("{}\n  {}".format(click.style("Test Warnings:", fg='yellow'), "\n  ".join(["http://nf-co.re/errors#{}: {}".format(eid, msg) for eid, msg in self.warned])))
+            logging.warning("{}\n  {}".format(click.style("Test Warnings:", fg='yellow'), "\n  ".join(["http://nf-co.re/errors#{}: {}".format(eid, msg) for eid, msg in self.warned])))
         if len(self.failed) > 0:
             logging.error("{}\n  {}".format(click.style("Test Failures:", fg='red'), "\n  ".join(["http://nf-co.re/errors#{}: {}".format(eid, msg) for eid, msg in self.failed])))

--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -123,9 +123,15 @@ def launch(pipeline, params, direct):
     type = str,
     help = "Output directory"
 )
-def download(pipeline, release, singularity, outdir):
+@click.option(
+    '-c', '--compress',
+    type = click.Choice(['tar.gz', 'tar.bz2', 'zip', 'none']),
+    default = 'tar.gz',
+    help = "Compression type"
+)
+def download(pipeline, release, singularity, outdir, compress):
     """ Download a pipeline and singularity container """
-    dl = nf_core.download.DownloadWorkflow(pipeline, release, singularity, outdir)
+    dl = nf_core.download.DownloadWorkflow(pipeline, release, singularity, outdir, compress)
     dl.download_workflow()
 
 # nf-core licences

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -215,11 +215,11 @@ class DownloadTest(unittest.TestCase):
     def test_download_workflow_with_success(self,
         mock_download_image):
 
-        tmp_dir = os.path.join(tempfile.mkdtemp(), 'new')
+        tmp_dir = tempfile.mkdtemp()
 
         download_obj = DownloadWorkflow(
             pipeline = "nf-core/methylseq",
-            outdir = tmp_dir,
+            outdir = os.path.join(tmp_dir, 'new'),
             singularity = True)
 
         download_obj.download_workflow()


### PR DESCRIPTION
New feature for `nf-core download` - compress the downloaded files into a single archive. Uses `.tar.gz` by default, can also choose `.tar.bz2`, `.zip` or to not compress.

Logging gives command needed to decompress files, as well as a MD5 checksum for the file.