### PR TITLE
Launch: fix double hyphen typo in final command example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Updated Blacklist of synced pipelines
 * Ignore pre-releases in `nf-core list`
 * Lint for `Singularity` file [and remove it](https://github.com/nf-core/tools/issues/458)
+* Fixed typo in `nf-core launch` final command
 
 ### Linting
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Specify the location of your input FastQ files.
 [..truncated..]
 
 Nextflow command:
-  nextflow run nf-core/rnaseq -profile "docker" -name "test_run" -r "1.3" --params-file "/Users/ewels/testing/nfx-params.json"
+  nextflow run nf-core/rnaseq -profile "docker" -name "test_run" -r "1.3" -params-file "/Users/ewels/testing/nfx-params.json"
 
 
 Do you want to run this command now? [y/N]: y

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -370,7 +370,7 @@ class Launch(object):
         if self.use_params_file:
             path = self.create_nfx_params_file()
             if path is not None:
-                self.nextflow_cmd = '{} {} "{}"'.format(self.nextflow_cmd, "--params-file", path)
+                self.nextflow_cmd = '{} {} "{}"'.format(self.nextflow_cmd, "-params-file", path)
             self.write_params_as_full_json()
 
         # Call nextflow with a list of command line flags


### PR DESCRIPTION
The `nf-core launch` command finishes by printing a command to the terminal for the user to run. It had a typo, with a double-hyphen for a core nextflow flag (`-params-file`).