### PR TITLE
Massive warning when using nf-core create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Added `macs_gsize` for danRer10, based on [this post](https://biostar.galaxyproject.org/p/18272/)
 * nf-core/tools version number now printed underneath header artwork
 * Bumped Conda version shipped with nfcore/base to 4.8.2
+* Added log message when creating new pipelines that people should talk to the community about their plans
 
 ## v1.9
 

--- a/README.md
+++ b/README.md
@@ -393,17 +393,19 @@ INFO: Initialising pipeline git repository
 INFO: Done. Remember to add a remote and push to GitHub:
   cd /path/to/nf-core-nextbigthing
   git remote add origin git@github.com:USERNAME/REPO_NAME.git
-  git push
+  git push --all origin
+
+INFO: This will also push your newly created dev branch and the TEMPLATE branch for syncing.
+
+INFO: !!!!!! IMPORTANT !!!!!!
+
+If you are interested in adding your pipeline to the nf-core community,
+PLEASE COME AND TALK TO US IN THE NF-CORE SLACK BEFORE WRITING ANY CODE!
+
+Please read: https://nf-co.re/developers/adding_pipelines#join-the-community
 ```
 
-Once you have run the command, create a new empty repository on GitHub under your username (not the `nf-core` organisation, yet).
-On your computer, add this repository as a git remote and push to it:
-
-```console
-git remote add origin https://github.com/ewels/nf-core-nextbigthing.git
-git push --set-upstream origin master
-```
-
+Once you have run the command, create a new empty repository on GitHub under your username (not the `nf-core` organisation, yet) and push the commits from your computer using the example commands in the above log.
 You can then continue to edit, commit and push normally as you build your pipeline.
 
 Please see the [nf-core documentation](https://nf-co.re/developers/adding_pipelines) for a full walkthrough of how to create a new nf-core workflow.

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -2,6 +2,7 @@
 """Creates a nf-core pipeline matching the current
 organization's specification based on a template.
 """
+import click
 import cookiecutter.main, cookiecutter.exceptions
 import git
 import logging
@@ -10,6 +11,7 @@ import requests
 import shutil
 import sys
 import tempfile
+import textwrap
 
 import nf_core
 
@@ -53,6 +55,14 @@ class PipelineCreate(object):
         # Init the git repository and make the first commit
         if not self.no_git:
             self.git_init_pipeline()
+
+        logging.info(click.style(textwrap.dedent("""            !!!!!! IMPORTANT !!!!!!
+
+            If you are interested in adding your pipeline to the nf-core community,
+            PLEASE COME AND TALK TO US IN THE NF-CORE SLACK BEFORE WRITING ANY CODE!
+
+            Please read: https://nf-co.re/developers/adding_pipelines#join-the-community
+            """), fg='green'))
 
     def run_cookiecutter(self):
         """Runs cookiecutter to create a new nf-core pipeline.
@@ -129,7 +139,7 @@ class PipelineCreate(object):
         repo = git.Repo.init(self.outdir)
         repo.git.add(A=True)
         repo.index.commit("initial template build from nf-core/tools, version {}".format(nf_core.__version__))
-        #Add TEMPLATE branch to git repository
+        # Add TEMPLATE branch to git repository
         repo.git.branch('TEMPLATE')
         repo.git.branch('dev')
         logging.info("Done. Remember to add a remote and push to GitHub:\n  cd {}\n  git remote add origin git@github.com:USERNAME/REPO_NAME.git\n  git push --all origin".format(self.outdir))


### PR DESCRIPTION
Adds enormous green log output after running `nf-core create` to encourage users to come and talk on Slack before writing a new pipeline:

![image](https://user-images.githubusercontent.com/465550/84939845-37e26180-b0df-11ea-9e20-00288cc399b9.png)

See also https://github.com/nf-core/nf-co.re/pull/385

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [x] `README.md` is updated