### PR TITLE
Only run Python CI tests if Python script edited

### DIFF
--- a/.github/workflows/code-tests.yml
+++ b/.github/workflows/code-tests.yml
@@ -1,6 +1,13 @@
 name: Python tests
 # This workflow is triggered on pushes and PRs to the repository.
-on: [push, pull_request]
+# Only run if we changed a Python file
+on:
+  push:
+    paths:
+      - '**.py'
+  pull_request:
+    paths:
+      - '**.py'
 
 jobs:
   PythonLint:


### PR DESCRIPTION
Having all of the Python CI tests running, complete with the CodeCoverage report, is kind of annoying when you're just tweaking a Markdown documentation file or editing some nextflow code in the template.

This PR modifies the Python CI workflow to only run if a `.py` script has been modified.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated