### PR TITLE
Add new lint test for cookiecutter strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Refactored PR branch tests to be a little clearer.
 * Linting error docs explain how to add an additional branch protecton rule to the `branch.yml` GitHub Actions workflow.
 * Adapted linting docs to the new PR branch tests.
+* Added test for template `{{ cookiecutter.var }}` placeholders
 
 ### Other
 

--- a/docs/lint_errors.md
+++ b/docs/lint_errors.md
@@ -313,3 +313,9 @@ As we are relying on [Docker Hub](https://hub.docker.com/) instead of Singularit
 ## Error #12 - Pipeline name ## {#12}
 
 In order to ensure consistent naming, pipeline names should contain only lower case, alphabetical characters. Otherwise a warning is displayed.
+
+## Error #13 - Pipeline name ## {#13}
+
+The `nf-core create` pipeline template uses [cookiecutter](https://github.com/cookiecutter/cookiecutter) behind the scenes.
+This check fails if any cookiecutter template variables such as `{{ cookiecutter.pipeline_name }}` are fouund in your pipeline code.
+Finding a placeholder like this means that something was probably copied and pasted from the template without being properly rendered for your pipeline.

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -921,8 +921,8 @@ class PipelineLint(object):
         """
         try:
             # First, try to get the list of files using git
-            git_ls_files = subprocess.check_output(['git','ls-files']).splitlines()
-            list_of_files = [s.decode("utf-8") for s in git_ls_files]
+            git_ls_files = subprocess.check_output(['git','ls-files'], cwd=self.path).splitlines()
+            list_of_files = [os.path.join(self.path, s.decode("utf-8")) for s in git_ls_files]
         except subprocess.CalledProcessError as e:
             # Failed, so probably not initialised as a git repository - just a list of all files
             logging.debug("Couldn't call 'git ls-files': {}".format(e))

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -38,7 +38,7 @@ PATHS_WRONG_LICENSE_EXAMPLE = [pf(WD, 'lint_examples/wrong_license_example'),
     pf(WD, 'lint_examples/license_incomplete_example')]
 
 # The maximum sum of passed tests currently possible
-MAX_PASS_CHECKS = 71
+MAX_PASS_CHECKS = 72
 # The additional tests passed for releases
 ADD_PASS_RELEASE = 1
 


### PR DESCRIPTION
Adds a new lint test that looks for cookiecutter template placeholders.

Failures produce error messages like this:

```
ERROR: Test Failures:
  http://nf-co.re/errors#13 : Found a cookiecutter template string in 'nf-core-philtest/README.md' L1: {{cookiecutter.pipeline_name}}
```

Reports the filename, line number and the cookiecutter variable that was found. One failure is generated per match, so if a file has a bunch then they are all reported in one scan.

Closes https://github.com/nf-core/tools/issues/564

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
