### PR TITLE
CI Tests: Force package version to be dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required
 language: python
 jdk: openjdk8
 python:
-  - '2.7'
   - '3.5'
   - '3.6'
   - '3.7'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Lint for `Singularity` file [and remove it](https://github.com/nf-core/tools/issues/458)
 * Added linting of GitHub actions workflows `linting.yml`, `ci.yml` and `branch.yml`
 * Warn if pipeline name contains upper case letters or non alphabetical characters [#85](https://github.com/nf-core/tools/issues/85)
+* Make CI tests of lint code pass for releases
 
 ### Template pipeline
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -42,6 +42,10 @@ MAX_PASS_CHECKS = 77
 # The additional tests passed for releases
 ADD_PASS_RELEASE = 1
 
+# The minimal working example expects a development release version
+if 'dev' not in nf_core.__version__:
+    nf_core.__version__ = '{}dev'.format(nf_core.__version__)
+
 class TestLint(unittest.TestCase):
     """Class for lint tests"""
 
@@ -127,7 +131,7 @@ class TestLint(unittest.TestCase):
         """Tests that config variable existence test falls over nicely with nextflow can't run"""
         bad_lint_obj = nf_core.lint.PipelineLint('/non/existant/path')
         bad_lint_obj.check_nextflow_config()
-    
+
     def test_actions_wf_branch_pass(self):
         """Tests that linting for GitHub actions workflow for branch protection works for a good example"""
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
@@ -135,7 +139,7 @@ class TestLint(unittest.TestCase):
         lint_obj.check_actions_branch_protection()
         expectations = {"failed": 0, "warned": 0, "passed": 2}
         self.assess_lint_status(lint_obj, **expectations)
-    
+
     def test_actions_wf_branch_fail(self):
         """Tests that linting for Github actions workflow for branch protection fails for a bad example"""
         lint_obj = nf_core.lint.PipelineLint(PATH_FAILING_EXAMPLE)


### PR DESCRIPTION
Currently, CI tests on the linting code fail when the package version is stable.

This is because the minimal working example hardcodes `dev` for the Dockerfile version:
https://github.com/nf-core/tools/blob/615c6a57d0cddefb7f38bac1c4ea83704bfd9214/tests/lint_examples/minimalworkingexample/Dockerfile#L1

The template tags this Dockerfile version based on the active python version number:
https://github.com/nf-core/tools/blob/615c6a57d0cddefb7f38bac1c4ea83704bfd9214/nf_core/pipeline-template/%7B%7Bcookiecutter.name_noslash%7D%7D/Dockerfile#L1

The lint code checks for the same:
https://github.com/nf-core/tools/blob/615c6a57d0cddefb7f38bac1c4ea83704bfd9214/nf_core/lint.py#L920

This fix is a little hacky, but basically just makes the package version number include `dev` if it doesn't, so that the CI tests run properly.

One day we should probably refactor how these tests work to get around these kinds of problems.. But for now this should get things working again, in lieu of a fairly complete rewrite.