### PR TITLE
Remove stray comma from markdownlint config yaml file

### DIFF
--- a/.github/markdownlint.yml
+++ b/.github/markdownlint.yml
@@ -1,7 +1,9 @@
 # Markdownlint configuration file
-default: true,
+default: true
 line-length: false
 no-duplicate-header:
     siblings_only: true
-no-bare-urls: false # tools only - the {{ jinja variables }} break URLs and cause this to error
-commands-show-output: false # tools only - suppresses error messages for usage of $ in main README
+# tools only - the {{ jinja variables }} break URLs and cause this to error
+no-bare-urls: false
+# tools only - suppresses error messages for usage of $ in main README
+commands-show-output: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Add `--publish_dir_mode` parameter [#585](https://github.com/nf-core/tools/issues/585)
 * Isolate R library paths to those in container [#541](https://github.com/nf-core/tools/issues/541)
-* Add ability to attach MultiQC reports to completion emails when using 'mail'
+* Add ability to attach MultiQC reports to completion emails when using `mail`
 * Update `output.md` and add in 'Pipeline information' section describing standard NF and pipeline reporting.
 
 ### Linting


### PR DESCRIPTION
Removed a stray comma from the yaml config file. This looks like a copy+paste error from the example file on the markdownlint-cli repo, which uses JSON for config files.

I'm not sure that it makes any difference, but I figured it shouldn't hurt to fix it.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated
