### PR TITLE
Add missing content type definition for mailutils email server emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ GitHub or on the nf-core [`#json-schema` Slack channel](https://nfcore.slack.com
 * nf-core/tools version number now printed underneath header artwork
 * Bumped Conda version shipped with nfcore/base to 4.8.2
 * Added log message when creating new pipelines that people should talk to the community about their plans
+* Fixed 'on completion' emails sent using the `mail` command not containing body text. 
 
 ## v1.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ GitHub or on the nf-core [`#json-schema` Slack channel](https://nfcore.slack.com
 * nf-core/tools version number now printed underneath header artwork
 * Bumped Conda version shipped with nfcore/base to 4.8.2
 * Added log message when creating new pipelines that people should talk to the community about their plans
-* Fixed 'on completion' emails sent using the `mail` command not containing body text. 
+* Fixed 'on completion' emails sent using the `mail` command not containing body text.
 
 ## v1.9
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
@@ -349,11 +349,11 @@ workflow.onComplete {
             log.info "[{{ cookiecutter.name }}] Sent summary e-mail to $email_address (sendmail)"
         } catch (all) {
             // Catch failures and try with plaintext
-            def mail_cmd = [ 'mail', '-s', subject, '--content-type=text', email_address ]
+            def mail_cmd = [ 'mail', '-s', subject, '--content-type=text/html', email_address ]
             if ( mqc_report.size() <= params.max_multiqc_email_size.toBytes() ) {
               mail_cmd += [ '-A', mqc_report ]
             }
-            mail_cmd.execute() << email_txt 
+            mail_cmd.execute() << email_html 
             log.info "[{{ cookiecutter.name }}] Sent summary e-mail to $email_address (mail)"
         }
     }

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
@@ -349,7 +349,7 @@ workflow.onComplete {
             log.info "[{{ cookiecutter.name }}] Sent summary e-mail to $email_address (sendmail)"
         } catch (all) {
             // Catch failures and try with plaintext
-            def mail_cmd = [ 'mail', '-s', subject, email_address ]
+            def mail_cmd = [ 'mail', '-s', subject, '--content-type=text', email_address ]
             if ( mqc_report.size() <= params.max_multiqc_email_size.toBytes() ) {
               mail_cmd += [ '-A', mqc_report ]
             }


### PR DESCRIPTION
Realised that without this, the body content is not actually displayed on viewing by a user (and was typically being replaced by the HTML attachment in fancy email browsers).

Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [x] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
