### PR TITLE
Linting: single_end and igenomes_ignore now must be snake case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Change remaining parameters from `camelCase` to `snakeCase` [#39](https://github.com/nf-core/hic/issues/39)
   * `--singleEnd` to `--single_end`
   * `--igenomesIgnore` to `--igenomes_ignore`
+  * Having the old camelCase versions of these will now throw an error
 * Add `autoMounts=true` to default singularity profile
 * Add in `markdownlint` checks that were being ignored by default
 

--- a/docs/lint_errors.md
+++ b/docs/lint_errors.md
@@ -93,9 +93,9 @@ The following variables throw warnings if missing:
   * If the pipeline version number contains the string `dev`, the dockerhub tag must be `:dev`
 * `params.reads`
   * Input parameter to specify input data (typically FastQ files / pairs)
-* `params.singleEnd`
+* `params.single_end`
   * Specify to work with single-end sequence data instead of default paired-end
-  * Used with Nextflow: `.fromFilePairs( params.reads, size: params.singleEnd ? 1 : 2 )`
+  * Used with Nextflow: `.fromFilePairs( params.reads, size: params.single_end ? 1 : 2 )`
 
 The following variables are depreciated and fail the test if they are still present:
 
@@ -105,6 +105,8 @@ The following variables are depreciated and fail the test if they are still pres
   * The old method for specifying the minimum Nextflow version. Replaced by `manifest.nextflowVersion`
 * `params.container`
   * The old method for specifying the dockerhub container address. Replaced by `process.container`
+* `singleEnd` and `igenomesIgnore`
+  * Now using `snake_case` for all command line options
 
 ## Error #5 - Continuous Integration configuration ## {#5}
 

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -112,11 +112,11 @@ class PipelineLint(object):
             params.help = false
             params.outdir = './results'
             params.bam = false
-            params.singleEnd = false
+            params.single_end = false
             params.seqtype = 'dna'
             params.solver = 'glpk'
             params.igenomes_base = './iGenomes'
-            params.clusterOptions = false
+            params.cluster_options = false
             ...
     """
     def __init__(self, path):
@@ -351,13 +351,15 @@ class PipelineLint(object):
             'dag.file',
             'params.reads',
             'process.container',
-            'params.singleEnd'
+            'params.single_end'
         ]
         # Old depreciated vars - fail if present
         config_fail_ifdefined = [
             'params.version',
             'params.nf_required_version',
-            'params.container'
+            'params.container',
+            'params.singleEnd',
+            'params.igenomesIgnore'
         ]
 
         # Get the nextflow config for this pipeline

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -116,7 +116,7 @@ class PipelineLint(object):
             params.seqtype = 'dna'
             params.solver = 'glpk'
             params.igenomes_base = './iGenomes'
-            params.cluster_options = false
+            params.clusterOptions = false
             ...
     """
     def __init__(self, path):

--- a/tests/lint_examples/minimal_working_example/nextflow.config
+++ b/tests/lint_examples/minimal_working_example/nextflow.config
@@ -2,7 +2,7 @@
 params {
   outdir = './results'
   reads = "data/*.fastq"
-  singleEnd = false
+  single_end = false
   custom_config_version = 'master'
   custom_config_base = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
 }

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -38,7 +38,7 @@ PATHS_WRONG_LICENSE_EXAMPLE = [pf(WD, 'lint_examples/wrong_license_example'),
     pf(WD, 'lint_examples/license_incomplete_example')]
 
 # The maximum sum of passed tests currently possible
-MAX_PASS_CHECKS = 59
+MAX_PASS_CHECKS = 61
 # The additional tests passed for releases
 ADD_PASS_RELEASE = 1
 
@@ -112,14 +112,14 @@ class TestLint(unittest.TestCase):
         """Tests that config variable existence test works with good pipeline example"""
         good_lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         good_lint_obj.check_nextflow_config()
-        expectations = {"failed": 0, "warned": 0, "passed": 33}
+        expectations = {"failed": 0, "warned": 0, "passed": 35}
         self.assess_lint_status(good_lint_obj, **expectations)
 
     def test_config_variable_example_with_failed(self):
         """Tests that config variable existence test fails with bad pipeline example"""
         bad_lint_obj = nf_core.lint.PipelineLint(PATH_FAILING_EXAMPLE)
         bad_lint_obj.check_nextflow_config()
-        expectations = {"failed": 19, "warned": 8, "passed": 6}
+        expectations = {"failed": 19, "warned": 8, "passed": 8}
         self.assess_lint_status(bad_lint_obj, **expectations)
 
     @pytest.mark.xfail(raises=AssertionError)


### PR DESCRIPTION
As we're now moving to `snake_case` for all command line variables, the linter should be updated. Previously, a warning was thrown if `--singleEnd` was _not_ there. Now, it throws a warning if `--single_end` is not there and throws failures for `--singleEnd` and `--igenomesIgnore`.

 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated

