### PR TITLE
nf-core Launch web GUI

### DIFF
--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -98,6 +98,17 @@ class Launch(object):
 
     def launch_pipeline(self):
 
+        # Check if the output file exists already
+        if os.path.exists(self.params_out):
+            logging.warning("Parameter output file already exists! {}".format(os.path.relpath(self.params_out)))
+            if click.confirm(click.style('Do you want to overwrite this file? ', fg='yellow')+click.style('[y/N]', fg='red'), default=False, show_default=False):
+                os.remove(self.params_out)
+                logging.info("Deleted {}\n".format(self.params_out))
+            else:
+                logging.info("Exiting. Use --params-out to specify a custom filename.")
+                return False
+
+
         logging.info("This tool ignores any pipeline parameter defaults overwritten by Nextflow config files or profiles\n")
 
         # Build the schema and starting inputs
@@ -442,7 +453,7 @@ class Launch(object):
         if param_obj.get('type') == 'boolean':
             # Filter returned value
             def filter_boolean(val):
-                return val == 'True'
+                return val.lower() == 'true'
             question['filter'] = filter_boolean
 
         if param_obj.get('type') == 'number':

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -68,11 +68,6 @@ class Launch(object):
                         'description': 'Unique name for this nextflow run',
                         'pattern': '^[a-zA-Z0-9-_]+$'
                     },
-                    '-revision': {
-                        'type': 'string',
-                        'description': 'Pipeline release / branch to use',
-                        'help_text': 'Revision of the project to run (either a git branch, tag or commit SHA number)'
-                    },
                     '-profile': {
                         'type': 'string',
                         'description': 'Configuration profile'
@@ -145,9 +140,6 @@ class Launch(object):
 
         # Check if this is a local directory
         if os.path.exists(self.pipeline):
-            # Remove the core -revision flag from the schema
-            logging.debug("Removing -revision from core nextflow schema, as local directory")
-            del self.nxf_flag_schema['Nextflow command-line flags']['properties']['-revision']
             # Set the launch commands to use full paths
             self.nfcore_launch_command = 'nf-core launch {}'.format(os.path.abspath(self.pipeline))
             self.nextflow_cmd = 'nextflow run {}'.format(os.path.abspath(self.pipeline))
@@ -156,6 +148,10 @@ class Launch(object):
             if self.pipeline.count('/') == 0:
                 self.nfcore_launch_command = 'nf-core launch nf-core/{}'.format(self.pipeline)
                 self.nextflow_cmd = 'nextflow run nf-core/{}'.format(self.pipeline)
+            # Add revision flag to commands if set
+            if self.pipeline_revision:
+                self.nfcore_launch_command += ' -r {}'.format(self.pipeline_revision)
+                self.nextflow_cmd += ' -r {}'.format(self.pipeline_revision)
 
         # Get schema from name, load it and lint it
         try:

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -259,7 +259,7 @@ class Launch(object):
                 assert web_response['status'] == 'recieved'
             except (AssertionError) as e:
                 logging.debug("Response content:\n{}".format(json.dumps(web_response, indent=4)))
-                raise AssertionError("JSON Schema builder response not recognised: {}\n See verbose log for full response (nf-core -v launch)".format(self.web_schema_launch_url))
+                raise AssertionError("Web launch response not recognised: {}\n See verbose log for full response (nf-core -v launch)".format(self.web_schema_launch_url))
             else:
                 self.web_schema_launch_web_url = web_response['web_url']
                 self.web_schema_launch_api_url = web_response['api_url']

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -250,7 +250,7 @@ class Launch(object):
                 'cli_launch': True,
                 'nextflow_cmd': self.nextflow_cmd,
                 'pipeline': self.pipeline,
-                'revision': self.revision
+                'revision': self.pipeline_revision
             }
             web_response = nf_core.utils.poll_nfcore_web_api(self.web_schema_launch_url, content)
             try:
@@ -298,7 +298,7 @@ class Launch(object):
                 self.cli_launch = web_response['cli_launch']
                 self.nextflow_cmd = web_response['nextflow_cmd']
                 self.pipeline = web_response['pipeline']
-                self.revision = web_response['revision']
+                self.pipeline_revision = web_response['revision']
                 # Sanitise form inputs, set proper variable types etc
                 self.sanitise_web_response()
             except json.decoder.JSONDecodeError as e:

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -12,45 +12,18 @@ import PyInquirer
 import re
 import subprocess
 import textwrap
+import webbrowser
 
-import nf_core.schema
+import nf_core.schema, nf_core.utils
 
 # TODO: Would be nice to be able to capture keyboard interruptions in a nicer way
 # add raise_keyboard_interrupt=True argument to PyInquirer.prompt() calls
 # Requires a new release of PyInquirer. See https://github.com/CITGuru/PyInquirer/issues/90
 
-def launch_pipeline(pipeline, revision=None, command_only=False, params_in=None, params_out=None, save_all=False, show_hidden=False):
-
-    logging.info("This tool ignores any pipeline parameter defaults overwritten by Nextflow config files or profiles\n")
-
-    # Create a pipeline launch object
-    launcher = Launch(pipeline, revision, command_only, params_in, params_out, show_hidden)
-
-    # Build the schema and starting inputs
-    if launcher.get_pipeline_schema() is False:
-        return False
-    launcher.set_schema_inputs()
-    launcher.merge_nxf_flag_schema()
-
-    # Kick off the interactive wizard to collect user inputs
-    launcher.prompt_schema()
-
-    # Validate the parameters that we now have
-    if not launcher.schema_obj.validate_params():
-        return False
-
-    # Strip out the defaults
-    if not save_all:
-        launcher.strip_default_params()
-
-    # Build and launch the `nextflow run` command
-    launcher.build_command()
-    launcher.launch_workflow()
-
 class Launch(object):
     """ Class to hold config option to launch a pipeline """
 
-    def __init__(self, pipeline, revision=None, command_only=False, params_in=None, params_out=None, show_hidden=False):
+    def __init__(self, pipeline, revision=None, command_only=False, params_in=None, params_out=None, save_all=False, show_hidden=False, url=None, web_id=None):
         """Initialise the Launcher class
 
         Args:
@@ -60,17 +33,17 @@ class Launch(object):
         self.pipeline = pipeline
         self.pipeline_revision = revision
         self.schema_obj = None
-        self.use_params_file = True
-        if command_only:
-            self.use_params_file = False
+        self.use_params_file = False if command_only else True
         self.params_in = params_in
-        if params_out:
-            self.params_out = params_out
-        else:
-            self.params_out = os.path.join(os.getcwd(), 'nf-params.json')
-        self.show_hidden = False
-        if show_hidden:
-            self.show_hidden = True
+        self.params_out = params_out if params_out else os.path.join(os.getcwd(), 'nf-params.json')
+        self.save_all = save_all
+        self.show_hidden = show_hidden
+        self.web_schema_launch_url = url if url else 'https://nf-co.re/json_schema_launch'
+        self.web_schema_launch_web_url = None
+        self.web_schema_launch_api_url = None
+        if web_id:
+            self.web_schema_launch_web_url = '{}?id={}'.format(self.web_schema_launch_url, web_id)
+            self.web_schema_launch_api_url = '{}?id={}&api=true'.format(self.web_schema_launch_url, web_id)
 
         self.nextflow_cmd = 'nextflow run {}'.format(self.pipeline)
 
@@ -118,6 +91,38 @@ class Launch(object):
         }
         self.nxf_flags = {}
         self.params_user = {}
+
+    def launch_pipeline(self):
+
+        logging.info("This tool ignores any pipeline parameter defaults overwritten by Nextflow config files or profiles\n")
+
+        # Build the schema and starting inputs
+        if self.get_pipeline_schema() is False:
+            return False
+        self.set_schema_inputs()
+        self.merge_nxf_flag_schema()
+
+        if self.prompt_web_gui():
+            try:
+                self.launch_web_gui()
+            except AssertionError as e:
+                logging.error(click.style(e.args[0], fg='red'))
+                return False
+        else:
+            # Kick off the interactive wizard to collect user inputs
+            self.prompt_schema()
+
+        # Validate the parameters that we now have
+        if not self.schema_obj.validate_params():
+            return False
+
+        # Strip out the defaults
+        if not self.save_all:
+            self.strip_default_params()
+
+        # Build and launch the `nextflow run` command
+        self.build_command()
+        self.launch_workflow()
 
     def get_pipeline_schema(self):
         """ Load and validate the schema from the supplied pipeline """
@@ -172,6 +177,109 @@ class Launch(object):
         schema_params.update(self.schema_obj.schema['properties'])
         self.schema_obj.schema['properties'] = schema_params
 
+    def prompt_web_gui(self):
+        """ Ask whether to use the web-based or cli wizard to collect params """
+
+        # Check whether --id was given and we're loading params from the web
+        if self.web_schema_launch_web_url is not None and self.web_schema_launch_api_url is not None:
+            return True
+
+        click.secho("\nWould you like to enter pipeline parameters using a web-based interface or a command-line wizard?\n", fg='magenta')
+        question = {
+            'type': 'list',
+            'name': 'use_web_gui',
+            'message': 'Choose launch method',
+            'choices': [
+                'Web based',
+                'Command line'
+            ]
+        }
+        answer = PyInquirer.prompt([question])
+        return answer['use_web_gui'] == 'Web based'
+
+    def launch_web_gui(self):
+        """ Send schema to nf-core website and launch input GUI """
+
+        # If --id given on the command line, we already know the URLs
+        if self.web_schema_launch_web_url is None and self.web_schema_launch_api_url is None:
+            content = {
+                'post_content': 'json_schema_launcher',
+                'api': 'true',
+                'version': nf_core.__version__,
+                'status': 'waiting_for_user',
+                'schema': json.dumps(self.schema_obj.schema),
+                'nxf_flags': json.dumps(self.nxf_flags),
+                'input_params': json.dumps(self.schema_obj.input_params)
+            }
+            web_response = nf_core.utils.poll_nfcore_web_api(self.web_schema_launch_url, content)
+            try:
+                assert 'api_url' in web_response
+                assert 'web_url' in web_response
+                assert web_response['status'] == 'recieved'
+            except (AssertionError) as e:
+                logging.debug("Response content:\n{}".format(json.dumps(web_response, indent=4)))
+                raise AssertionError("JSON Schema builder response not recognised: {}\n See verbose log for full response (nf-core -v launch)".format(self.web_schema_launch_url))
+            else:
+                self.web_schema_launch_web_url = web_response['web_url']
+                self.web_schema_launch_api_url = web_response['api_url']
+
+        # ID supplied - has it been completed or not?
+        else:
+            logging.debug("ID supplied - checking status at {}".format(self.web_schema_launch_api_url))
+            if self.get_web_launch_response():
+                return True
+
+        # Launch the web GUI
+        logging.info("Opening URL: {}".format(self.web_schema_launch_web_url))
+        webbrowser.open(self.web_schema_launch_web_url)
+        logging.info("Waiting for form to be completed in the browser. Remember to click Finished when you're done.\n")
+        nf_core.utils.wait_cli_function(self.get_web_launch_response)
+
+    def get_web_launch_response(self):
+        """
+        Given a URL for a web-gui launch response, recursively query it until results are ready.
+        """
+        web_response = nf_core.utils.poll_nfcore_web_api(self.web_schema_launch_api_url)
+        if web_response['status'] == 'error':
+            raise AssertionError("Got error from launch API ({})".format(web_response.get('message')))
+        elif web_response['status'] == 'waiting_for_user':
+            return False
+        elif web_response['status'] == 'launch_params_complete':
+            logging.info("Found completed parameters from nf-core launch GUI")
+            try:
+                self.nxf_flags = json.loads(web_response['nxf_flags'])
+                self.schema_obj.input_params = json.loads(web_response['input_params'])
+                self.sanitise_web_response()
+            except json.decoder.JSONDecodeError as e:
+                raise AssertionError("Could not load JSON response from web API: {}".format(e))
+            except KeyError as e:
+                raise AssertionError("Missing return key from web API: {}".format(e))
+            return True
+        else:
+            logging.debug("Response content:\n{}".format(json.dumps(web_response, indent=4)))
+            raise AssertionError("Web launch GUI returned unexpected status ({}): {}\n See verbose log for full response".format(web_response['status'], self.web_schema_launch_api_url))
+
+    def sanitise_web_response(self):
+        """
+        The web builder returns everything as strings.
+        Use the functions defined in the cli wizard to convert to the correct types.
+        """
+        # Collect pyinquirer objects for each defined input_param
+        pyinquirer_objects = {}
+        for param_id, param_obj in self.schema_obj.schema['properties'].items():
+            if(param_obj['type'] == 'object'):
+                for child_param_id, child_param_obj in param_obj['properties'].items():
+                    if child_param_id in self.schema_obj.input_params:
+                        pyinquirer_objects[child_param_id] = self.single_param_to_pyinquirer(child_param_id, child_param_obj, print_help=False)
+            else:
+                if param_id in self.schema_obj.input_params:
+                    pyinquirer_objects[param_id] = self.single_param_to_pyinquirer(param_id, param_obj, print_help=False)
+
+        # Go through input params and sanitise
+        for param_id, val in self.schema_obj.input_params.items():
+            filter_func = pyinquirer_objects.get(param_id, {}).get('filter')
+            if filter_func is not None:
+                self.schema_obj.input_params[param_id] = filter_func(val)
 
     def prompt_schema(self):
         """ Go through the pipeline schema and prompt user to change defaults """
@@ -269,7 +377,7 @@ class Launch(object):
 
         return answers
 
-    def single_param_to_pyinquirer(self, param_id, param_obj, answers=None):
+    def single_param_to_pyinquirer(self, param_id, param_obj, answers=None, print_help=True):
         """Convert a JSONSchema param to a PyInquirer question
 
         Args:
@@ -289,8 +397,9 @@ class Launch(object):
         }
 
         # Print the name, description & help text
-        nice_param_id = '--{}'.format(param_id) if not param_id.startswith('-') else param_id
-        self.print_param_header(nice_param_id, param_obj)
+        if print_help:
+            nice_param_id = '--{}'.format(param_id) if not param_id.startswith('-') else param_id
+            self.print_param_header(nice_param_id, param_obj)
 
         if param_obj.get('type') == 'boolean':
             question['type'] = 'confirm'
@@ -425,7 +534,7 @@ class Launch(object):
         """ Strip parameters if they have not changed from the default """
 
         for param_id, val in self.schema_obj.schema_defaults.items():
-            if self.schema_obj.input_params[param_id] == val:
+            if self.schema_obj.input_params.get(param_id) == val:
                 del self.schema_obj.input_params[param_id]
 
     def build_command(self):
@@ -457,7 +566,7 @@ class Launch(object):
                         self.nextflow_cmd += " --{}".format(param)
                     # everything else
                     else:
-                        self.nextflow_cmd += ' --{} "{}"'.format(param, val.replace('"', '\\"'))
+                        self.nextflow_cmd += ' --{} "{}"'.format(param, str(val).replace('"', '\\"'))
 
 
     def launch_workflow(self):

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -301,8 +301,6 @@ class Launch(object):
                 self.pipeline_revision = web_response['revision']
                 # Sanitise form inputs, set proper variable types etc
                 self.sanitise_web_response()
-            except json.decoder.JSONDecodeError as e:
-                raise AssertionError("Could not load JSON response from web API: {}".format(e))
             except KeyError as e:
                 raise AssertionError("Missing return key from web API: {}".format(e))
             except Exception as e:

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -469,6 +469,8 @@ class Launch(object):
         if param_obj.get('type') == 'boolean':
             # Filter returned value
             def filter_boolean(val):
