### PR TITLE
Add PR branch check to tools repo

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,0 +1,16 @@
+name: nf-core branch protection
+# This workflow is triggered on PRs to master branch on the repository
+# It fails when someone tries to make a PR against the nf-core `master` branch instead of `dev`
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    steps:
+      # PRs are only ok if coming from an nf-core `dev` branch or a fork `patch` branch
+      - name: Check PRs
+        run: |
+          { [[ $(git remote get-url origin) == *nf-core/tools ]] && [[ ${GITHUB_HEAD_REF} = "dev" ]]; } || [[ ${GITHUB_HEAD_REF} == "patch" ]]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## v1.10dev
 
-_..nothing yet.._
+### Other
+
+* Added CI test to check for PRs against `master` in tools repo
 
 ## v1.9
 


### PR DESCRIPTION
I was surprised that tests passed on https://github.com/nf-core/tools/pull/547 when I had accidentally made the PR against `master` instead of `dev`.

Looking now I see that we have this test in the pipeline template, but not for the tools repo itself. Added it here.