### PR TITLE
Add extra clean step to the apt cache in the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ LABEL authors="phil.ewels@scilifelab.se,alexander.peltzer@qbic.uni-tuebingen.de"
 # deep clean the apt cache to reduce image/layer size
 RUN apt-get update \
  && apt-get install -y procps \
- && apt-get clean && rm -rf /var/lib/apt/lists/*
+ && apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,11 @@ FROM continuumio/miniconda3:4.7.12
 LABEL authors="phil.ewels@scilifelab.se,alexander.peltzer@qbic.uni-tuebingen.de" \
       description="Docker image containing base requirements for the nfcore pipelines"
 
-# Install procps so that Nextflow can poll CPU usage
+
 RUN apt-get update && apt-get install -y procps && apt-get clean -y
+
+# Install procps so that Nextflow can poll CPU usage and 
+# deep clean the apt cache to reduce image/layer size
+RUN apt-get update \
+ && apt-get install -y procps \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@ FROM continuumio/miniconda3:4.7.12
 LABEL authors="phil.ewels@scilifelab.se,alexander.peltzer@qbic.uni-tuebingen.de" \
       description="Docker image containing base requirements for the nfcore pipelines"
 
-
-RUN apt-get update && apt-get install -y procps && apt-get clean -y
-
 # Install procps so that Nextflow can poll CPU usage and 
 # deep clean the apt cache to reduce image/layer size
 RUN apt-get update \


### PR DESCRIPTION
Taken from:

https://docs.docker.com/develop/develop-images/dockerfile_best-practices/

"In addition, when you clean up the apt cache by removing /var/lib/apt/lists it reduces the image size, since the apt cache is not stored in a layer. Since the RUN statement starts with apt-get update, the package cache is always refreshed prior to apt-get install."

This PR brings the dockerfile inline with docker best practices