### PR TITLE
Add information about config files to summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ GitHub or on the nf-core [`#json-schema` Slack channel](https://nfcore.slack.com
 * Allow multiple container tags in `ci.yml` if performing multiple tests in parallel
 * Add AWS CI tests and full tests GitHub Actions workflows
 * Update AWS CI tests and full tests secrets names
+* Add information about config files used for workflow execution (`workflow.configFiles`) to summary
 
 ### Linting
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
@@ -146,7 +146,7 @@ summary['Config Profile'] = workflow.profile
 if (params.config_profile_description) summary['Config Profile Description'] = params.config_profile_description
 if (params.config_profile_contact)     summary['Config Profile Contact']     = params.config_profile_contact
 if (params.config_profile_url)         summary['Config Profile URL']         = params.config_profile_url
-summary['Config Files'] = workflow.configFiles
+summary['Config Files'] = workflow.configFiles.join(', ')
 if (params.email || params.email_on_fail) {
     summary['E-mail Address']    = params.email
     summary['E-mail on failure'] = params.email_on_fail

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
@@ -143,9 +143,10 @@ if (workflow.profile.contains('awsbatch')) {
     summary['AWS CLI']      = params.awscli
 }
 summary['Config Profile'] = workflow.profile
-if (params.config_profile_description) summary['Config Description'] = params.config_profile_description
-if (params.config_profile_contact)     summary['Config Contact']     = params.config_profile_contact
-if (params.config_profile_url)         summary['Config URL']         = params.config_profile_url
+if (params.config_profile_description) summary['Config Profile Description'] = params.config_profile_description
+if (params.config_profile_contact)     summary['Config Profile Contact']     = params.config_profile_contact
+if (params.config_profile_url)         summary['Config Profile URL']         = params.config_profile_url
+summary['Config Files'] = workflow.configFiles
 if (params.email || params.email_on_fail) {
     summary['E-mail Address']    = params.email
     summary['E-mail on failure'] = params.email_on_fail


### PR DESCRIPTION
Hi, I added the `workflow.configFiles` information to the summary. In this way it will automatically be added to the email and pipeline_report.

Regarding the nextflow version, it works already for v19.10.0, so it should be fine.

I also changed the summary names from "Config Description" to "Config Profile Description" etc., to distinguish this information about profiles from general config files.


## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
