### PR TITLE
add `mac_gsize` for danRer10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * Added CI test to check for PRs against `master` in tools repo
 * CI PR branch tests fixed & now automatically add a comment on the PR if failing, explaining what is wrong
 * Describe alternative installation method via conda with `conda env create`
-* Added `mac_gsize` for danRer10, based on https://biostar.galaxyproject.org/p/18272/
+* Added `macs_gsize` for danRer10, based on [this post](https://biostar.galaxyproject.org/p/18272/)
 
 ## v1.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Added CI test to check for PRs against `master` in tools repo
 * CI PR branch tests fixed & now automatically add a comment on the PR if failing, explaining what is wrong
 * Describe alternative installation method via conda with `conda env create`
+* Added `mac_gsize` for danRer10, based on https://biostar.galaxyproject.org/p/18272/
 
 ## v1.9
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/conf/igenomes.config
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/conf/igenomes.config
@@ -340,7 +340,7 @@ params {
       gtf         = "${params.igenomes_base}/Danio_rerio/UCSC/danRer10/Annotation/Genes/genes.gtf"
       bed12       = "${params.igenomes_base}/Danio_rerio/UCSC/danRer10/Annotation/Genes/genes.bed"
       mito_name   = "chrM"
-      macs_gsize  = "1.35e9"
+      macs_gsize  = "1.37e9"
     }
     'dm6' {
       fasta       = "${params.igenomes_base}/Drosophila_melanogaster/UCSC/dm6/Sequence/WholeGenomeFasta/genome.fa"

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/conf/igenomes.config
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/conf/igenomes.config
@@ -340,6 +340,7 @@ params {
       gtf         = "${params.igenomes_base}/Danio_rerio/UCSC/danRer10/Annotation/Genes/genes.gtf"
       bed12       = "${params.igenomes_base}/Danio_rerio/UCSC/danRer10/Annotation/Genes/genes.bed"
       mito_name   = "chrM"
+      macs_gsize  = "1.35e9"
     }
     'dm6' {
       fasta       = "${params.igenomes_base}/Drosophila_melanogaster/UCSC/dm6/Sequence/WholeGenomeFasta/genome.fa"


### PR DESCRIPTION
I added the missing `mac_gsize` for danRer10. Is that something I need to add to the changelog?

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated