### PR TITLE
Don't clobber MultiQC config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: required
 language: python
 jdk: openjdk8
 python:
-  - '3.5'
   - '3.6'
   - '3.7'
+  - '3.8'
 before_install:
   # PRs to master are only ok if coming from dev branch
   - '[ $TRAVIS_PULL_REQUEST = "false" ] || [ $TRAVIS_BRANCH != "master" ] || ([ $TRAVIS_PULL_REQUEST_SLUG = $TRAVIS_REPO_SLUG ] && ([ $TRAVIS_PULL_REQUEST_BRANCH = "dev" ] || [ $TRAVIS_PULL_REQUEST_BRANCH = "patch" ]))'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Rewrote the documentation markdown > HTML conversion in Python instead of R
 * Removed the requirement for R in the conda environment
+* Make `params.multiqc_config` give an _additional_ MultiQC config file instead of replacing the one that ships with the pipeline
 
 ### Linting
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/assets/multiqc_config.yaml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/assets/multiqc_config.yaml
@@ -3,7 +3,9 @@ report_comment: >
     analysis pipeline. For information about how to interpret these results, please see the
     <a href="https://github.com/{{ cookiecutter.name }}" target="_blank">documentation</a>.
 report_section_order:
-    {{ cookiecutter.name.lower().replace(' ', '-') }}-software-versions:
+    software_versions:
         order: -1000
+    {{ cookiecutter.name.lower().replace('/', '-') }}-summary:
+        order: -1001
 
 export_plots: true

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
@@ -91,7 +91,7 @@ if (workflow.profile.contains('awsbatch')) {
 
 // Stage config files
 ch_multiqc_config = file("$baseDir/assets/multiqc_config.yaml", checkIfExists: true)
-ch_multiqc_custom_config = params.multiqc_config ? file(params.multiqc_config, checkIfExists: true) : Channel.empty()
+ch_multiqc_custom_config = params.multiqc_config ? Channel.fromPath(params.multiqc_config, checkIfExists: true) : Channel.empty()
 ch_output_docs = file("$baseDir/docs/output.md", checkIfExists: true)
 
 /*
@@ -226,8 +226,8 @@ process multiqc {
     publishDir "${params.outdir}/MultiQC", mode: 'copy'
 
     input:
-    file multiqc_config from ch_multiqc_config
-    file multiqc_config from ch_multiqc_custom_config.collect().ifEmpty([])
+    file (multiqc_config) from ch_multiqc_config
+    file (mqc_custom_config) from ch_multiqc_custom_config.collect().ifEmpty([])
     // TODO nf-core: Add in log files from your new processes for MultiQC to find!
     file ('fastqc/*') from ch_fastqc_results.collect().ifEmpty([])
     file ('software_versions/*') from ch_software_versions_yaml.collect()
@@ -241,10 +241,10 @@ process multiqc {
     script:
     rtitle = custom_runName ? "--title \"$custom_runName\"" : ''
     rfilename = custom_runName ? "--filename " + custom_runName.replaceAll('\\W','_').replaceAll('_+','_') + "_multiqc_report" : ''
-    custom_config_file = params.multiqc_config ? "--config $ch_multiqc_custom_config"
+    custom_config_file = params.multiqc_config ? "--config $mqc_custom_config" : ''
     // TODO nf-core: Specify which MultiQC modules to use with -m for a faster run time
     """
-    multiqc -f $rtitle $rfilename --config $multiqc_config $custom_config_file .
+    multiqc -f $rtitle $rfilename $custom_config_file .
     """
 }
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
@@ -17,7 +17,7 @@ params {
 
   // Boilerplate options
   name = false
-  multiqc_config = "$baseDir/assets/multiqc_config.yaml"
+  multiqc_config = false
   email = false
   email_on_fail = false
   max_multiqc_email_size = 25.MB


### PR DESCRIPTION
MultiQC config: If `--multiqc_config` given, supply this to MultQC _in addition_ to the config that is bundled with the pipeline instead of clobbering it.

This hit this when the pipeline failed due to missing output files because we didn't have `export_plot: true` in our custom MultiQC config file.

The config files are loaded in order, so it should be possible to overwrite anything that's in the bundled MultiQC config file still.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated
