### PR TITLE
Utils: Tolerate extra output from nextflow config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 * Improve documentation for installing `nf-core/tools`
 * Add details of the new nf-core publication in Nature Biotechnology :champagne:
+* Tolerate unexpected output from `nextflow config` command
 
 ### Template pipeline
 

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -59,7 +59,7 @@ def fetch_wf_config(wf_path, wf=None):
             try:
                 k, v = ul.split(' = ', 1)
                 config[k] = v
-            except ValueError(e):
+            except ValueError:
                 logging.debug("Couldn't find key=value config pair:\n  {}".format(ul))
 
     # If we can, save a cached copy

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -56,8 +56,11 @@ def fetch_wf_config(wf_path, wf=None):
     else:
         for l in nfconfig_raw.splitlines():
             ul = l.decode('utf-8')
-            k, v = ul.split(' = ', 1)
-            config[k] = v
+            try:
+                k, v = ul.split(' = ', 1)
+                config[k] = v
+            except ValueError(e):
+                logging.debug("Couldn't find key=value config pair:\n  {}".format(ul))
 
     # If we can, save a cached copy
     if cache_path:


### PR DESCRIPTION
We had an error where the config parsing code broke because it couldn't tolerate unexpected output from the `nextflow config` command:

```python
Traceback (most recent call last):
  File \"/lupus/ngi/irma3/nf-core-env/bin/nf-core\", line 279, in <module>
    nf_core_cli()
  File \"/lupus/ngi/irma3/nf-core-env/lib/python2.7/site-packages/click/core.py\", line 764, in __call__
    return self.main(*args, **kwargs)
  File \"/lupus/ngi/irma3/nf-core-env/lib/python2.7/site-packages/click/core.py\", line 717, in main
    rv = self.invoke(ctx)
  File \"/lupus/ngi/irma3/nf-core-env/lib/python2.7/site-packages/click/core.py\", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File \"/lupus/ngi/irma3/nf-core-env/lib/python2.7/site-packages/click/core.py\", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File \"/lupus/ngi/irma3/nf-core-env/lib/python2.7/site-packages/click/core.py\", line 555, in invoke
    return callback(*args, **kwargs)
  File \"/lupus/ngi/irma3/nf-core-env/bin/nf-core\", line 135, in download
    dl.download_workflow()
  File \"/lupus/ngi/irma3/nf-core-env/lib/python2.7/site-packages/nf_core/download.py\", line 93, in download_workflow
    self.find_container_images()
  File \"/lupus/ngi/irma3/nf-core-env/lib/python2.7/site-packages/nf_core/download.py\", line 250, in find_container_images
    self.config = nf_core.utils.fetch_wf_config(os.path.join(self.outdir, 'workflow'))
  File \"/lupus/ngi/irma3/nf-core-env/lib/python2.7/site-packages/nf_core/utils.py\", line 59, in fetch_wf_config
    k, v = ul.split(' = ', 1)
ValueError: need more than 1 value to unpack", "stdout": "
```

This extra try/except should handle this case without crashing the entire download.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated
