### PR TITLE
Comment on PR if branch test fails

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -26,8 +26,7 @@ jobs:
 
             It looks like this pull-request is has been made against the ${{github.event.pull_request.head.repo.full_name}} `master` branch.
             The `master` branch on nf-core repositories should always contain code from the latest release.
-            Beacuse of this, PRs to `master` are only allowed if they come from the ${{github.event.pull_request.head.repo.full_name}} `dev` branch
-            or from a forked repo branch called `patch` (for minor patch pipeline releases).
+            Beacuse of this, PRs to `master` are only allowed if they come from the ${{github.event.pull_request.head.repo.full_name}} `dev` branch.
 
             You do not need to close this PR, you can change the target branch to `dev` by clicking the _"Edit"_ button at the top of this page.
 

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -29,7 +29,7 @@ jobs:
             Beacuse of this, PRs to `master` are only allowed if they come from the ${{github.event.pull_request.head.repo.full_name}} `dev` branch
             or from a forked repo branch called `patch` (for minor patch pipeline releases).
 
-            You do not need to close this PR, you can change the target branch to `dev` by clicking on _EDIT_ at the top of this page.
+            You do not need to close this PR, you can change the target branch to `dev` by clicking the _"Edit"_ button at the top of this page.
 
             Thanks again for your contribution!
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -9,8 +9,28 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+
       # PRs to the nf-core repo master branch are only ok if coming from the nf-core repo `dev` or any `patch` branches
       - name: Check PRs
         if: github.repository == 'nf-core/tools'
         run: |
-          { [[ $(git remote get-url origin) == *nf-core/tools ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
+          { [[ ${{github.event.pull_request.head.repo.full_name}} == nf-core/tools ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
+
+      # If the above check failed, post a comment on the PR explaining the failure
+      - name: Post PR comment
+        if: failure()
+        uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            Hi @${{ github.event.pull_request.user.login }},
+
+            It looks like this pull-request is has been made against the ${{github.event.pull_request.head.repo.full_name}} `master` branch.
+            The `master` branch on nf-core repositories should always contain code from the latest release.
+            Beacuse of this, PRs to `master` are only allowed if they come from the ${{github.event.pull_request.head.repo.full_name}} `dev` branch
+            or from a forked repo branch called `patch` (for minor patch pipeline releases).
+
+            You do not need to close this PR, you can change the target branch to `dev` by clicking on _EDIT_ at the top of this page.
+
+            Thanks again for your contribution!
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-repeats: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Other
 
 * Added CI test to check for PRs against `master` in tools repo
+* CI PR branch tests now automatically add a comment on the PR if failing, explaining what is wrong
 
 ## v1.9
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/branch.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/branch.yml
@@ -26,8 +26,7 @@ jobs:
 
             It looks like this pull-request is has been made against the ${{github.event.pull_request.head.repo.full_name}} `master` branch.
             The `master` branch on nf-core repositories should always contain code from the latest release.
-            Beacuse of this, PRs to `master` are only allowed if they come from the ${{github.event.pull_request.head.repo.full_name}} `dev` branch
-            or from a forked repo branch called `patch` (for minor patch pipeline releases).
+            Beacuse of this, PRs to `master` are only allowed if they come from the ${{github.event.pull_request.head.repo.full_name}} `dev` branch.
 
             You do not need to close this PR, you can change the target branch to `dev` by clicking the _"Edit"_ button at the top of this page.
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/branch.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/branch.yml
@@ -29,7 +29,7 @@ jobs:
             Beacuse of this, PRs to `master` are only allowed if they come from the ${{github.event.pull_request.head.repo.full_name}} `dev` branch
             or from a forked repo branch called `patch` (for minor patch pipeline releases).
 
-            You do not need to close this PR, you can change the target branch to `dev` by clicking on _EDIT_ at the top of this page.
+            You do not need to close this PR, you can change the target branch to `dev` by clicking the _"Edit"_ button at the top of this page.
 
             Thanks again for your contribution!
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/branch.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/branch.yml
@@ -14,3 +14,24 @@ jobs:
         if: github.repository == '{{cookiecutter.name}}'
         run: |
           { [[ $(git remote get-url origin) == *{{cookiecutter.name}} ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
+
+{% raw %}
+      # If the above check failed, post a comment on the PR explaining the failure
+      - name: Post PR comment
+        if: failure()
+        uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            Hi @${{ github.event.pull_request.user.login }},
+
+            It looks like this pull-request is has been made against the ${{github.event.pull_request.head.repo.full_name}} `master` branch.
+            The `master` branch on nf-core repositories should always contain code from the latest release.
+            Beacuse of this, PRs to `master` are only allowed if they come from the ${{github.event.pull_request.head.repo.full_name}} `dev` branch
+            or from a forked repo branch called `patch` (for minor patch pipeline releases).
+
+            You do not need to close this PR, you can change the target branch to `dev` by clicking on _EDIT_ at the top of this page.
+
+            Thanks again for your contribution!
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-repeats: false
+{% endraw %}


### PR DESCRIPTION
If the GitHub Actions test for the PR target branch fails, automatically add a comment to the PR explaining what went wrong and how to fix it.

Closes nf-core/tools#558

Also updated variable handling mentioned in nf-core/tools#554


## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
