### PR TITLE
Conda Bump for base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Move some of the issue and PR templates into HTML `<!-- comments -->` so that they don't show in issues / PRs
 * Added `macs_gsize` for danRer10, based on [this post](https://biostar.galaxyproject.org/p/18272/)
 * nf-core/tools version number now printed underneath header artwork
+* Bumped Conda version shipped with nfcore/base to 4.8.3
 
 ## v1.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 * Move some of the issue and PR templates into HTML `<!-- comments -->` so that they don't show in issues / PRs
 * Added `macs_gsize` for danRer10, based on [this post](https://biostar.galaxyproject.org/p/18272/)
 * nf-core/tools version number now printed underneath header artwork
-* Bumped Conda version shipped with nfcore/base to 4.8.3
+* Bumped Conda version shipped with nfcore/base to 4.8.2
 
 ## v1.9
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM continuumio/miniconda3:4.7.12
+FROM continuumio/miniconda3:4.8.2
 LABEL authors="phil.ewels@scilifelab.se,alexander.peltzer@qbic.uni-tuebingen.de" \
       description="Docker image containing base requirements for the nfcore pipelines"
 
 # Install procps so that Nextflow can poll CPU usage
 RUN apt-get update && apt-get install -y procps && apt-get clean -y
-RUN conda update -n base -c defaults conda=4.8.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,4 @@ LABEL authors="phil.ewels@scilifelab.se,alexander.peltzer@qbic.uni-tuebingen.de"
 
 # Install procps so that Nextflow can poll CPU usage
 RUN apt-get update && apt-get install -y procps && apt-get clean -y
+RUN conda update -n base -c defaults conda=4.8.3


### PR DESCRIPTION
Bump to latest stable conda 4.8.3 for next tools release to get rid of warning.



## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated
