### PR TITLE
Move some of PR and issue templates into comments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
+<!--
 Many thanks for contributing to nf-core/tools!
 
 Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).
+-->
 
 ## PR checklist
  - [ ] This comment contains a description of changes (with reason)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Added CI test to check for PRs against `master` in tools repo
 * CI PR branch tests fixed & now automatically add a comment on the PR if failing, explaining what is wrong
 * Describe alternative installation method via conda with `conda env create`
+* Move some of the issue and PR templates into HTML `<!-- comments -->` so that they don't show in issues / PRs
 * Added `macs_gsize` for danRer10, based on [this post](https://biostar.galaxyproject.org/p/18272/)
 
 ## v1.9

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,24 +1,27 @@
+<!--
 # {{ cookiecutter.name }} bug report
 
 Hi there!
 
 Thanks for telling us about a problem with the pipeline.
+
 Please delete this text and anything that's not relevant from the template below:
+-->
 
-## Describe the bug
+## Description of the bug
 
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 ## Steps to reproduce
 
 Steps to reproduce the behaviour:
 
-1. Command line: `nextflow run ...`
-2. See error: _Please provide your error message_
+1. Command line: <!-- [e.g. `nextflow run ...`] -->
+2. See error: <!-- [Please provide your error message] -->
 
 ## Expected behaviour
 
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
 
 ## System
 
@@ -39,4 +42,4 @@ A clear and concise description of what you expected to happen.
 
 ## Additional context
 
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,24 +1,26 @@
+<!--
 # {{ cookiecutter.name }} feature request
 
 Hi there!
 
 Thanks for suggesting a new feature for the pipeline!
 Please delete this text and anything that's not relevant from the template below:
+-->
 
 ## Is your feature request related to a problem? Please describe
 
-A clear and concise description of what the problem is.
+<!-- A clear and concise description of what the problem is. -->
 
-Ex. I'm always frustrated when [...]
+<!-- e.g. [I'm always frustrated when ...] -->
 
 ## Describe the solution you'd like
 
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
 ## Describe alternatives you've considered
 
-A clear and concise description of any alternative solutions or features you've considered.
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
 ## Additional context
 
-Add any other context about the feature request here.
+<!-- Add any other context about the feature request here. -->

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/PULL_REQUEST_TEMPLATE.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,11 @@
+<!--
 # {{ cookiecutter.name }} pull request
 
 Many thanks for contributing to {{ cookiecutter.name }}!
 
 Please fill in the appropriate checklist below (delete whatever is not relevant).
 These are the most common things requested on pull requests (PRs).
+-->
 
 ## PR checklist
 


### PR DESCRIPTION
When we originally started using templates for PRs and issues, I assumed that people would read the text _(delete whatever is not relevant)_. But a lot of people do not, and many PRs and issues still contain this helping text.

This PR moves this stuff into `<!-- HTML comments -->` which don't render, so if people do leave them in then they won't show up at least. It also makes all templates a little more consistent.

---

Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
