### PR TITLE
Add attaching MultiQC report to 'mail' based emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Add `--publish_dir_mode` parameter [#585](https://github.com/nf-core/tools/issues/585)
 * Isolate R library paths to those in container [#541](https://github.com/nf-core/tools/issues/541)
+* Add ability to attach MultiQC reports to completion emails when using 'mail'
 
 ### Linting
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
@@ -349,7 +349,7 @@ workflow.onComplete {
             log.info "[{{ cookiecutter.name }}] Sent summary e-mail to $email_address (sendmail)"
         } catch (all) {
             // Catch failures and try with plaintext
-            [ 'mail', '-s', subject, email_address ].execute() << email_txt
+            [ 'mail', '-s', subject, email_address, '-A', mqc_report ].execute() << email_txt
             log.info "[{{ cookiecutter.name }}] Sent summary e-mail to $email_address (mail)"
         }
     }

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
@@ -349,11 +349,11 @@ workflow.onComplete {
             log.info "[{{ cookiecutter.name }}] Sent summary e-mail to $email_address (sendmail)"
         } catch (all) {
             // Catch failures and try with plaintext
+            def mail_cmd = [ 'mail', '-s', subject, email_address ]
             if ( mqc_report.size() <= params.max_multiqc_email_size.toBytes() ) {
-              [ 'mail', '-s', subject, email_address, '-A', mqc_report ].execute() << email_txt 
-            } else {
-              [ 'mail', '-s', subject, email_address ].execute() << email_txt 
+              mail_cmd += [ '-A', mqc_report ]
             }
+            mail_cmd.execute() << email_txt 
             log.info "[{{ cookiecutter.name }}] Sent summary e-mail to $email_address (mail)"
         }
     }

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
@@ -349,7 +349,11 @@ workflow.onComplete {
             log.info "[{{ cookiecutter.name }}] Sent summary e-mail to $email_address (sendmail)"
         } catch (all) {
             // Catch failures and try with plaintext
-            [ 'mail', '-s', subject, email_address, '-A', mqc_report ].execute() << email_txt
+            if ( mqc_report.size() <= params.max_multiqc_email_size.toBytes() ) {
+              [ 'mail', '-s', subject, email_address, '-A', mqc_report ].execute() << email_txt 
+            } else {
+              [ 'mail', '-s', subject, email_address ].execute() << email_txt 
+            }
             log.info "[{{ cookiecutter.name }}] Sent summary e-mail to $email_address (mail)"
         }
     }


### PR DESCRIPTION
Previously MultiQC reports would only be sent with pipeline completion email if sendmail was used. Here we add the 'mail' version of the attachment.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