+                if isinstance(val, bool):
+                    return val
                 return val.lower() == 'true'
             question['filter'] = filter_boolean
 

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -422,7 +422,7 @@ class PipelineSchema (object):
         elif web_response['status'] == 'web_builder_edited':
             logging.info("Found saved status from nf-core JSON Schema builder")
             try:
-                self.schema = json.loads(web_response['schema'])
+                self.schema = web_response['schema']
                 self.validate_schema(self.schema)
             except json.decoder.JSONDecodeError as e:
                 raise AssertionError("Could not parse returned JSON:\n {}".format(e))

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -424,8 +424,6 @@ class PipelineSchema (object):
             try:
                 self.schema = web_response['schema']
                 self.validate_schema(self.schema)
-            except json.decoder.JSONDecodeError as e:
-                raise AssertionError("Could not parse returned JSON:\n {}".format(e))
             except AssertionError as e:
                 raise AssertionError("Response from JSON Builder did not pass validation:\n {}".format(e))
             else:

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -416,7 +416,7 @@ class PipelineSchema (object):
         """
         web_response = nf_core.utils.poll_nfcore_web_api(self.web_schema_build_api_url)
         if web_response['status'] == 'error':
-            raise AssertionError("Got error from JSON Schema builder ( {} )".format(click.style(web_response.get('message'), fg='red')))
+            raise AssertionError("Got error from JSON Schema builder ( {} )".format(web_response.get('message')))
         elif web_response['status'] == 'waiting_for_user':
             return False
         elif web_response['status'] == 'web_builder_edited':
@@ -432,5 +432,5 @@ class PipelineSchema (object):
                 self.save_schema()
                 return True
         else:
-            logging.debug("Response content:\n{}".format(response.content))
+            logging.debug("Response content:\n{}".format(json.dumps(web_response, indent=4)))
             raise AssertionError("JSON Schema builder returned unexpected status ({}): {}\n See verbose log for full response".format(web_response['status'], self.web_schema_build_api_url))

--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -134,7 +134,7 @@ def list(keywords, sort, json):
 @click.option(
     '--url',
     type = str,
-    default = 'https://nf-co.re/json_schema_build',
+    default = 'https://nf-co.re/json_schema_launch',
     help = 'Customise the builder URL (for development work)'
 )
 def launch(pipeline, id, revision, command_only, params_in, params_out, save_all, show_hidden, url):

--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -91,7 +91,7 @@ def list(keywords, sort, json):
 @nf_core_cli.command(help_priority=2)
 @click.argument(
     'pipeline',
-    required = True,
+    required = False,
     metavar = "<pipeline name>"
 )
 @click.option(
@@ -134,7 +134,7 @@ def list(keywords, sort, json):
 @click.option(
     '--url',
     type = str,
-    default = 'https://nf-co.re/json_schema_launch',
+    default = 'https://nf-co.re/launch',
     help = 'Customise the builder URL (for development work)'
 )
 def launch(pipeline, id, revision, command_only, params_in, params_out, save_all, show_hidden, url):

--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -95,6 +95,10 @@ def list(keywords, sort, json):
     metavar = "<pipeline name>"
 )
 @click.option(
+    '-i', '--id',
+    help = "ID for web-gui launch parameter set"
+)
+@click.option(
     '-r', '--revision',
     help = "Release/branch/SHA of the project to run (if remote)"
 )
@@ -127,9 +131,16 @@ def list(keywords, sort, json):
     default = False,
     help = "Show hidden parameters."
 )
-def launch(pipeline, revision, command_only, params_in, params_out, save_all, show_hidden):
+@click.option(
+    '--url',
+    type = str,
+    default = 'https://nf-co.re/json_schema_build',
+    help = 'Customise the builder URL (for development work)'
+)
+def launch(pipeline, id, revision, command_only, params_in, params_out, save_all, show_hidden, url):
     """ Run pipeline, interactive parameter prompts """
-    if nf_core.launch.launch_pipeline(pipeline, revision, command_only, params_in, params_out, save_all, show_hidden) == False:
+    launcher = nf_core.launch.Launch(pipeline, revision, command_only, params_in, params_out, save_all, show_hidden, url, id)
+    if launcher.launch_pipeline() == False:
         sys.exit(1)
 
 # nf-core download

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'jsonschema',
         # 'PyInquirer>1.0.3',
         # Need the new release of PyInquirer, see nf_core/launch.py for details
-        'PyInquirer @ git+ssh://git@github.com/CITGuru/PyInquirer.git@master#egg=PyInquirer',
+        'PyInquirer @ https://github.com/CITGuru/PyInquirer/archive/master.zip',
         'pyyaml',
         'requests',
         'requests_cache',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,9 @@ setup(
         'GitPython',
         'jinja2',
         'jsonschema',
-        'PyInquirer',
+        # 'PyInquirer>1.0.3',
+        # Need the new release of PyInquirer, see nf_core/launch.py for details
+        'PyInquirer @ git+ssh://git@github.com/CITGuru/PyInquirer.git@master#egg=PyInquirer',
         'pyyaml',
         'requests',
         'requests_cache',

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -90,12 +90,18 @@ class TestLaunch(unittest.TestCase):
             "default": "True",
         }
         result = self.launcher.single_param_to_pyinquirer('single_end', sc_obj)
-        assert result == {
-            'type': 'confirm',
-            'name': 'single_end',
-            'message': 'single_end',
-            'default': True
-        }
+        assert result['type'] == 'list'
+        assert result['name'] == 'single_end'
+        assert result['message'] == 'single_end'
+        assert result['choices'] == ['True', 'False']
+        assert result['default'] == 'True'
+        print(type(True))
+        assert result['filter']('True') == True
+        assert result['filter']('true') == True
+        assert result['filter'](True) == True
+        assert result['filter']('False') == False
+        assert result['filter']('false') == False
+        assert result['filter'](False) == False
 
     def test_ob_to_pyinquirer_number(self):
         """ Check converting a python dict to a pyenquirer format - with enum """

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -127,6 +127,16 @@ class TestLaunch(unittest.TestCase):
             }
             return MockResponse(response_data, 200)
 
+    @mock.patch('nf_core.utils.poll_nfcore_web_api', side_effect=[{}])
+    def test_launch_web_gui_missing_keys(self, mock_poll_nfcore_web_api):
+        """ Check the code that opens the web browser """
+        self.launcher.get_pipeline_schema()
+        self.launcher.merge_nxf_flag_schema()
+        try:
+            self.launcher.launch_web_gui()
+        except AssertionError as e:
+            assert e.args[0].startswith('Web launch response not recognised:')
+
     @mock.patch('nf_core.utils.poll_nfcore_web_api', side_effect=[{'api_url': 'foo', 'web_url': 'bar', 'status': 'recieved'}])
     @mock.patch('webbrowser.open')
     @mock.patch('nf_core.utils.wait_cli_function')

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -145,6 +145,17 @@ class TestLaunch(unittest.TestCase):
         self.launcher.merge_nxf_flag_schema()
         assert self.launcher.launch_web_gui() == True
 
+    def test_sanitise_web_response(self):
+        """ Check that we can properly sanitise results from the web """
+        self.launcher.get_pipeline_schema()
+        self.launcher.nxf_flags['-name'] = ''
+        self.launcher.schema_obj.input_params['single_end'] = 'true'
+        self.launcher.schema_obj.input_params['max_cpus'] = '12'
+        self.launcher.sanitise_web_response()
+        assert '-name' not in self.launcher.nxf_flags
+        assert self.launcher.schema_obj.input_params['single_end'] == True
+        assert self.launcher.schema_obj.input_params['max_cpus'] == 12
+
     def test_ob_to_pyinquirer_bool(self):
         """ Check converting a python dict to a pyenquirer format - booleans """
         sc_obj = {

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -22,6 +22,12 @@ class TestLaunch(unittest.TestCase):
         self.nf_params_fn = os.path.join(tempfile.mkdtemp(), 'nf-params.json')
         self.launcher = nf_core.launch.Launch(self.template_dir, params_out = self.nf_params_fn)
 
+    @mock.patch.object(nf_core.launch.Launch, 'prompt_web_gui', side_effect=[True])
+    @mock.patch.object(nf_core.launch.Launch, 'launch_web_gui')
+    def test_launch_pipeline(self, mock_webbrowser, mock_lauch_web_gui):
+        """ Test the main launch function """
+        self.launcher.launch_pipeline()
+
     def test_get_pipeline_schema(self):
         """ Test loading the params schema from a pipeline """
         self.launcher.get_pipeline_schema()

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -102,7 +102,7 @@ class TestLaunch(unittest.TestCase):
                 self.status_code = status_code
                 self.content = json.dumps(data)
 
-        if kwargs['url'] == 'https://nf-co.re/json_schema_launch':
+        if kwargs['url'] == 'https://nf-co.re/launch':
             response_data = {
                 'status': 'recieved',
                 'api_url': 'https://nf-co.re',

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -357,7 +357,7 @@ class TestSchema(unittest.TestCase):
         try:
             self.schema_obj.launch_web_builder()
         except AssertionError as e:
-            assert e.args[0] == 'Could not access remote JSON Schema builder: invalid_url (HTML 404 Error)'
+            assert e.args[0] == 'Could not access remote API results: invalid_url (HTML 404 Error)'
 
     @mock.patch('requests.post', side_effect=mocked_requests_post)
     def test_launch_web_builder_invalid_status(self, mock_post):
@@ -378,7 +378,7 @@ class TestSchema(unittest.TestCase):
             self.schema_obj.launch_web_builder()
         except AssertionError as e:
             # Assertion error comes from get_web_builder_response() function
-            assert e.args[0].startswith('Could not access remote JSON Schema builder results: https://nf-co.re')
+            assert e.args[0].startswith('Could not access remote API results: https://nf-co.re')
 
 
     def mocked_requests_get(*args, **kwargs):
@@ -421,7 +421,7 @@ class TestSchema(unittest.TestCase):
         try:
             self.schema_obj.get_web_builder_response()
         except AssertionError as e:
-            assert e.args[0] == "Could not access remote JSON Schema builder results: invalid_url (HTML 404 Error)"
+            assert e.args[0] == "Could not access remote API results: invalid_url (HTML 404 Error)"
 
     @mock.patch('requests.get', side_effect=mocked_requests_get)
     def test_get_web_builder_response_error(self, mock_post):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -22,7 +22,10 @@ class TestSchema(unittest.TestCase):
         """ Create a new PipelineSchema object """
         self.schema_obj = nf_core.schema.PipelineSchema()
         self.root_repo_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-        self.template_dir = os.path.join(self.root_repo_dir, 'nf_core', 'pipeline-template', '{{cookiecutter.name_noslash}}')
+        # Copy the template to a temp directory so that we can use that for tests
+        self.template_dir = os.path.join(tempfile.mkdtemp(), 'wf')
+        template_dir = os.path.join(self.root_repo_dir, 'nf_core', 'pipeline-template', '{{cookiecutter.name_noslash}}')
+        shutil.copytree(template_dir, self.template_dir)
         self.template_schema = os.path.join(self.template_dir, 'nextflow_schema.json')
 
     def test_load_lint_schema(self):
@@ -410,7 +413,7 @@ class TestSchema(unittest.TestCase):
             response_data = {
                 'status': 'web_builder_edited',
                 'message': 'testing',
-                'schema': '{ "foo": "bar" }'
+                'schema': { "foo": "bar" }
             }
             return MockResponse(response_data, 200)
 


### PR DESCRIPTION
New code for using a nice web graphical user interface when running `nf-core launch`. Should work with any nextflow pipeline.

Bunch of other small tweaks and improvements to `nf-core launch` and `nf-core schema` too.

Tests haven't been updated so will probably get a lot of failures. Will fix these next week. In the mean time, any code review and / or testing the tools are very welcome!

Works in tandem with changes to the nf-core website, see https://github.com/nf-core/nf-co.re/pull/400

See Slack `#json-schema` for screen capture demos: https://nfcore.slack.com/archives/CUC8PPDL2/p1593212486143900

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated