### PR TITLE
Template Dockerfile: use tagged nfcore/base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Add proper `nf-core` logo for tools
 * Add `Quick Start` section to main README of template
 * Fix [Docker RunOptions](https://github.com/nf-core/tools/pull/351) to get UID and GID set in the template
+* `Dockerfile` now specifically uses the proper release tag of the nfcore/base image
 * Use [`file`](https://github.com/nf-core/tools/pull/354) instead of `new File`
   to avoid weird behavior such as making an `s3:/` directory locally when using
   an AWS S3 bucket as the `--outdir`.

--- a/docs/lint_errors.md
+++ b/docs/lint_errors.md
@@ -195,7 +195,7 @@ If a workflow has a conda `environment.yml` file (see above), the `Dockerfile` s
 to create the container. Such `Dockerfile`s can usually be very short, eg:
 
 ```Dockerfile
-FROM nfcore/base
+FROM nfcore/base:1.7
 LABEL authors="your@email.com" \
       description="Container image containing all requirements for nf-core/EXAMPLE pipeline"
 
@@ -207,6 +207,9 @@ To enforce this minimal `Dockerfile` and check for common copy+paste errors, we 
 that the above template is used.
 Failures are generated if the `FROM`, `COPY` and `RUN` statements above are not present.
 These lines must be an exact copy of the above example.
+
+Note that the base `nfcore/base` image should be tagged to the most recent release.
+The linting tool compares the tag against the currently installed version.
 
 Additional lines and different metadata can be added without causing the test to fail.
 

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -81,7 +81,8 @@ class PipelineCreate(object):
                 'author': self.author,
                 'name_noslash': self.name_noslash,
                 'name_docker': self.name_docker,
-                'version': self.new_version
+                'version': self.new_version,
+                'nf_core_version': nf_core.__version__
             },
             no_input = True,
             overwrite_if_exists = self.force,

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -756,7 +756,7 @@ class PipelineLint(object):
             return
 
         expected_strings = [
-            'FROM nfcore/base',
+            "FROM nfcore/base:{}".format('dev' if 'dev' in nf_core.__version__ else nf_core.__version__),
             'COPY environment.yml /',
             'RUN conda env create -f /environment.yml && conda clean -a',
             'ENV PATH /opt/conda/envs/{}/bin:$PATH'.format(self.conda_config['name'])

--- a/nf_core/pipeline-template/cookiecutter.json
+++ b/nf_core/pipeline-template/cookiecutter.json
@@ -4,5 +4,6 @@
     "author": "Rocky Balboa",
     "name_noslash": "{{ cookiecutter.name.replace('/', '-') }}",
     "name_docker": "{{ cookiecutter.name_docker }}",
-    "version": "1.0dev"
+    "version": "1.0dev",
+    "nf_core_version": "{{ cookiecutter.nf_core_version }}"
 }

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/Dockerfile
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/Dockerfile
@@ -1,4 +1,4 @@
-FROM nfcore/base
+FROM nfcore/base:{{ 'dev' if 'dev' in cookiecutter.nf_core_version else cookiecutter.nf_core_version }}
 LABEL authors="{{ cookiecutter.author }}" \
       description="Docker image containing all requirements for {{ cookiecutter.name }} pipeline"
 

--- a/tests/lint_examples/minimal_working_example/Dockerfile
+++ b/tests/lint_examples/minimal_working_example/Dockerfile
@@ -1,4 +1,4 @@
-FROM nfcore/base
+FROM nfcore/base:dev
 MAINTAINER Phil Ewels <phil.ewels@scilifelab.se>
 LABEL authors="phil.ewels@scilifelab.se" \
     description="Docker image containing all requirements for the nf-core tools pipeline"


### PR DESCRIPTION
Instead of always using `nfcore/base` as the base image in the `Dockerfile`, use the tag from the current release being used (eg. `nfcore/base:1.7`). If the current version contains the word `dev`, just pull the `dev` tag instead (eg. `nfcore/base:dev`).

Closes nf-core/tools#335