### PR TITLE
Template: branch check, use GH API var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Other
 
 * Added CI test to check for PRs against `master` in tools repo
-* CI PR branch tests now automatically add a comment on the PR if failing, explaining what is wrong
+* CI PR branch tests fixed & now automatically add a comment on the PR if failing, explaining what is wrong
 
 ## v1.9
 

--- a/docs/lint_errors.md
+++ b/docs/lint_errors.md
@@ -192,7 +192,7 @@ This test will fail if the following requirements are not met in these files:
         - name: Check PRs
           if: github.repository == 'nf-core/<pipeline_name>'
           run: |
-            { [[ $(git remote get-url origin) == *nf-core/<pipeline_name> ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
+            { [[ ${{github.event.pull_request.head.repo.full_name}} == nf-core/<pipeline_name> ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
       ```
 
     * For branch protection in repositories outside of _nf-core_, you can add an additional step to this workflow. Keep the _nf-core_ branch protection step, to ensure that the `nf-core lint` tests pass. Here's an example:
@@ -203,11 +203,11 @@ This test will fail if the following requirements are not met in these files:
         - name: Check PRs
           if: github.repository == 'nf-core/<pipeline_name>'
           run: |
-            { [[ $(git remote get-url origin) == *nf-core/<pipeline_name> ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
+            { [[ ${{github.event.pull_request.head.repo.full_name}} == nf-core/<pipeline_name> ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
         - name: Check PRs in another repository
           if: github.repository == '<repo_name>/<pipeline_name>'
           run: |
-            { [[ $(git remote get-url origin) == *<repo_name>/<pipeline_name> ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
+            { [[ ${{github.event.pull_request.head.repo.full_name}} == <repo_name>/<pipeline_name> ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
       ```
 
 ## Error #6 - Repository `README.md` tests ## {#6}

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -520,7 +520,8 @@ class PipelineLint(object):
             for step in steps:
                 has_name = step.get('name', '').strip() == 'Check PRs'
                 has_if = step.get('if', '').strip() == "github.repository == 'nf-core/{}'".format(self.pipeline_name.lower())
-                has_run = step.get('run', '').strip() == '{{ [[ ${{github.event.pull_request.head.repo.full_name}} == nf-core/{} ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; }} || [[ $GITHUB_HEAD_REF == "patch" ]]'.format(self.pipeline_name.lower())
+                # Don't use .format() as the squiggly brackets get ridiculous
+                has_run = step.get('run', '').strip() == '{ [[ ${{github.event.pull_request.head.repo.full_name}} == nf-core/PIPELINENAME ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]'.replace('PIPELINENAME', self.pipeline_name.lower())
                 if has_name and has_if and has_run:
                     self.passed.append((5, "GitHub Actions 'branch' workflow checks that forks don't submit PRs to master: '{}'".format(fn)))
                     break

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -520,7 +520,7 @@ class PipelineLint(object):
             for step in steps:
                 has_name = step.get('name', '').strip() == 'Check PRs'
                 has_if = step.get('if', '').strip() == "github.repository == 'nf-core/{}'".format(self.pipeline_name.lower())
-                has_run = step.get('run', '').strip() == '{{ [[ $(git remote get-url origin) == *nf-core/{} ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; }} || [[ $GITHUB_HEAD_REF == "patch" ]]'.format(self.pipeline_name.lower())
+                has_run = step.get('run', '').strip() == '{{ [[ ${{github.event.pull_request.head.repo.full_name}} == nf-core/{} ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; }} || [[ $GITHUB_HEAD_REF == "patch" ]]'.format(self.pipeline_name.lower())
                 if has_name and has_if and has_run:
                     self.passed.append((5, "GitHub Actions 'branch' workflow checks that forks don't submit PRs to master: '{}'".format(fn)))
                     break

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/branch.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/branch.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check PRs
         if: github.repository == '{{cookiecutter.name}}'
         run: |
-          { [[ ${{github.event.pull_request.head.repo.full_name}} == {{cookiecutter.name}} ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
+          { [[ {% raw %}${{github.event.pull_request.head.repo.full_name}}{% endraw %} == {{cookiecutter.name}} ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
 
 {% raw %}
       # If the above check failed, post a comment on the PR explaining the failure

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/branch.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/branch.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check PRs
         if: github.repository == '{{cookiecutter.name}}'
         run: |
-          { [[ $(git remote get-url origin) == *{{cookiecutter.name}} ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
+          { [[ ${{github.event.pull_request.head.repo.full_name}} == {{cookiecutter.name}} ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
 
 {% raw %}
       # If the above check failed, post a comment on the PR explaining the failure

--- a/tests/lint_examples/minimalworkingexample/.github/workflows/branch.yml
+++ b/tests/lint_examples/minimalworkingexample/.github/workflows/branch.yml
@@ -13,4 +13,4 @@ jobs:
       - name: Check PRs
         if: github.repository == 'nf-core/tools'
         run: |
-          { [[ $(git remote get-url origin) == *nf-core/tools ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
+          { [[ ${{github.event.pull_request.head.repo.full_name}} == nf-core/tools ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]


### PR DESCRIPTION
Instead of calling `$(git remote get-url origin)`, use `${{github.event.pull_request.head.repo.full_name}}`

Should fix this error: https://github.com/nf-core/chipseq/pull/143/checks?check_run_id=474749336

I think that the above error is because we are not calling the checkout action step before it, so we don't actually have the repo in the working directory. So when we call `$(git remote get-url origin)` it fails. Instead of changing this by checking out the repo, we can just use the `${{github.event.pull_request.head.repo.full_name}}` variable though, from the GitHub API. This should be properly populated and work.

Note that I already made this change in the branch CI for the main tools repo, I just didn't do it in the template. It seems to be working ok there - I tested a variant on my fork [here](https://github.com/ewels/nf-core-tools/pull/1/checks?check_run_id=472208320) and it worked properly at least.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated