### PR TITLE
Add travis test support for nf-tower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Move `params`section from `base.config` to `nextflow.config`
 * Use `env` scope to export `PYTHONNOUSERSITE` in `nextflow.config` to prevent conflicts with host Python environment.
 * Bump minimum Nextflow version to `19.10.0` - required to properly use `env` scope in `nextflow.config`
+* Added support for nf-tower in the travis tests, using public mailbox nf-core@mailinator.com
 
 ### Other
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.travis.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.travis.yml
@@ -30,8 +30,13 @@ install:
   - sudo apt-get install npm && npm install -g markdownlint-cli
 
 env:
-  - NXF_VER='19.10.0' # Specify a minimum NF version that should be tested and work
-  - NXF_VER='' # Plus: get the latest NF version and check that it works
+  # Tower token is to inspect runs on https://tower.nf
+  # Use public mailbox nf-core@mailinator.com to log in: https://www.mailinator.com/v3/index.jsp?zone=public&query=nf-core
+  # Specify a minimum NF version that should be tested and work
+  - NXF_VER='19.10.0'  TOWER_ACCESS_TOKEN="1c1f493bc2703472d6f1b9f6fb9e9d117abab7b1"
+   # Plus: get the latest NF version and check that it works
+  - NXF_VER=''         TOWER_ACCESS_TOKEN="1c1f493bc2703472d6f1b9f6fb9e9d117abab7b1"
+
 
 script:
   # Lint the pipeline code
@@ -39,4 +44,4 @@ script:
   # Lint the documentation
   - markdownlint ${TRAVIS_BUILD_DIR} -c ${TRAVIS_BUILD_DIR}/.github/markdownlint.yml
   # Run the pipeline with the test profile
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker -ansi-log false
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker -ansi-log false -name {{ cookiecutter.short_name }}-${TRAVIS_EVENT_TYPE}-${TRAVIS_PULL_REQUEST}-${TRAVIS_COMMIT:0:6}-test-description


### PR DESCRIPTION
Now that https://github.com/nf-core/methylseq/pull/104 is passing, added support for nf-core@mailinator.com nf-tower monitoring to the template.