### PR TITLE
Remove api build dir from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 
 .coverage
 .pytest_cache
-docs/api/_build
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
Don’t ignore the built api docs!