### PR TITLE
Template documentation emphasises container usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Removed the requirement for R in the conda environment
 * Make `params.multiqc_config` give an _additional_ MultiQC config file instead of replacing the one that ships with the pipeline
 * Ignore only `tests/` and `testing/` directories in `.gitignore` to avoid ignoring `test.config` configuration file
+* Rephrase quickstart and usage templates to promote usage of containers over conda for more stable reproducibility
 
 ### Linting
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Removed the requirement for R in the conda environment
 * Make `params.multiqc_config` give an _additional_ MultiQC config file instead of replacing the one that ships with the pipeline
 * Ignore only `tests/` and `testing/` directories in `.gitignore` to avoid ignoring `test.config` configuration file
-* Rephrase quickstart and usage templates to promote usage of containers over conda for more stable reproducibility
+* Rephrase docs to promote usage of containers over Conda to ensure reproducibility
 
 ### Linting
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
@@ -17,7 +17,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io), a workflow tool
 
 i. Install [`nextflow`](https://nf-co.re/usage/installation)
 
-ii. Install either [`Docker`](https://docs.docker.com/engine/installation/) or [`Singularity`](https://www.sylabs.io/guides/3.0/user-guide/) for full pipeline reproducibility (please only use [`Conda`](https://conda.io/miniconda.html) as a last resort; see [documentation](https://nf-co.re/usage/configuration#basic-configuration-profiles))
+ii. Install either [`Docker`](https://docs.docker.com/engine/installation/) or [`Singularity`](https://www.sylabs.io/guides/3.0/user-guide/) for full pipeline reproducibility (please only use [`Conda`](https://conda.io/miniconda.html) as a last resort; see [docs](https://nf-co.re/usage/configuration#basic-configuration-profiles))
 
 iii. Download the pipeline and test it on a minimal dataset with a single command
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
@@ -17,7 +17,8 @@ The pipeline is built using [Nextflow](https://www.nextflow.io), a workflow tool
 
 i. Install [`nextflow`](https://nf-co.re/usage/installation)
 
-ii. Install one of [`docker`](https://docs.docker.com/engine/installation/), [`singularity`](https://www.sylabs.io/guides/3.0/user-guide/) or [`conda`](https://conda.io/miniconda.html)
+ii. Install either [`docker`](https://docs.docker.com/engine/installation/) or [`singularity`](https://www.sylabs.io/guides/3.0/user-guide/) for full pipeline reproducibility (or when these are not possible, [`conda`](https://conda.io/miniconda.html))
+
 
 iii. Download the pipeline and test it on a minimal dataset with a single command
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
@@ -17,7 +17,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io), a workflow tool
 
 i. Install [`nextflow`](https://nf-co.re/usage/installation)
 
-ii. Install either [`docker`](https://docs.docker.com/engine/installation/) or [`singularity`](https://www.sylabs.io/guides/3.0/user-guide/) for full pipeline reproducibility (or when these are not possible, [`conda`](https://conda.io/miniconda.html))
+ii. Install either [`Docker`](https://docs.docker.com/engine/installation/) or [`Singularity`](https://www.sylabs.io/guides/3.0/user-guide/) for full pipeline reproducibility (please only use [`Conda`](https://conda.io/miniconda.html) as a last resort; see [documentation](https://nf-co.re/usage/configuration#basic-configuration-profiles))
 
 iii. Download the pipeline and test it on a minimal dataset with a single command
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
@@ -19,7 +19,6 @@ i. Install [`nextflow`](https://nf-co.re/usage/installation)
 
 ii. Install either [`docker`](https://docs.docker.com/engine/installation/) or [`singularity`](https://www.sylabs.io/guides/3.0/user-guide/) for full pipeline reproducibility (or when these are not possible, [`conda`](https://conda.io/miniconda.html))
 
-
 iii. Download the pipeline and test it on a minimal dataset with a single command
 
 ```bash

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
@@ -94,7 +94,7 @@ Use this parameter to choose a configuration profile. Profiles can give configur
 
 Several generic profiles are bundled with the pipeline which instruct the pipeline to use software packaged using different methods (Docker, Singularity, Conda) - see below.
 
-> We highly recommend the use of Docker or Singularity containers for full pipeline reproducibility, however when these are not possible, conda is well supported.
+> We highly recommend the use of Docker or Singularity containers for full pipeline reproducibility, however when these are not possible, Conda is also supported.
 
 The pipeline also dynamically loads configurations from [https://github.com/nf-core/configs](https://github.com/nf-core/configs) when it runs, making multiple config profiles for various institutional clusters available at run time. For more information and to see if your system is available in these configs please see the [nf-core/configs documentation](https://github.com/nf-core/configs#documentation).
 
@@ -110,8 +110,8 @@ If `-profile` is not specified, the pipeline will run locally and expect all sof
   * A generic configuration profile to be used with [Singularity](http://singularity.lbl.gov/)
   * Pulls software from DockerHub: [`{{ cookiecutter.name_docker }}`](http://hub.docker.com/r/{{ cookiecutter.name_docker }}/)
 * `conda`
-  * Recommended only if Docker and Singularity not possible
-  * A generic configuration profile to be used with [conda](https://conda.io/docs/)
+  * Please only use Conda as a last resort i.e. it's not possible to run the pipeline with Docker or Singularity.
+  * A generic configuration profile to be used with [Conda](https://conda.io/docs/)
   * Pulls most software from [Bioconda](https://bioconda.github.io/)
 * `test`
   * A profile with a complete configuration for automated testing

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
@@ -110,7 +110,7 @@ If `-profile` is not specified, the pipeline will run locally and expect all sof
   * A generic configuration profile to be used with [Singularity](http://singularity.lbl.gov/)
   * Pulls software from DockerHub: [`{{ cookiecutter.name_docker }}`](http://hub.docker.com/r/{{ cookiecutter.name_docker }}/)
 * `conda`
-  * Please only use Conda as a last resort i.e. it's not possible to run the pipeline with Docker or Singularity.
+  * Please only use Conda as a last resort i.e. when it's not possible to run the pipeline with Docker or Singularity.
   * A generic configuration profile to be used with [Conda](https://conda.io/docs/)
   * Pulls most software from [Bioconda](https://bioconda.github.io/)
 * `test`

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
@@ -94,7 +94,7 @@ Use this parameter to choose a configuration profile. Profiles can give configur
 
 Several generic profiles are bundled with the pipeline which instruct the pipeline to use software packaged using different methods (Docker, Singularity, Conda) - see below.
 
-> We highly recommend the use of Docker or Singularity containers for full pipeline reproducibility, however when these are not possible, Conda is also supported.
+> We highly recommend the use of Docker or Singularity containers for full pipeline reproducibility, however when this is not possible, Conda is also supported.
 
 The pipeline also dynamically loads configurations from [https://github.com/nf-core/configs](https://github.com/nf-core/configs) when it runs, making multiple config profiles for various institutional clusters available at run time. For more information and to see if your system is available in these configs please see the [nf-core/configs documentation](https://github.com/nf-core/configs#documentation).
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
@@ -94,6 +94,8 @@ Use this parameter to choose a configuration profile. Profiles can give configur
 
 Several generic profiles are bundled with the pipeline which instruct the pipeline to use software packaged using different methods (Docker, Singularity, Conda) - see below.
 
+> We highly recommend the use of Docker or Singularity containers for full pipeline reproducibility, however when these are not possible, conda is well supported.
+
 The pipeline also dynamically loads configurations from [https://github.com/nf-core/configs](https://github.com/nf-core/configs) when it runs, making multiple config profiles for various institutional clusters available at run time. For more information and to see if your system is available in these configs please see the [nf-core/configs documentation](https://github.com/nf-core/configs#documentation).
 
 Note that multiple profiles can be loaded, for example: `-profile test,docker` - the order of arguments is important!
@@ -101,15 +103,16 @@ They are loaded in sequence, so later profiles can overwrite earlier profiles.
 
 If `-profile` is not specified, the pipeline will run locally and expect all software to be installed and available on the `PATH`. This is _not_ recommended.
 
-* `conda`
-  * A generic configuration profile to be used with [conda](https://conda.io/docs/)
-  * Pulls most software from [Bioconda](https://bioconda.github.io/)
 * `docker`
   * A generic configuration profile to be used with [Docker](http://docker.com/)
   * Pulls software from dockerhub: [`{{ cookiecutter.name_docker }}`](http://hub.docker.com/r/{{ cookiecutter.name_docker }}/)
 * `singularity`
   * A generic configuration profile to be used with [Singularity](http://singularity.lbl.gov/)
   * Pulls software from DockerHub: [`{{ cookiecutter.name_docker }}`](http://hub.docker.com/r/{{ cookiecutter.name_docker }}/)
+* `conda`
+  * Recommended only if Docker and Singularity not possible
+  * A generic configuration profile to be used with [conda](https://conda.io/docs/)
+  * Pulls most software from [Bioconda](https://bioconda.github.io/)
 * `test`
   * A profile with a complete configuration for automated testing
   * Includes links to test data so needs no other parameters


### PR DESCRIPTION
This PR includes some small template changes on the README and usage documentation files, to emphasise that docker/singularity is preferred over conda for full (and more stable) reproducibility of running pipelines, after the discussion on #help slack channel on 2020-02-20.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [x] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
