### PR TITLE
Lint errors: pad with whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Linting
 
 * Removed linting for circleci
+* Added whitespace padding to lint error URLs
 
 ## v1.8
 

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -975,8 +975,8 @@ class PipelineLint(object):
             click.style("{0:>4} tests failed".format(len(self.failed)), fg='red') + rl
         )
         if len(self.passed) > 0:
-            logging.debug("{}\n  {}".format(click.style("Test Passed:", fg='green'), "\n  ".join(["http://nf-co.re/errors#{}: {}".format(eid, msg) for eid, msg in self.passed])))
+            logging.debug("{}\n  {}".format(click.style("Test Passed:", fg='green'), "\n  ".join(["http://nf-co.re/errors#{} : {}".format(eid, msg) for eid, msg in self.passed])))
         if len(self.warned) > 0:
-            logging.warning("{}\n  {}".format(click.style("Test Warnings:", fg='yellow'), "\n  ".join(["http://nf-co.re/errors#{}: {}".format(eid, msg) for eid, msg in self.warned])))
+            logging.warning("{}\n  {}".format(click.style("Test Warnings:", fg='yellow'), "\n  ".join(["http://nf-co.re/errors#{} : {}".format(eid, msg) for eid, msg in self.warned])))
         if len(self.failed) > 0:
-            logging.error("{}\n  {}".format(click.style("Test Failures:", fg='red'), "\n  ".join(["http://nf-co.re/errors#{}: {}".format(eid, msg) for eid, msg in self.failed])))
+            logging.error("{}\n  {}".format(click.style("Test Failures:", fg='red'), "\n  ".join(["http://nf-co.re/errors#{} : {}".format(eid, msg) for eid, msg in self.failed])))


### PR DESCRIPTION
The http://nf-co.re/errors links can be corrupted in some cases by having an adjacent `:` character. Adding a space after the link should resolve this.

Reported by @MaxUlysse