### PR TITLE
More GitHub Actions tweaks

### DIFF
--- a/.github/workflows/create-lint-wf.yml
+++ b/.github/workflows/create-lint-wf.yml
@@ -4,15 +4,12 @@ on: [push, pull_request]
 jobs:
   MakeTestWorkflow:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.6, 3.7, 3.8]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.7
         uses: actions/setup-python@v1
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.7
       - name: Install python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tools-api-docs.yml
+++ b/.github/workflows/tools-api-docs.yml
@@ -1,7 +1,7 @@
 name: Publish nf-core/tools API documentation
 on:
   push:
-    branches: [master]
+    branches: [master, dev]
 
 jobs:
   build-n-publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Travis CI tests are now deprecated within the pipeline template. Please switch to GitHub Actions.
   * `nf-core bump-version` support has been removed for `.travis.yml`
   * `nf-core lint` now fails if a `.travis.yml` file is found
-* Ported Travis CI to GitHub Actions for this nf-core/tools repository
+* Ported nf-core/tools Travis CI to GitHub Actions
 
 ### Template
 


### PR DESCRIPTION
* Don't need to create and test a workflow on all python versions
* Also build tools api docs on both dev and master for now - should mean I can actually get it running before the release
  * Can wind back to only master at a later date if we want to. Maybe can leave it like this though.