### PR TITLE
Dev installs: append git hash in version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 ### Other
 
 * Improve documentation for installing `nf-core/tools`
+* Added the git hash to the version number when installing a development build
 * Add details of the new nf-core publication in Nature Biotechnology :champagne:
 
 ### Template pipeline

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,18 @@
 #!/usr/bin/env python
 
 from setuptools import setup, find_packages
+import subprocess
 import sys
 
 version = '1.9dev'
+
+# Try to append the git hash if we can
+if 'dev' in version:
+    try:
+        git_hash = str(subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).strip()).strip('"\'').lstrip("b'")
+        version = '{}-{}'.format(version, git_hash)
+    except IndexError:
+        pass
 
 with open('README.md') as f:
     readme = f.read()


### PR DESCRIPTION
Append the short git hash to the version number when it includes `dev`.
This should prevent Test PyPI uploads to fail due to identical filenames.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated