### PR TITLE
Template: Fix ANSI codes in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Add new code for Travis CI to allow PRs from patch branches too
 * Fix small typo in central readme of tools for future releases
 * Small code polishing + typo fix in the template main.nf file
+* Header ANSI codes no longer print `[2m` to console when using `-with-ansi`
 * Switched to yaml.safe_load() to fix PyYAML warning that was thrown because of a possible [exploit](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation)
 * Add `nf-core` citation
 * Add proper `nf-core` logo for tools

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
@@ -153,7 +153,7 @@ if(params.email || params.email_on_fail) {
   summary['MultiQC maxsize'] = params.maxMultiqcEmailFileSize
 }
 log.info summary.collect { k,v -> "${k.padRight(18)}: $v" }.join("\n")
-log.info "\033[2m----------------------------------------------------\033[0m"
+log.info "-\033[2m--------------------------------------------------\033[0m-"
 
 // Check the hostnames against configured profiles
 checkHostname()
@@ -403,14 +403,14 @@ def nfcoreHeader(){
     c_cyan = params.monochrome_logs ? '' : "\033[0;36m";
     c_white = params.monochrome_logs ? '' : "\033[0;37m";
 
-    return """    ${c_dim}----------------------------------------------------${c_reset}
+    return """    -${c_dim}--------------------------------------------------${c_reset}-
                                             ${c_green},--.${c_black}/${c_green},-.${c_reset}
     ${c_blue}        ___     __   __   __   ___     ${c_green}/,-._.--~\'${c_reset}
     ${c_blue}  |\\ | |__  __ /  ` /  \\ |__) |__         ${c_yellow}}  {${c_reset}
     ${c_blue}  | \\| |       \\__, \\__/ |  \\ |___     ${c_green}\\`-._,-`-,${c_reset}
                                             ${c_green}`._,._,\'${c_reset}
     ${c_purple}  {{ cookiecutter.name }} v${workflow.manifest.version}${c_reset}
-    ${c_dim}----------------------------------------------------${c_reset}
+    -${c_dim}--------------------------------------------------${c_reset}-
     """.stripIndent()
 }
 


### PR DESCRIPTION
Refactoring all of the header code to use the `Ansi` library like Nextflow does was too much hard work. I figured it was weird that we were only getting the partial code shown for the codes at the start of the strings though, so played around with that. Sure enough - if there is a character before the first code, then the existing code works fine.

So, now, we have some bling _undimmed_  hyphens are the start of the log. I added one at the end of the hyphen line too, to make it symmetrical:

![image](https://user-images.githubusercontent.com/465550/66288300-f3a88b80-e8d8-11e9-8ef8-f8219d01634d.png)

Sparkly! ✨ And seems to fix #329.. ✅ 