### PR TITLE
Remove and reorder some checklist points from PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,17 @@
 <!--
 Many thanks for contributing to nf-core/tools!
 
-Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).
+Please fill in the appropriate checklist below (delete whatever is not relevant).
+These are the most common things requested on pull requests (PRs).
+
+Remember that PRs should be made against the dev branch, unless you're preparing a release.
+
+Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
 -->
 
 ## PR checklist
+
  - [ ] This comment contains a description of changes (with reason)
  - [ ] `CHANGELOG.md` is updated
  - [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] Documentation in `docs` is updated
-
-**Learn more about contributing:** https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,9 +6,8 @@ Please fill in the appropriate checklist below (delete whatever is not relevant)
 
 ## PR checklist
  - [ ] This comment contains a description of changes (with reason)
+ - [ ] `CHANGELOG.md` is updated
  - [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] Documentation in `docs` is updated
- - [ ] `CHANGELOG.md` is updated
- - [ ] `README.md` is updated
 
 **Learn more about contributing:** https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/PULL_REQUEST_TEMPLATE.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,12 +10,9 @@ These are the most common things requested on pull requests (PRs).
 ## PR checklist
 
 - [ ] This comment contains a description of changes (with reason)
-- [ ] If you've fixed a bug or added code that should be tested, add tests!
-- [ ] If necessary, also make a PR on the [{{ cookiecutter.name }} branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/{{ cookiecutter.name }})
-- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
-- [ ] Make sure your code lints (`nf-core lint .`).
-- [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
-- [ ] `README.md` is updated
+- [ ] If you've fixed a bug or added code that should be tested, add tests!
+- [ ] Documentation in `docs` is updated
+- [ ] If necessary, also make a PR on the [{{ cookiecutter.name }} branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/{{ cookiecutter.name }})
 
 **Learn more about contributing:** [CONTRIBUTING.md](https://github.com/{{ cookiecutter.name }}/tree/master/.github/CONTRIBUTING.md)

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/PULL_REQUEST_TEMPLATE.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,10 @@ Many thanks for contributing to {{ cookiecutter.name }}!
 
 Please fill in the appropriate checklist below (delete whatever is not relevant).
 These are the most common things requested on pull requests (PRs).
+
+Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.
+
+Learn more about contributing: [CONTRIBUTING.md](https://github.com/{{ cookiecutter.name }}/tree/master/.github/CONTRIBUTING.md)
 -->
 
 ## PR checklist
@@ -14,5 +18,3 @@ These are the most common things requested on pull requests (PRs).
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [ ] If necessary, also make a PR on the [{{ cookiecutter.name }} branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/{{ cookiecutter.name }})
-
-**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/{{ cookiecutter.name }}/tree/master/.github/CONTRIBUTING.md)


### PR DESCRIPTION
A bit more simplification of the pull-request templates for both the tools package and the pipeline template.

Basically just removing the stuff that I delete 99% of the time and moving more of the help text into a hidden comment.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated