### PR TITLE
Try to improve command line help for nf-core launch

### DIFF
--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -95,41 +95,41 @@ def list(keywords, sort, json):
     metavar = "<pipeline name>"
 )
 @click.option(
-    '-i', '--id',
-    help = "ID for web-gui launch parameter set"
-)
-@click.option(
     '-r', '--revision',
     help = "Release/branch/SHA of the project to run (if remote)"
+)
+@click.option(
+    '-i', '--id',
+    help = "ID for web-gui launch parameter set"
 )
 @click.option(
     '-c', '--command-only',
     is_flag = True,
     default = False,
-    help = "Set params directly in the nextflow command."
-)
-@click.option(
-    '-p', '--params-in',
-    type = click.Path(exists=True),
-    help = "Input parameters JSON file."
+    help = "Set params in the nextflow command (no params file)"
 )
 @click.option(
     '-o', '--params-out',
     type = click.Path(),
     default = os.path.join(os.getcwd(), 'nf-params.json'),
-    help = "Path to save parameters JSON file to."
+    help = "Path to save run parameters to"
+)
+@click.option(
+    '-p', '--params-in',
+    type = click.Path(exists=True),
+    help = "Set of input run params to use from a previous run"
 )
 @click.option(
     '-a', '--save-all',
     is_flag = True,
     default = False,
-    help = "Save all parameters, even if default."
+    help = "Save all parameters, even if unchanged from default"
 )
 @click.option(
     '-h', '--show-hidden',
     is_flag = True,
     default = False,
-    help = "Show hidden parameters."
+    help = "Show hidden params which don't normally need changing"
 )
 @click.option(
     '--url',
@@ -138,7 +138,13 @@ def list(keywords, sort, json):
     help = 'Customise the builder URL (for development work)'
 )
 def launch(pipeline, id, revision, command_only, params_in, params_out, save_all, show_hidden, url):
-    """ Run pipeline, interactive parameter prompts """
+    """
+    Launch a pipeline using either an interactive web GUI or command line prompts to set parameter values.
+
+    When finished, saves a file with the selected parameters which can be passed to Nextflow using the -params-file option.
+
+    Run using a remote pipeline name (org/repo), a local pipeline directory or an ID from the nf-core web launch tool.
+    """
     launcher = nf_core.launch.Launch(pipeline, revision, command_only, params_in, params_out, save_all, show_hidden, url, id)
     if launcher.launch_pipeline() == False:
         sys.exit(1)
@@ -292,7 +298,7 @@ def lint(pipeline_dir, release, markdown, json):
 ## nf-core schema subcommands
 @nf_core_cli.group(cls=CustomHelpOrder)
 def schema():
-    """ Manage pipeline JSON Schema """
+    """ Suite of tools to help developers to manage pipeline JSON Schema """
     pass
 
 @schema.command(help_priority=1)
@@ -354,7 +360,7 @@ def validate(pipeline, params):
     help = 'Customise the builder URL (for development work)'
 )
 def build(pipeline_dir, no_prompts, web_only, url):
-    """ Interactively build a schema from Nextflow params. """
+    """ Interactively build a pipeline schema from Nextflow params. """
     schema_obj = nf_core.schema.PipelineSchema()
     if schema_obj.build_schema(pipeline_dir, no_prompts, web_only, url) is False:
         sys.exit(1)

--- a/scripts/nf-core
+++ b/scripts/nf-core
@@ -106,13 +106,13 @@ def list(keywords, sort, json):
     '-c', '--command-only',
     is_flag = True,
     default = False,
-    help = "Set params in the nextflow command (no params file)"
+    help = "Create Nextflow command with params (no params file)"
 )
 @click.option(
     '-o', '--params-out',
     type = click.Path(),
     default = os.path.join(os.getcwd(), 'nf-params.json'),
-    help = "Path to save run parameters to"
+    help = "Path to save run parameters file"
 )
 @click.option(
     '-p', '--params-in',


### PR DESCRIPTION
New improved command line help for `nf-core launch`, hopefully a little clearer now. Note that I removed all mention of `JSON`, `schema` and `template` to try to avoid confusion.

New output:

```console
(python3)  ~ » nf-core launch --help

                                          ,--./,-.
          ___     __   __   __   ___     /,-._.--~\
    |\ | |__  __ /  ` /  \ |__) |__         }  {
    | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                          `._,._,'

    nf-core/tools version 1.10.dev0

Usage: nf-core launch [OPTIONS] <pipeline name>

  Launch a pipeline using either an interactive web GUI or command line
  prompts to set parameter values.

  When finished, saves a file with the selected parameters which can be
  passed to Nextflow using the -params-file option.

  Run using a remote pipeline name (org/repo), a local pipeline directory or
  an ID from the nf-core web launch tool.

Options:
  -r, --revision TEXT    Release/branch/SHA of the project to run (if remote)
  -i, --id TEXT          ID for web-gui launch parameter set
  -c, --command-only     Set params in the nextflow command (no params file)
  -o, --params-out PATH  Path to save run parameters to
  -p, --params-in PATH   Set of input run params to use from a previous run
  -a, --save-all         Save all parameters, even if unchanged from default
  -h, --show-hidden      Show hidden params which don't normally need changing
  --url TEXT             Customise the builder URL (for development work)
  --help                 Show this message and exit.
```

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated