### PR TITLE
Set PYTHONNOUSERSITE in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Add in `markdownlint` checks that were being ignored by default
 * Disable ansi logging in the travis CI tests.
 * Move `params`section from `base.config` to `nextflow.config`
+* Added environment variable `PYTHONNOUSERSITE` to template Dockerfile to try to prevent conflicts with host python environment.
 
 ### Other
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/Dockerfile
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/Dockerfile
@@ -2,7 +2,15 @@ FROM nfcore/base:{{ 'dev' if 'dev' in cookiecutter.nf_core_version else cookiecu
 LABEL authors="{{ cookiecutter.author }}" \
       description="Docker image containing all requirements for {{ cookiecutter.name }} pipeline"
 
+# Install the conda environment
 COPY environment.yml /
 RUN conda env create -f /environment.yml && conda clean -a
-RUN conda env export --name {{ cookiecutter.name_noslash }}-{{ cookiecutter.version }} > {{ cookiecutter.name_noslash }}-{{ cookiecutter.version }}.yml
+
+# Add conda installation dir to PATH (instead of doing 'conda activate')
 ENV PATH /opt/conda/envs/{{ cookiecutter.name_noslash }}-{{ cookiecutter.version }}/bin:$PATH
+
+# Dump the details of the installed packages to a file for posterity
+RUN conda env export --name {{ cookiecutter.name_noslash }}-{{ cookiecutter.version }} > {{ cookiecutter.name_noslash }}-{{ cookiecutter.version }}.yml
+
+# Prevent Python from loading packages from outside the container
+ENV PYTHONNOUSERSITE=1


### PR DESCRIPTION
Exporting `PYTHONNOUSERSITE` in the Dockerfile may hopefully prevent some of the weird Python conflict errors that we've seen recently, by preventing interaction with the Python environment outside of the container.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated