### PR TITLE
Linting: check for 'dev' in pipeline version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * Improved documentation for lint errors
 * Allow either `>=` or `!>=` in nextflow version checks (the latter exits with an error instead of just warning) [#506](https://github.com/nf-core/tools/issues/506)
 * Check that `manifest.version` ends in `dev` and throw a warning if not
-    * If running with `--release` check the opposite and fail if not
+  * If running with `--release` check the opposite and fail if not
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Travis CI tests are now deprecated within the pipeline template. Please switch to GitHub Actions.
   * `nf-core bump-version` support has been removed for `.travis.yml`
   * `nf-core lint` now fails if a `.travis.yml` file is found
-  
+
 ### Template
 
 * Rewrote the documentation markdown > HTML conversion in Python instead of R
@@ -20,6 +20,8 @@
 * Added whitespace padding to lint error URLs
 * Improved documentation for lint errors
 * Allow either `>=` or `!>=` in nextflow version checks (the latter exits with an error instead of just warning) [#506](https://github.com/nf-core/tools/issues/506)
+* Check that `manifest.version` ends in `dev` and throw a warning if not
+    * If running with `--release` check the opposite and fail if not
 
 ### Other
 

--- a/docs/lint_errors.md
+++ b/docs/lint_errors.md
@@ -121,8 +121,6 @@ The following variables are depreciated and fail the test if they are still pres
 Process-level configuration syntax is checked and fails if uses the old Nextflow syntax, for example:
 `process.$fastqc` instead of `process withName:'fastqc'`.
 
-
-
 ## Error #5 - Continuous Integration configuration ## {#5}
 
 nf-core pipelines must have CI testing with GitHub Actions.

--- a/docs/lint_errors.md
+++ b/docs/lint_errors.md
@@ -72,6 +72,8 @@ The following variables fail the test if missing:
   * A description of the pipeline
 * `manifest.version`
   * The version of this pipeline. This should correspond to a [GitHub release](https://help.github.com/articles/creating-releases/).
+  * If `--release` is set when running `nf-core lint`, the version number must not contain the string `dev`
+  * If `--release` is _not_ set, the version should end in `dev` (warning triggered if not)
 * `manifest.nextflowVersion`
   * The minimum version of Nextflow required to run the pipeline.
   * Should be `>=` or `!>=` and a version number, eg. `manifest.nextflowVersion = '>=0.31.0'` (see [Nextflow documentation](https://www.nextflow.io/docs/latest/config.html#scope-manifest))
@@ -81,7 +83,7 @@ The following variables fail the test if missing:
   * The homepage for the pipeline. Should be the nf-core GitHub repository URL,
     so beginning with `https://github.com/nf-core/`
 * `timeline.enabled`, `trace.enabled`, `report.enabled`, `dag.enabled`
-  * The nextflow timeline, trace, report and DAG should be enabled by default
+  * The nextflow timeline, trace, report and DAG should be enabled by default (set to `true`)
 * `process.cpus`, `process.memory`, `process.time`
   * Default CPUs, memory and time limits for tasks
 
@@ -97,7 +99,7 @@ The following variables throw warnings if missing:
 * `process.container`
   * Dockerhub handle for a single default container for use by all processes.
   * Must specify a tag that matches the pipeline version number if set.
-  * If the pipeline version number contains the string `dev`, the dockerhub tag must be `:dev`
+  * If the pipeline version number contains the string `dev`, the DockerHub tag must be `:dev`
 * `params.reads`
   * Input parameter to specify input data (typically FastQ files / pairs)
 * `params.single_end`
@@ -115,6 +117,11 @@ The following variables are depreciated and fail the test if they are still pres
 * `singleEnd` and `igenomesIgnore`
   * Changed to `single_end` and `igenomes_ignore`
   * The `snake_case` convention should now be used when defining pipeline parameters
+
+Process-level configuration syntax is checked and fails if uses the old Nextflow syntax, for example:
+`process.$fastqc` instead of `process withName:'fastqc'`.
+
+
 
 ## Error #5 - Continuous Integration configuration ## {#5}
 

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -484,6 +484,18 @@ class PipelineLint(object):
             else:
                 self.passed.append((4, "Config variable process.container looks correct: '{}'".format(container_name)))
 
+        # Check that the pipeline version contains `dev`
+        if not self.release_mode and 'manifest.version' in self.config:
+            if self.config['manifest.version'].strip(' \'"').endswith('dev'):
+                self.passed.append((4, "Config variable manifest.version ends in 'dev': '{}'".format(self.config['manifest.version'])))
+            else:
+                self.warned.append((4, "Config variable manifest.version should end in 'dev': '{}'".format(self.config['manifest.version'])))
+        elif 'manifest.version' in self.config:
+            if 'dev' in self.config['manifest.version']:
+                self.failed.append((4, "Config variable manifest.version should not contain 'dev' for a release: '{}'".format(self.config['manifest.version'])))
+            else:
+                self.passed.append((4, "Config variable manifest.version does not contain 'dev' for release: '{}'".format(self.config['manifest.version'])))
+
     def check_actions_branch_protection(self):
         """Checks that the GitHub Actions branch protection workflow is valid.
 

--- a/tests/lint_examples/failing_example/nextflow.config
+++ b/tests/lint_examples/failing_example/nextflow.config
@@ -1,6 +1,7 @@
 manifest.homePage = 'http://nf-co.re/pipelines'
 manifest.name = 'pipelines'
 manifest.nextflowVersion = '0.30.1'
+manifest.version = '0.4dev'
 
 dag.file = "dag.html"
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -38,7 +38,7 @@ PATHS_WRONG_LICENSE_EXAMPLE = [pf(WD, 'lint_examples/wrong_license_example'),
     pf(WD, 'lint_examples/license_incomplete_example')]
 
 # The maximum sum of passed tests currently possible
-MAX_PASS_CHECKS = 70
+MAX_PASS_CHECKS = 71
 # The additional tests passed for releases
 ADD_PASS_RELEASE = 1
 
@@ -62,7 +62,7 @@ class TestLint(unittest.TestCase):
         This should not result in any exception for the minimal
         working example"""
         lint_obj = nf_core.lint.run_linting(PATH_WORKING_EXAMPLE, False)
-        expectations = {"failed": 0, "warned": 3, "passed": MAX_PASS_CHECKS}
+        expectations = {"failed": 0, "warned": 4, "passed": MAX_PASS_CHECKS-1}
         self.assess_lint_status(lint_obj, **expectations)
 
     @pytest.mark.xfail(raises=AssertionError)
@@ -116,14 +116,14 @@ class TestLint(unittest.TestCase):
         """Tests that config variable existence test works with good pipeline example"""
         good_lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         good_lint_obj.check_nextflow_config()
-        expectations = {"failed": 0, "warned": 0, "passed": 35}
+        expectations = {"failed": 0, "warned": 1, "passed": 35}
         self.assess_lint_status(good_lint_obj, **expectations)
 
     def test_config_variable_example_with_failed(self):
         """Tests that config variable existence test fails with bad pipeline example"""
         bad_lint_obj = nf_core.lint.PipelineLint(PATH_FAILING_EXAMPLE)
         bad_lint_obj.check_nextflow_config()
-        expectations = {"failed": 19, "warned": 8, "passed": 8}
+        expectations = {"failed": 18, "warned": 8, "passed": 10}
         self.assess_lint_status(bad_lint_obj, **expectations)
 
     @pytest.mark.xfail(raises=AssertionError)


### PR DESCRIPTION
Checks that the pipeline version looks like a development version. That is, that `manifest.version` ends in `dev`.

If running lint with `--release` then checks for the opposite.

Triggers a warning if dev not found when it should be, a failure if it is found when it shouldn't be.


## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated
