### PR TITLE
Linting: Allow !>= for minimum nextflow version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Removed linting for CircleCI
 * Added whitespace padding to lint error URLs
 * Improved documentation for lint errors
+* Allow either `>=` or `!>=` in nextflow version checks (the latter exits with an error instead of just warning) [#506](https://github.com/nf-core/tools/issues/506)
 
 ### Other
 

--- a/docs/lint_errors.md
+++ b/docs/lint_errors.md
@@ -75,7 +75,8 @@ The following variables fail the test if missing:
   * The version of this pipeline. This should correspond to a [GitHub release](https://help.github.com/articles/creating-releases/).
 * `manifest.nextflowVersion`
   * The minimum version of Nextflow required to run the pipeline.
-  * Should `>=` a version number, eg. `manifest.nextflowVersion = '>=0.31.0'` (check the [Nexftlow documentation](https://www.nextflow.io/docs/latest/config.html#scope-manifest) for more.)
+  * Should `>=` or `!>=` a version number, eg. `manifest.nextflowVersion = '>=0.31.0'` (check the [Nexftlow documentation](https://www.nextflow.io/docs/latest/config.html#scope-manifest) for more.)
+  * `>=` warns about old versions but tries to run anyway, `!>=` fails for old versions. Only use the latter if you _know_ that the pipeline will certainly fail before this version.
   * This should correspond to the `NXF_VER` version tested by Travis.
 * `manifest.homePage`
   * The homepage for the pipeline. Should be the nf-core GitHub repository URL,

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -463,8 +463,8 @@ class PipelineLint(object):
 
         # Check that the minimum nextflowVersion is set properly
         if 'manifest.nextflowVersion' in self.config:
-            if self.config.get('manifest.nextflowVersion', '').strip('"\'').startswith('>='):
-                self.passed.append((4, "Config variable 'manifest.nextflowVersion' started with >="))
+            if self.config.get('manifest.nextflowVersion', '').strip('"\'').lstrip('!').startswith('>='):
+                self.passed.append((4, "Config variable 'manifest.nextflowVersion' started with >= or !>="))
                 # Save self.minNextflowVersion for convenience
                 nextflowVersionMatch = re.search(r'[0-9\.]+(-edge)?', self.config.get('manifest.nextflowVersion', ''))
                 if nextflowVersionMatch:
@@ -472,7 +472,7 @@ class PipelineLint(object):
                 else:
                     self.minNextflowVersion = None
             else:
-                self.failed.append((4, "Config variable 'manifest.nextflowVersion' did not start with '>=' : '{}'".format(self.config.get('manifest.nextflowVersion', '')).strip('"\'')))
+                self.failed.append((4, "Config variable 'manifest.nextflowVersion' did not start with '>=' or '!>=' : '{}'".format(self.config.get('manifest.nextflowVersion', '')).strip('"\'')))
 
         # Check that the process.container name is pulling the version tag or :dev
         if self.config.get('process.container'):


### PR DESCRIPTION
Linting: Allow `!>=` as well as `>=` for minimum nextflow version check

Closes https://github.com/nf-core/tools/issues/506

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated
