### PR TITLE
nf-core list: ignore pre-releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Tools helper code
 
 * Updated Blacklist of synced pipelines
+* Ignore pre-releases in `nf-core list`
 
 ### Template
 

--- a/nf_core/list.py
+++ b/nf_core/list.py
@@ -238,8 +238,8 @@ class RemoteWorkflow(object):
         self.watchers_count = data.get('watchers_count')
         self.forks_count = data.get('forks_count')
 
-        # Placeholder vars for releases info
-        self.releases = data.get('releases')
+        # Placeholder vars for releases info (ignore pre-releases)
+        self.releases = [ r for r in data.get('releases', []) if r.get('published_at') is not None ]
 
         # Placeholder vars for local comparison
         self.local_wf = None


### PR DESCRIPTION
Fixes crash in `nf-core list` caused by pre-releases with no release date.

Alternative implementation of https://github.com/nf-core/tools/pull/455