### PR TITLE
Refactor actions branchcheck linting

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -9,7 +9,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      # PRs to the nf-core repo are only ok if coming from the `dev` or `patch` branches
+      # PRs to the nf-core repo master branch are only ok if coming from the nf-core repo `dev` or any `patch` branches
       - name: Check PRs
         if: github.repository == 'nf-core/tools'
-        run: '[[ $GITHUB_HEAD_REF == "dev" ]] || [[ $GITHUB_HEAD_REF == "patch" ]]'
+        run: |
+          { [[ $(git remote get-url origin) == *nf-core/tools ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -3,14 +3,13 @@ name: nf-core branch protection
 # It fails when someone tries to make a PR against the nf-core `master` branch instead of `dev`
 on:
   pull_request:
-    branches:
-    - master
+    branches: [master]
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      # PRs are only ok if coming from an nf-core `dev` branch or a fork `patch` branch
+      # PRs to the nf-core repo are only ok if coming from the `dev` or `patch` branches
       - name: Check PRs
-        run: |
-          { [[ $(git remote get-url origin) == *nf-core/tools ]] && [[ ${GITHUB_HEAD_REF} = "dev" ]]; } || [[ ${GITHUB_HEAD_REF} == "patch" ]]
+        if: github.repository == 'nf-core/tools'
+        run: '[[ $GITHUB_HEAD_REF == "dev" ]] || [[ $GITHUB_HEAD_REF == "patch" ]]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v1.10dev
 
+### Linting
+
+* Refactored PR branch tests to be a little clearer
+
 ### Other
 
 * Added CI test to check for PRs against `master` in tools repo

--- a/docs/lint_errors.md
+++ b/docs/lint_errors.md
@@ -192,7 +192,7 @@ This test will fail if the following requirements are not met in these files:
         - name: Check PRs
           if: github.repository == 'nf-core/<pipeline_name>'
           run: |
-            { [[ $(git remote get-url origin) == *nf-core/tools ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
+            { [[ $(git remote get-url origin) == *nf-core/<pipeline_name> ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
       ```
 
 ## Error #6 - Repository `README.md` tests ## {#6}

--- a/docs/lint_errors.md
+++ b/docs/lint_errors.md
@@ -190,8 +190,8 @@ This test will fail if the following requirements are not met in these files:
       steps:
         # PRs are only ok if coming from an nf-core `dev` branch or a fork `patch` branch
         - name: Check PRs
-          run: |
-            { [[ $(git remote get-url origin) == *nf-core/<pipeline_name> ]] && [[ ${GITHUB_HEAD_REF} = "dev" ]]; } || [[ ${GITHUB_HEAD_REF} == "patch" ]]
+          if: github.repository == 'nf-core/<pipeline_name>'
+          run: [[ $GITHUB_HEAD_REF == "dev" ]] || [[ $GITHUB_HEAD_REF == "patch" ]]
       ```
 
 ## Error #6 - Repository `README.md` tests ## {#6}

--- a/docs/lint_errors.md
+++ b/docs/lint_errors.md
@@ -184,14 +184,15 @@ This test will fail if the following requirements are not met in these files:
           - master
       ```
 
-    * Checks that PRs to the protected `master` branch can only come from an nf-core `dev` branch or a fork `patch` branch:
+    * Checks that PRs to the protected nf-core repo `master` branch can only come from an nf-core `dev` branch or a fork `patch` branch:
 
       ```yaml
       steps:
-        # PRs are only ok if coming from an nf-core `dev` branch or a fork `patch` branch
+        # PRs to the nf-core repo master branch are only ok if coming from the nf-core repo `dev` or any `patch` branches
         - name: Check PRs
           if: github.repository == 'nf-core/<pipeline_name>'
-          run: [[ $GITHUB_HEAD_REF == "dev" ]] || [[ $GITHUB_HEAD_REF == "patch" ]]
+          run: |
+            { [[ $(git remote get-url origin) == *nf-core/tools ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
       ```
 
 ## Error #6 - Repository `README.md` tests ## {#6}

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -516,7 +516,6 @@ class PipelineLint(object):
                 self.passed.append((5, "GitHub Actions 'branch' workflow is triggered for PRs to master: '{}'".format(fn)))
 
             # Check that PRs are only ok if coming from an nf-core `dev` branch or a fork `patch` branch
-            PRMasterCheck = '[[ $GITHUB_HEAD_REF == "dev" ]] || [[ $GITHUB_HEAD_REF == "patch" ]]'
             steps = branchwf.get('jobs', {}).get('test', {}).get('steps', [])
             for step in steps:
                 has_name = step.get('name').strip() == 'Check PRs'

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -518,9 +518,9 @@ class PipelineLint(object):
             # Check that PRs are only ok if coming from an nf-core `dev` branch or a fork `patch` branch
             steps = branchwf.get('jobs', {}).get('test', {}).get('steps', [])
             for step in steps:
-                has_name = step.get('name').strip() == 'Check PRs'
-                has_if = step.get('if').strip() == "github.repository == 'nf-core/{}'".format(self.pipeline_name.lower())
-                has_run = step.get('run').strip() == '{{ [[ $(git remote get-url origin) == *nf-core/{} ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; }} || [[ $GITHUB_HEAD_REF == "patch" ]]'.format(self.pipeline_name.lower())
+                has_name = step.get('name', '').strip() == 'Check PRs'
+                has_if = step.get('if', '').strip() == "github.repository == 'nf-core/{}'".format(self.pipeline_name.lower())
+                has_run = step.get('run', '').strip() == '{{ [[ $(git remote get-url origin) == *nf-core/{} ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; }} || [[ $GITHUB_HEAD_REF == "patch" ]]'.format(self.pipeline_name.lower())
                 if has_name and has_if and has_run:
                     self.passed.append((5, "GitHub Actions 'branch' workflow checks that forks don't submit PRs to master: '{}'".format(fn)))
                     break

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -519,9 +519,9 @@ class PipelineLint(object):
             PRMasterCheck = '[[ $GITHUB_HEAD_REF == "dev" ]] || [[ $GITHUB_HEAD_REF == "patch" ]]'
             steps = branchwf.get('jobs', {}).get('test', {}).get('steps', [])
             for step in steps:
-                has_name = step.get('name') == 'Check PRs'
-                has_if = step.get('if') == "github.repository == 'nf-core/{}'".format(self.pipeline_name.lower())
-                has_run = step.get('run') == '[[ $GITHUB_HEAD_REF == "dev" ]] || [[ $GITHUB_HEAD_REF == "patch" ]]'
+                has_name = step.get('name').strip() == 'Check PRs'
+                has_if = step.get('if').strip() == "github.repository == 'nf-core/{}'".format(self.pipeline_name.lower())
+                has_run = step.get('run').strip() == '{{ [[ $(git remote get-url origin) == *nf-core/{} ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; }} || [[ $GITHUB_HEAD_REF == "patch" ]]'.format(self.pipeline_name.lower())
                 if has_name and has_if and has_run:
                     self.passed.append((5, "GitHub Actions 'branch' workflow checks that forks don't submit PRs to master: '{}'".format(fn)))
                     break

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/branch.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/branch.yml
@@ -9,7 +9,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      # PRs to the nf-core repo are only ok if coming from the `dev` or `patch` branches
+      # PRs to the nf-core repo master branch are only ok if coming from the nf-core repo `dev` or any `patch` branches
       - name: Check PRs
         if: github.repository == '{{cookiecutter.name}}'
-        run: '[[ $GITHUB_HEAD_REF == "dev" ]] || [[ $GITHUB_HEAD_REF == "patch" ]]'
+        run: |
+          { [[ $(git remote get-url origin) == *{{cookiecutter.name}} ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/branch.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/branch.yml
@@ -3,14 +3,13 @@ name: nf-core branch protection
 # It fails when someone tries to make a PR against the nf-core `master` branch instead of `dev`
 on:
   pull_request:
-    branches:
-    - master
+    branches: [master]
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      # PRs are only ok if coming from an nf-core `dev` branch or a fork `patch` branch
+      # PRs to the nf-core repo are only ok if coming from the `dev` or `patch` branches
       - name: Check PRs
-        run: |
-          { [[ $(git remote get-url origin) == *{{cookiecutter.name}} ]] && [[ ${GITHUB_HEAD_REF} = "dev" ]]; } || [[ ${GITHUB_HEAD_REF} == "patch" ]]
+        if: github.repository == '{{cookiecutter.name}}'
+        run: '[[ $GITHUB_HEAD_REF == "dev" ]] || [[ $GITHUB_HEAD_REF == "patch" ]]'

--- a/tests/lint_examples/minimalworkingexample/.github/workflows/branch.yml
+++ b/tests/lint_examples/minimalworkingexample/.github/workflows/branch.yml
@@ -9,7 +9,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      # PRs to the nf-core repo are only ok if coming from the `dev` or `patch` branches
+      # PRs to the nf-core repo master branch are only ok if coming from the nf-core repo `dev` or any `patch` branches
       - name: Check PRs
         if: github.repository == 'nf-core/tools'
-        run: '[[ $GITHUB_HEAD_REF == "dev" ]] || [[ $GITHUB_HEAD_REF == "patch" ]]'
+        run: |
+          { [[ $(git remote get-url origin) == *nf-core/tools ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]

--- a/tests/lint_examples/minimalworkingexample/.github/workflows/branch.yml
+++ b/tests/lint_examples/minimalworkingexample/.github/workflows/branch.yml
@@ -3,15 +3,13 @@ name: nf-core branch protection
 # It fails when someone tries to make a PR against the nf-core `master` branch instead of `dev`
 on:
   pull_request:
-    branches:
-    - master
+    branches: [master]
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      # PRs are only ok if coming from an nf-core `dev` branch or a fork `patch` branch
+      # PRs to the nf-core repo are only ok if coming from the `dev` or `patch` branches
       - name: Check PRs
-        run: |
-          { [[ $(git remote get-url origin) == *nf-core/tools ]] && [[ ${GITHUB_HEAD_REF} = "dev" ]]; } || [[ ${GITHUB_HEAD_REF} == "patch" ]]
+        if: github.repository == 'nf-core/tools'
+        run: '[[ $GITHUB_HEAD_REF == "dev" ]] || [[ $GITHUB_HEAD_REF == "patch" ]]'


### PR DESCRIPTION
So this ended up being quite a minor PR in the end. I did a bunch of refactoring, felt smug about how much cleaner and easier to read the code was, then realised that it no longer did what it was meant to 😆 After looking at it for a while, I came to the conclusion that what we already had was already optimal..

Couple of things I did change:

* Action now only runs on the main nf-core repo and not forks
  * Am I missing something here? I feel like the previous code would have failed for PRs coming to `master` on forks as well..
* Linting code is hopefully now a little more tolerant for variable YAML structures
* Minor tidying and a couple of small tweaks

The `$(git remote get-url origin)` bugs me! There's `$GITHUB_REPOSITORY` which is the base repo as far as I can tell, so why is there not also `$GITHUB_HEAD_REPOSITORY`??

See also #552 and #553