### PR TITLE
 fix spellings of Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ INFO: Downloading centralised configs from GitHub
 
 INFO: Downloading 1 singularity container
 
-INFO: Building singularity image from dockerhub: docker://nfcore/methylseq:1.4
+INFO: Building singularity image from Docker Hub: docker://nfcore/methylseq:1.4
 INFO:    Converting OCI blobs to SIF format
 INFO:    Starting build...
 Getting image source signatures
@@ -567,5 +567,5 @@ If you use `nf-core tools` in your work, please cite the `nf-core` publication a
 >
 > Philip Ewels, Alexander Peltzer, Sven Fillinger, Harshil Patel, Johannes Alneberg, Andreas Wilm, Maxime Ulysse Garcia, Paolo Di Tommaso & Sven Nahnsen.
 >
-> _Nat Biotechnol._ 2020 Feb 13. doi: [10.1038/s41587-020-0439-x](https://dx.doi.org/10.1038/s41587-020-0439-x).  
+> _Nat Biotechnol._ 2020 Feb 13. doi: [10.1038/s41587-020-0439-x](https://dx.doi.org/10.1038/s41587-020-0439-x).
 > ReadCube: [Full Access Link](https://rdcu.be/b1GjZ)

--- a/docs/lint_errors.md
+++ b/docs/lint_errors.md
@@ -97,9 +97,9 @@ The following variables throw warnings if missing:
   * The DAG file path should end with `.svg`
     * If Graphviz is not installed, Nextflow will generate a `.dot` file instead
 * `process.container`
-  * Dockerhub handle for a single default container for use by all processes.
+  * Docker Hub handle for a single default container for use by all processes.
   * Must specify a tag that matches the pipeline version number if set.
-  * If the pipeline version number contains the string `dev`, the DockerHub tag must be `:dev`
+  * If the pipeline version number contains the string `dev`, the Docker Hub tag must be `:dev`
 * `params.reads` or `params.input` or `params.design`
   * Input parameter to specify input data - one or more of these can be used to avoid a warning
   * Typical usage:
@@ -117,7 +117,7 @@ The following variables are depreciated and fail the test if they are still pres
 * `params.nf_required_version`
   * The old method for specifying the minimum Nextflow version. Replaced by `manifest.nextflowVersion`
 * `params.container`
-  * The old method for specifying the dockerhub container address. Replaced by `process.container`
+  * The old method for specifying the Docker Hub container address. Replaced by `process.container`
 * `singleEnd` and `igenomesIgnore`
   * Changed to `single_end` and `igenomes_ignore`
   * The `snake_case` convention should now be used when defining pipeline parameters

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -98,7 +98,7 @@ class DownloadWorkflow(object):
                 logging.info("Downloading {} singularity container{}".format(len(self.containers), 's' if len(self.containers) > 1 else ''))
                 for container in self.containers:
                     try:
-                        # Download from Dockerhub in all cases
+                        # Download from Docker Hub in all cases
                         self.pull_singularity_image(container)
                     except RuntimeWarning as r:
                         # Raise exception if this is not possible
@@ -269,7 +269,7 @@ class DownloadWorkflow(object):
         out_path = os.path.abspath(os.path.join(self.outdir, 'singularity-images', out_name))
         address = 'docker://{}'.format(container.replace('docker://', ''))
         singularity_command = ["singularity", "pull", "--name", out_path, address]
-        logging.info("Building singularity image from dockerhub: {}".format(address))
+        logging.info("Building singularity image from Docker Hub: {}".format(address))
         logging.debug("Singularity command: {}".format(' '.join(singularity_command)))
 
         # Try to use singularity to pull image

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
@@ -105,10 +105,10 @@ If `-profile` is not specified, the pipeline will run locally and expect all sof
 
 * `docker`
   * A generic configuration profile to be used with [Docker](http://docker.com/)
-  * Pulls software from dockerhub: [`{{ cookiecutter.name_docker }}`](http://hub.docker.com/r/{{ cookiecutter.name_docker }}/)
+  * Pulls software from Docker Hub: [`{{ cookiecutter.name_docker }}`](http://hub.docker.com/r/{{ cookiecutter.name_docker }}/)
 * `singularity`
   * A generic configuration profile to be used with [Singularity](http://singularity.lbl.gov/)
-  * Pulls software from DockerHub: [`{{ cookiecutter.name_docker }}`](http://hub.docker.com/r/{{ cookiecutter.name_docker }}/)
+  * Pulls software from Docker Hub: [`{{ cookiecutter.name_docker }}`](http://hub.docker.com/r/{{ cookiecutter.name_docker }}/)
 * `conda`
   * Please only use Conda as a last resort i.e. when it's not possible to run the pipeline with Docker or Singularity.
   * A generic configuration profile to be used with [Conda](https://conda.io/docs/)


### PR DESCRIPTION
Streamlined the various different spellings of Docker Hub to the one they use on their website https://docs.docker.com/docker-hub/.

See also https://github.com/nf-core/nf-co.re/pull/315.
