### PR TITLE
Slack readme badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Isolate R library paths to those in container [#541](https://github.com/nf-core/tools/issues/541)
 * Add ability to attach MultiQC reports to completion emails when using `mail`
 * Update `output.md` and add in 'Pipeline information' section describing standard NF and pipeline reporting.
+* New Slack channel badge in pipeline readme
 
 ### Linting
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![codecov](https://codecov.io/gh/nf-core/tools/branch/master/graph/badge.svg)](https://codecov.io/gh/nf-core/tools)
 [![install with Bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](https://bioconda.github.io/recipes/nf-core/README.html)
 [![install with PyPI](https://img.shields.io/badge/install%20with-PyPI-blue.svg)](https://pypi.org/project/nf-core/)
+[![Get help on Slack](http://img.shields.io/badge/slack-nf--core%20%23tools-4A154B?style=plastic&logo=slack)](https://nfcore.slack.com/channels/tools)
 
 A python package with helper tools for the nf-core community.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/nf-core/tools/branch/master/graph/badge.svg)](https://codecov.io/gh/nf-core/tools)
 [![install with Bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](https://bioconda.github.io/recipes/nf-core/README.html)
 [![install with PyPI](https://img.shields.io/badge/install%20with-PyPI-blue.svg)](https://pypi.org/project/nf-core/)
-[![Get help on Slack](http://img.shields.io/badge/slack-nf--core%20%23tools-4A154B?style=plastic&logo=slack)](https://nfcore.slack.com/channels/tools)
+[![Get help on Slack](http://img.shields.io/badge/slack-nf--core%20%23tools-4A154B?logo=slack)](https://nfcore.slack.com/channels/tools)
 
 A python package with helper tools for the nf-core community.
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
@@ -8,6 +8,7 @@
 
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](https://bioconda.github.io/)
 [![Docker](https://img.shields.io/docker/automated/{{ cookiecutter.name_docker }}.svg)](https://hub.docker.com/r/{{ cookiecutter.name_docker }})
+![[Get help on Slack](http://img.shields.io/badge/slack-nf--core%20%23{{ cookiecutter.short_name }}-4A154B?style=plastic&logo=slack)](https://nfcore.slack.com/channels/{{ cookiecutter.short_name }})
 
 ## Introduction
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
@@ -8,7 +8,7 @@
 
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](https://bioconda.github.io/)
 [![Docker](https://img.shields.io/docker/automated/{{ cookiecutter.name_docker }}.svg)](https://hub.docker.com/r/{{ cookiecutter.name_docker }})
-![[Get help on Slack](http://img.shields.io/badge/slack-nf--core%20%23{{ cookiecutter.short_name }}-4A154B?style=plastic&logo=slack)](https://nfcore.slack.com/channels/{{ cookiecutter.short_name }})
+![[Get help on Slack](http://img.shields.io/badge/slack-nf--core%20%23{{ cookiecutter.short_name }}-4A154B?logo=slack)](https://nfcore.slack.com/channels/{{ cookiecutter.short_name }})
 
 ## Introduction
 


### PR DESCRIPTION
Template update to add a Slack badge in the pipeline readme.

See nf-core/rnaseq#428 for pipeline implementation:

![image](https://user-images.githubusercontent.com/465550/83860945-43697c00-a720-11ea-99fb-229d6c3c1321.png)


## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [x] `README.md` is updated

