### PR TITLE
Use stderr instead of stdout for header artwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 ### Other
 
 * Improve documentation for installing `nf-core/tools`
+* Use `stderr` instead of `stdout` for header artwork
 * Add details of the new nf-core publication in Nature Biotechnology :champagne:
 
 ### Template pipeline

--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -345,9 +345,9 @@ def sync(pipeline_dir, make_template_branch, from_branch, pull_request, username
 
 
 if __name__ == '__main__':
-    click.echo(click.style("\n                                          ,--.", fg='green')+click.style("/",fg='black')+click.style(",-.", fg='green'))
-    click.echo(click.style("          ___     __   __   __   ___     ", fg='blue')+click.style("/,-._.--~\\", fg='green'))
-    click.echo(click.style("    |\ | |__  __ /  ` /  \ |__) |__      ", fg='blue')+click.style("   }  {", fg='yellow'))
-    click.echo(click.style("    | \| |       \__, \__/ |  \ |___     ", fg='blue')+click.style("\`-._,-`-,", fg='green'))
-    click.secho("                                          `._,._,'\n", fg='green')
+    click.echo(click.style("\n                                          ,--.", fg='green')+click.style("/",fg='black')+click.style(",-.", fg='green'), err=True)
+    click.echo(click.style("          ___     __   __   __   ___     ", fg='blue')+click.style("/,-._.--~\\", fg='green'), err=True)
+    click.echo(click.style("    |\ | |__  __ /  ` /  \ |__) |__      ", fg='blue')+click.style("   }  {", fg='yellow'), err=True)
+    click.echo(click.style("    | \| |       \__, \__/ |  \ |___     ", fg='blue')+click.style("\`-._,-`-,", fg='green'), err=True)
+    click.secho("                                          `._,._,'\n", fg='green', err=True)
     nf_core_cli()


### PR DESCRIPTION
I realised that the header ascii artwork was being printed to `STDOUT`, when log messages etc go to `STDERR`.
Changed so that everything goes to `STDERR`.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

