### PR TITLE
Bump to v1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # nf-core/tools: Changelog
 
-## v1.9dev
+## v1.9
 
 ### Continuous integration
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 import sys
 
-version = '1.9dev'
+version = '1.9'
 
 with open('README.md') as f:
     readme = f.read()


### PR DESCRIPTION
Bumping version number for tools from `v1.9dev` to `v1.9`

Only merge after https://github.com/nf-core/tools/pull/543 and https://github.com/nf-core/tools/pull/542