### PR TITLE
Container promotion over conda

### DIFF
--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
@@ -18,7 +18,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io), a workflow tool
 
 i. Install [`nextflow`](https://nf-co.re/usage/installation)
 
-ii. Install one of [`docker`](https://docs.docker.com/engine/installation/), [`singularity`](https://www.sylabs.io/guides/3.0/user-guide/) or [`conda`](https://conda.io/miniconda.html)
+ii. Install either [`docker`](https://docs.docker.com/engine/installation/) or [`singularity`](https://www.sylabs.io/guides/3.0/user-guide/) for full pipeline reproducibility (or when these are not possible, [`conda`](https://conda.io/miniconda.html))
 
 iii. Download the pipeline and test it on a minimal dataset with a single command
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
@@ -94,6 +94,8 @@ Use this parameter to choose a configuration profile. Profiles can give configur
 
 Several generic profiles are bundled with the pipeline which instruct the pipeline to use software packaged using different methods (Docker, Singularity, Conda) - see below.
 
+> We highly recommend the use of Docker or Singularity containers for full pipeline reproducibility, however when these are not possible, conda is well supported.
+
 The pipeline also dynamically loads configurations from [https://github.com/nf-core/configs](https://github.com/nf-core/configs) when it runs, making multiple config profiles for various institutional clusters available at run time. For more information and to see if your system is available in these configs please see the [nf-core/configs documentation](https://github.com/nf-core/configs#documentation).
 
 Note that multiple profiles can be loaded, for example: `-profile test,docker` - the order of arguments is important!
@@ -101,15 +103,17 @@ They are loaded in sequence, so later profiles can overwrite earlier profiles.
 
 If `-profile` is not specified, the pipeline will run locally and expect all software to be installed and available on the `PATH`. This is _not_ recommended.
 
-* `conda`
-  * A generic configuration profile to be used with [conda](https://conda.io/docs/)
-  * Pulls most software from [Bioconda](https://bioconda.github.io/)
 * `docker`
+  * Recommended!
   * A generic configuration profile to be used with [Docker](http://docker.com/)
   * Pulls software from dockerhub: [`{{ cookiecutter.name_docker }}`](http://hub.docker.com/r/{{ cookiecutter.name_docker }}/)
 * `singularity`
+  * Recommended!
   * A generic configuration profile to be used with [Singularity](http://singularity.lbl.gov/)
   * Pulls software from DockerHub: [`{{ cookiecutter.name_docker }}`](http://hub.docker.com/r/{{ cookiecutter.name_docker }}/)
+* `conda`
+  * A generic configuration profile to be used with [conda](https://conda.io/docs/)
+  * Pulls most software from [Bioconda](https://bioconda.github.io/)
 * `test`
   * A profile with a complete configuration for automated testing
   * Includes links to test data so needs no other parameters


### PR DESCRIPTION
This PR includes some small template changes on the README and Documenation, to emphasise that docker/singularity is preferred over conda for full (and more stable) reproducibility of running pipelines, after the discussion on #help slack channel on 2020-02-20.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [x] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
