### PR TITLE
List: Handle missing description when searching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Lint for `Singularity` file [and remove it](https://github.com/nf-core/tools/issues/458)
 * Updated documentation for `nf-core download`
 * Fixed typo in `nf-core launch` final command
+* Handle missing pipeline descriptions in `nf-core list`
 
 ### Linting
 

--- a/nf_core/list.py
+++ b/nf_core/list.py
@@ -145,8 +145,8 @@ class Workflows(object):
         filtered_workflows = []
         for wf in self.remote_workflows:
             for k in self.keyword_filters:
-                in_name = k in wf.name
-                in_desc = k in wf.description
+                in_name = k in wf.name if wf.name else False
+                in_desc = k in wf.description if wf.description else False
                 in_topics = any([ k in t for t in wf.topics])
                 if not in_name and not in_desc and not in_topics:
                     break


### PR DESCRIPTION
`nf-core list` broke when searching for keywords because a new template didn't have a description.

This fix handles the case when the name (??) or description could be false.