### PR TITLE
Travis disable ansi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   * `--igenomesIgnore` to `--igenomes_ignore`
 * Add `autoMounts=true` to default singularity profile
 * Add in `markdownlint` checks that were being ignored by default
+* Disable ansi logging in the travis CI tests.
 
 ### Other
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.travis.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.travis.yml
@@ -39,4 +39,4 @@ script:
   # Lint the documentation
   - markdownlint ${TRAVIS_BUILD_DIR} -c ${TRAVIS_BUILD_DIR}/.github/markdownlint.yml
   # Run the pipeline with the test profile
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker -ansi-log false


### PR DESCRIPTION
The nice new ansi logging is great in interactive terminals, but causes the Travis CI logs to be super super long and difficult to read. In this PR I just add `-ansi-log false` to the travis `nextflow run` commands.