### PR TITLE
Use rich for linting progress bar and tracebacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,8 @@ making a pull-request. See [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md) 
 * New `--json` and `--markdown` options to print lint results to JSON / markdown files
 * Linting code now automatically posts warning / failing results to GitHub PRs as a comment if it can
 * Added AWS GitHub Actions workflows linting
-* Fail if `params.input` isnt defined.
+* Fail if `params.input` isn't defined.
+* Beautiful new progress bar to look at whilst linting is running
 
 ### nf-core/tools Continuous Integration
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -7,7 +7,8 @@ import click
 import sys
 import os
 import re
-import rich
+import rich.console
+import rich.traceback
 
 import nf_core
 import nf_core.bump_version
@@ -26,6 +27,9 @@ import logging
 
 
 def run_nf_core():
+    # Set up the rich traceback
+    rich.traceback.install()
+
     # Print nf-core header to STDERR
     stderr = rich.console.Console(file=sys.stderr, highlight=False)
     stderr.print("\n[green]{},--.[grey39]/[green],-.".format(" " * 42))

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -15,6 +15,7 @@ import re
 import requests
 import subprocess
 import textwrap
+import rich.progress
 
 import click
 import requests
@@ -217,12 +218,12 @@ class PipelineLint(object):
         if release_mode:
             self.release_mode = True
             check_functions.extend(["check_version_consistency"])
-        with click.progressbar(check_functions, label="Running pipeline tests", item_show_func=repr) as fun_names:
-            for fun_name in fun_names:
-                getattr(self, fun_name)()
-                if len(self.failed) > 0:
-                    logging.error("Found test failures in '{}', halting lint run.".format(fun_name))
-                    break
+
+        for fun_name in rich.progress.track(check_functions, description="Running pipeline tests"):
+            getattr(self, fun_name)()
+            if len(self.failed) > 0:
+                logging.error("Found test failures in '{}', halting lint run.".format(fun_name))
+                break
 
     def check_files_exist(self):
         """Checks a given pipeline directory for required files.

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -219,11 +219,21 @@ class PipelineLint(object):
             self.release_mode = True
             check_functions.extend(["check_version_consistency"])
 
-        for fun_name in rich.progress.track(check_functions, description="Running pipeline tests"):
-            getattr(self, fun_name)()
-            if len(self.failed) > 0:
-                logging.error("Found test failures in '{}', halting lint run.".format(fun_name))
-                break
+        progress = rich.progress.Progress(
+            "[bold blue]{task.description}",
+            rich.progress.BarColumn(),
+            "[magenta]{task.completed} of {task.total}[reset] » [bold yellow]{task.fields[func_name]}",
+        )
+        with progress:
+            lint_progress = progress.add_task(
+                "Running lint checks", total=len(check_functions), func_name=check_functions[0]
+            )
+            for fun_name in check_functions:
+                progress.update(lint_progress, advance=1, func_name=fun_name)
+                getattr(self, fun_name)()
+                if len(self.failed) > 0:
+                    logging.error("Found test failures in '{}', halting lint run.".format(fun_name))
+                    break
 
     def check_files_exist(self):
         """Checks a given pipeline directory for required files.


### PR DESCRIPTION
Added `rich` support for tracebacks and linting progress bars

<img width="803" alt="Screenshot 2020-07-15 at 12 46 07" src="https://user-images.githubusercontent.com/465550/87536391-4e0d1e80-c699-11ea-9c55-9e98b381cb5a.png">

![image](https://user-images.githubusercontent.com/465550/87536347-42215c80-c699-11ea-8312-f0c02a152e65.png)

I tried to make the progress bar use the function name as it updates, as the current bar does. But I struggled a bit and moved on. If anyone else knows how to do this nicely, then that would be a good improvement 👍 