### PR TITLE
nf-core list: handle unreleased tags in pipelines.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Tools helper code
 
+* Fixed a bug that caused `nf-core list` to fail if there were unreleased tags in `pipelines.json`
 * Updated Blacklist of synced pipelines
 
 ### Template

--- a/nf_core/list.py
+++ b/nf_core/list.py
@@ -254,7 +254,7 @@ class RemoteWorkflow(object):
                 release['published_at_timestamp'] = int(datetime.datetime.strptime(release.get('published_at'), "%Y-%m-%dT%H:%M:%SZ").strftime("%s"))
             else:
                 release['published_at_pretty'] = str('unreleased')
-                release['published_at_timestamp'] = str('unreleased')
+                release['published_at_timestamp'] = int(0)
 
 
 class LocalWorkflow(object):

--- a/nf_core/list.py
+++ b/nf_core/list.py
@@ -247,10 +247,14 @@ class RemoteWorkflow(object):
 
         # Beautify date
         for release in self.releases:
-            release['published_at_pretty'] = pretty_date(
-                datetime.datetime.strptime(release.get('published_at'), "%Y-%m-%dT%H:%M:%SZ")
-            )
-            release['published_at_timestamp'] = int(datetime.datetime.strptime(release.get('published_at'), "%Y-%m-%dT%H:%M:%SZ").strftime("%s"))
+            if release.get('published_at') is not None:
+                release['published_at_pretty'] = pretty_date(
+                    datetime.datetime.strptime(release.get('published_at'), "%Y-%m-%dT%H:%M:%SZ")
+                )
+                release['published_at_timestamp'] = int(datetime.datetime.strptime(release.get('published_at'), "%Y-%m-%dT%H:%M:%SZ").strftime("%s"))
+            else:
+                release['published_at_pretty'] = str('unreleased')
+                release['published_at_timestamp'] = str('unreleased')
 
 
 class LocalWorkflow(object):


### PR DESCRIPTION
Many thanks to contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated

**Learn more about contributing:** https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md

Following up on: https://github.com/nf-core/tools/pull/453#issuecomment-554893748

I think this is `1.7.1` material, as  `nf-core list` is broken in `1.7`

You can reproduce the bug by running `nf-core list`


Previously, the list command would fail if there were unreleased tags in the pipelines.json,
because in that case',
the `published_at` field is not populated.

This commit adds a conditional that checks if the field is populated.