### PR TITLE
Use Rich logging and terminal styling

### DIFF
--- a/.github/workflows/create-lint-wf.yml
+++ b/.github/workflows/create-lint-wf.yml
@@ -34,3 +34,4 @@ jobs:
           nf-core sync nf-core-testpipeline/
           nf-core schema build nf-core-testpipeline/ --no-prompts
           nf-core bump-version nf-core-testpipeline/ 1.1
+          nf-core modules install nf-core-testpipeline/ fastqc

--- a/.github/workflows/create-lint-wf.yml
+++ b/.github/workflows/create-lint-wf.yml
@@ -25,7 +25,12 @@ jobs:
           wget -qO- get.nextflow.io | bash
           sudo ln -s /tmp/nextflow/nextflow /usr/local/bin/nextflow
 
-      - name: Run nf-core tools
+      - name: Run nf-core/tools
         run: |
           nf-core create -n testpipeline -d "This pipeline is for testing" -a "Testing McTestface"
           nf-core lint nf-core-testpipeline
+          nf-core list
+          nf-core licences nf-core-testpipeline
+          nf-core sync nf-core-testpipeline/
+          nf-core schema build nf-core-testpipeline/ --no-prompts
+          nf-core bump-version nf-core-testpipeline/ 1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,8 @@ making a pull-request. See [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md) 
 * Linting code now automatically posts warning / failing results to GitHub PRs as a comment if it can
 * Added AWS GitHub Actions workflows linting
 * Fail if `params.input` isn't defined.
-* Beautiful new progress bar to look at whilst linting is running
+* Beautiful new progress bar to look at whilst linting is running and awesome new formatted output on the command line :heart_eyes:
+  * All made using the excellent [`rich` python library](https://github.com/willmcgugan/rich) - check it out!
 
 ### nf-core/tools Continuous Integration
 
@@ -96,6 +97,7 @@ making a pull-request. See [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md) 
 * `nf-core list` now hides archived pipelines unless `--show_archived` flag is set
 * Command line tools now checks if there is a new version of nf-core/tools available
   * Disable this by setting the environment variable `NFCORE_NO_VERSION_CHECK`, eg. `export NFCORE_NO_VERSION_CHECK=1`
+* Better command-line output formatting of nearly all `nf-core` commands using [`rich`](https://github.com/willmcgugan/rich)
 
 ## v1.9
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 5%
+    patch:
+      default:
+        threshold: 5%

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,4 @@ coverage:
     project:
       default:
         threshold: 5%
-    patch:
-      default:
-        threshold: 5%
+    patch: off

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -218,8 +218,12 @@ def licences(pipeline, json):
     Package name, version and licence is printed to the command line.
     """
     lic = nf_core.licences.WorkflowLicences(pipeline)
-    lic.fetch_conda_licences()
-    lic.print_licences(as_json=json)
+    lic.as_json = json
+    try:
+        print(lic.run_licences())
+    except LookupError as e:
+        log.error(e)
+        sys.exit(1)
 
 
 # nf-core create

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -103,11 +103,12 @@ class CustomHelpOrder(click.Group):
 @click.version_option(nf_core.__version__)
 @click.option("-v", "--verbose", is_flag=True, default=False, help="Verbose output (print debug statements).")
 def nf_core_cli(verbose):
+    stderr = rich.console.Console(file=sys.stderr)
     logging.basicConfig(
         level=logging.DEBUG if verbose else logging.INFO,
         format="%(message)s",
         datefmt=".",
-        handlers=[rich.logging.RichHandler()],
+        handlers=[rich.logging.RichHandler(console=stderr)],
     )
 
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -24,7 +24,7 @@ import nf_core.schema
 import nf_core.sync
 import nf_core.utils
 
-log = logging.getLogger("nfcore")
+log = logging.getLogger(__name__)
 
 
 def run_nf_core():

--- a/nf_core/bump_version.py
+++ b/nf_core/bump_version.py
@@ -3,12 +3,13 @@
 a nf-core pipeline.
 """
 
+import click
 import logging
 import os
 import re
 import sys
 
-import click
+log = logging.getLogger("nfcore")
 
 
 def bump_pipeline_version(lint_obj, new_version):
@@ -22,12 +23,12 @@ def bump_pipeline_version(lint_obj, new_version):
     # Collect the old and new version numbers
     current_version = lint_obj.config.get("manifest.version", "").strip(" '\"")
     if new_version.startswith("v"):
-        logging.warning("Stripping leading 'v' from new version number")
+        log.warning("Stripping leading 'v' from new version number")
         new_version = new_version[1:]
     if not current_version:
-        logging.error("Could not find config variable manifest.version")
+        log.error("Could not find config variable manifest.version")
         sys.exit(1)
-    logging.info(
+    log.info(
         "Changing version number:\n  Current version number is '{}'\n  New version number will be '{}'".format(
             current_version, new_version
         )
@@ -43,7 +44,7 @@ def bump_pipeline_version(lint_obj, new_version):
     if new_version.replace(".", "").isdigit():
         docker_tag = new_version
     else:
-        logging.info("New version contains letters. Setting docker tag to 'dev'")
+        log.info("New version contains letters. Setting docker tag to 'dev'")
     nfconfig_pattern = r"container\s*=\s*[\'\"]nfcore/{}:(?:{}|dev)[\'\"]".format(
         lint_obj.pipeline_name.lower(), current_version.replace(".", r"\.")
     )
@@ -99,9 +100,9 @@ def bump_nextflow_version(lint_obj, new_version):
     current_version = re.sub(r"[^0-9\.]", "", current_version)
     new_version = re.sub(r"[^0-9\.]", "", new_version)
     if not current_version:
-        logging.error("Could not find config variable manifest.nextflowVersion")
+        log.error("Could not find config variable manifest.nextflowVersion")
         sys.exit(1)
-    logging.info(
+    log.info(
         "Changing version number:\n  Current version number is '{}'\n  New version number will be '{}'".format(
             current_version, new_version
         )
@@ -156,10 +157,11 @@ def update_file_version(filename, lint_obj, pattern, newstr, allow_multiple=Fals
     new_content = re.sub(pattern, newstr, content)
     matches_newstr = re.findall("^.*{}.*$".format(newstr), new_content, re.MULTILINE)
 
-    logging.info(
+    log.info(
         "Updating version in {}\n".format(filename)
-        + click.style(" - {}\n".format("\n - ".join(matches_pattern).strip()), fg="red")
-        + click.style(" + {}\n".format("\n + ".join(matches_newstr).strip()), fg="green")
+        + "[red] - {}\n".format("\n - ".join(matches_pattern).strip())
+        + "[green] + {}\n".format("\n + ".join(matches_newstr).strip()),
+        extra={"markup": True},
     )
 
     with open(fn, "w") as fh:

--- a/nf_core/bump_version.py
+++ b/nf_core/bump_version.py
@@ -9,7 +9,7 @@ import os
 import re
 import sys
 
-log = logging.getLogger("nfcore")
+log = logging.getLogger(__name__)
 
 
 def bump_pipeline_version(lint_obj, new_version):

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -15,6 +15,8 @@ import textwrap
 
 import nf_core
 
+log = logging.getLogger("nfcore")
+
 
 class PipelineCreate(object):
     """Creates a nf-core pipeline a la carte from the nf-core best-practise template.
@@ -57,33 +59,26 @@ class PipelineCreate(object):
         if not self.no_git:
             self.git_init_pipeline()
 
-        logging.info(
-            click.style(
-                textwrap.dedent(
-                    """            !!!!!! IMPORTANT !!!!!!
-
-            If you are interested in adding your pipeline to the nf-core community,
-            PLEASE COME AND TALK TO US IN THE NF-CORE SLACK BEFORE WRITING ANY CODE!
-
-            Please read: https://nf-co.re/developers/adding_pipelines#join-the-community
-            """
-                ),
-                fg="green",
-            )
+        log.info(
+            "[green bold]!!!!!! IMPORTANT !!!!!!\n\n"
+            + "[green not bold]If you are interested in adding your pipeline to the nf-core community,\n"
+            + "PLEASE COME AND TALK TO US IN THE NF-CORE SLACK BEFORE WRITING ANY CODE!\n\n"
+            + "[default]Please read: [link=https://nf-co.re/developers/adding_pipelines#join-the-community]https://nf-co.re/developers/adding_pipelines#join-the-community[/link]",
+            extra={"markup": True},
         )
 
     def run_cookiecutter(self):
         """Runs cookiecutter to create a new nf-core pipeline.
         """
-        logging.info("Creating new nf-core pipeline: {}".format(self.name))
+        log.info("Creating new nf-core pipeline: {}".format(self.name))
 
         # Check if the output directory exists
         if os.path.exists(self.outdir):
             if self.force:
-                logging.warning("Output directory '{}' exists - continuing as --force specified".format(self.outdir))
+                log.warning("Output directory '{}' exists - continuing as --force specified".format(self.outdir))
             else:
-                logging.error("Output directory '{}' exists!".format(self.outdir))
-                logging.info("Use -f / --force to overwrite existing files")
+                log.error("Output directory '{}' exists!".format(self.outdir))
+                log.info("Use -f / --force to overwrite existing files")
                 sys.exit(1)
         else:
             os.makedirs(self.outdir)
@@ -123,17 +118,17 @@ class PipelineCreate(object):
         """
 
         logo_url = "https://nf-co.re/logo/{}".format(self.short_name)
-        logging.debug("Fetching logo from {}".format(logo_url))
+        log.debug("Fetching logo from {}".format(logo_url))
 
         email_logo_path = "{}/{}/assets/{}_logo.png".format(self.tmpdir, self.name_noslash, self.name_noslash)
-        logging.debug("Writing logo to {}".format(email_logo_path))
+        log.debug("Writing logo to {}".format(email_logo_path))
         r = requests.get("{}?w=400".format(logo_url))
         with open(email_logo_path, "wb") as fh:
             fh.write(r.content)
 
         readme_logo_path = "{}/{}/docs/images/{}_logo.png".format(self.tmpdir, self.name_noslash, self.name_noslash)
 
-        logging.debug("Writing logo to {}".format(readme_logo_path))
+        log.debug("Writing logo to {}".format(readme_logo_path))
         if not os.path.exists(os.path.dirname(readme_logo_path)):
             os.makedirs(os.path.dirname(readme_logo_path))
         r = requests.get("{}?w=600".format(logo_url))
@@ -143,16 +138,18 @@ class PipelineCreate(object):
     def git_init_pipeline(self):
         """Initialises the new pipeline as a Git repository and submits first commit.
         """
-        logging.info("Initialising pipeline git repository")
+        log.info("Initialising pipeline git repository")
         repo = git.Repo.init(self.outdir)
         repo.git.add(A=True)
         repo.index.commit("initial template build from nf-core/tools, version {}".format(nf_core.__version__))
         # Add TEMPLATE branch to git repository
         repo.git.branch("TEMPLATE")
         repo.git.branch("dev")
-        logging.info(
-            "Done. Remember to add a remote and push to GitHub:\n  cd {}\n  git remote add origin git@github.com:USERNAME/REPO_NAME.git\n  git push --all origin".format(
-                self.outdir
-            )
+        log.info(
+            "Done. Remember to add a remote and push to GitHub:\n"
+            + "[white on grey23] cd {} \n".format(self.outdir)
+            + " git remote add origin git@github.com:USERNAME/REPO_NAME.git \n"
+            + " git push --all origin                                       ",
+            extra={"markup": True},
         )
-        logging.info("This will also push your newly created dev branch and the TEMPLATE branch for syncing.")
+        log.info("This will also push your newly created dev branch and the TEMPLATE branch for syncing.")

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -15,7 +15,7 @@ import textwrap
 
 import nf_core
 
-log = logging.getLogger("nfcore")
+log = logging.getLogger(__name__)
 
 
 class PipelineCreate(object):

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -18,6 +18,8 @@ from zipfile import ZipFile
 import nf_core.list
 import nf_core.utils
 
+log = logging.getLogger("nfcore")
+
 
 class DownloadWorkflow(object):
     """Downloads a nf-core workflow from GitHub to the local file system.
@@ -64,15 +66,15 @@ class DownloadWorkflow(object):
 
         # Check that the outdir doesn't already exist
         if os.path.exists(self.outdir):
-            logging.error("Output directory '{}' already exists".format(self.outdir))
+            log.error("Output directory '{}' already exists".format(self.outdir))
             sys.exit(1)
 
         # Check that compressed output file doesn't already exist
         if self.output_filename and os.path.exists(self.output_filename):
-            logging.error("Output file '{}' already exists".format(self.output_filename))
+            log.error("Output file '{}' already exists".format(self.output_filename))
             sys.exit(1)
 
-        logging.info(
+        log.info(
             "Saving {}".format(self.pipeline)
             + "\n Pipeline release: {}".format(self.release)
             + "\n Pull singularity containers: {}".format("Yes" if self.singularity else "No")
@@ -80,23 +82,23 @@ class DownloadWorkflow(object):
         )
 
         # Download the pipeline files
-        logging.info("Downloading workflow files from GitHub")
+        log.info("Downloading workflow files from GitHub")
         self.download_wf_files()
 
         # Download the centralised configs
-        logging.info("Downloading centralised configs from GitHub")
+        log.info("Downloading centralised configs from GitHub")
         self.download_configs()
         self.wf_use_local_configs()
 
         # Download the singularity images
         if self.singularity:
-            logging.debug("Fetching container names for workflow")
+            log.debug("Fetching container names for workflow")
             self.find_container_images()
             if len(self.containers) == 0:
-                logging.info("No container names found in workflow")
+                log.info("No container names found in workflow")
             else:
                 os.mkdir(os.path.join(self.outdir, "singularity-images"))
-                logging.info(
+                log.info(
                     "Downloading {} singularity container{}".format(
                         len(self.containers), "s" if len(self.containers) > 1 else ""
                     )
@@ -107,12 +109,12 @@ class DownloadWorkflow(object):
                         self.pull_singularity_image(container)
                     except RuntimeWarning as r:
                         # Raise exception if this is not possible
-                        logging.error("Not able to pull image. Service might be down or internet connection is dead.")
+                        log.error("Not able to pull image. Service might be down or internet connection is dead.")
                         raise r
 
         # Compress into an archive
         if self.compress_type is not None:
-            logging.info("Compressing download..")
+            log.info("Compressing download..")
             self.compress_download()
 
     def fetch_workflow_details(self, wfs):
@@ -139,7 +141,7 @@ class DownloadWorkflow(object):
                     wf.releases = sorted(wf.releases, key=lambda k: k.get("published_at_timestamp", 0), reverse=True)
                     self.release = wf.releases[0]["tag_name"]
                     self.wf_sha = wf.releases[0]["tag_sha"]
-                    logging.debug("No release specified. Using latest release: {}".format(self.release))
+                    log.debug("No release specified. Using latest release: {}".format(self.release))
                 # Find specified release hash
                 elif self.release is not None:
                     for r in wf.releases:
@@ -147,8 +149,8 @@ class DownloadWorkflow(object):
                             self.wf_sha = r["tag_sha"]
                             break
                     else:
-                        logging.error("Not able to find release '{}' for {}".format(self.release, wf.full_name))
-                        logging.info(
+                        log.error("Not able to find release '{}' for {}".format(self.release, wf.full_name))
+                        log.info(
                             "Available {} releases: {}".format(
                                 wf.full_name, ", ".join([r["tag_name"] for r in wf.releases])
                             )
@@ -159,7 +161,7 @@ class DownloadWorkflow(object):
                 elif not self.release:
                     self.release = "dev"
                     self.wf_sha = "master"  # Cheating a little, but GitHub download link works
-                    logging.warning(
+                    log.warning(
                         "Pipeline is in development - downloading current code on master branch.\n"
                         + "This is likely to change soon should not be considered fully reproducible."
                     )
@@ -177,8 +179,8 @@ class DownloadWorkflow(object):
         # If we got this far, must not be a nf-core pipeline
         if self.pipeline.count("/") == 1:
             # Looks like a GitHub address - try working with this repo
-            logging.warning("Pipeline name doesn't match any nf-core workflows")
-            logging.info("Pipeline name looks like a GitHub address - attempting to download anyway")
+            log.warning("Pipeline name doesn't match any nf-core workflows")
+            log.info("Pipeline name looks like a GitHub address - attempting to download anyway")
             self.wf_name = self.pipeline
             if not self.release:
                 self.release = "master"
@@ -190,14 +192,14 @@ class DownloadWorkflow(object):
             # Set the download URL and return
             self.wf_download_url = "https://github.com/{}/archive/{}.zip".format(self.pipeline, self.release)
         else:
-            logging.error("Not able to find pipeline '{}'".format(self.pipeline))
-            logging.info("Available pipelines: {}".format(", ".join([w.name for w in wfs.remote_workflows])))
+            log.error("Not able to find pipeline '{}'".format(self.pipeline))
+            log.info("Available pipelines: {}".format(", ".join([w.name for w in wfs.remote_workflows])))
             raise LookupError("Not able to find pipeline '{}'".format(self.pipeline))
 
     def download_wf_files(self):
         """Downloads workflow files from GitHub to the :attr:`self.outdir`.
         """
-        logging.debug("Downloading {}".format(self.wf_download_url))
+        log.debug("Downloading {}".format(self.wf_download_url))
 
         # Download GitHub zip file into memory and extract
         url = requests.get(self.wf_download_url)
@@ -218,7 +220,7 @@ class DownloadWorkflow(object):
         """
         configs_zip_url = "https://github.com/nf-core/configs/archive/master.zip"
         configs_local_dir = "configs-master"
-        logging.debug("Downloading {}".format(configs_zip_url))
+        log.debug("Downloading {}".format(configs_zip_url))
 
         # Download GitHub zip file into memory and extract
         url = requests.get(configs_zip_url)
@@ -239,7 +241,7 @@ class DownloadWorkflow(object):
         nfconfig_fn = os.path.join(self.outdir, "workflow", "nextflow.config")
         find_str = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
         repl_str = "../configs/"
-        logging.debug("Editing params.custom_config_base in {}".format(nfconfig_fn))
+        log.debug("Editing params.custom_config_base in {}".format(nfconfig_fn))
 
         # Load the nextflow.config file into memory
         with open(nfconfig_fn, "r") as nfconfig_fh:
@@ -277,8 +279,8 @@ class DownloadWorkflow(object):
         out_path = os.path.abspath(os.path.join(self.outdir, "singularity-images", out_name))
         address = "docker://{}".format(container.replace("docker://", ""))
         singularity_command = ["singularity", "pull", "--name", out_path, address]
-        logging.info("Building singularity image from Docker Hub: {}".format(address))
-        logging.debug("Singularity command: {}".format(" ".join(singularity_command)))
+        log.info("Building singularity image from Docker Hub: {}".format(address))
+        log.debug("Singularity command: {}".format(" ".join(singularity_command)))
 
         # Try to use singularity to pull image
         try:
@@ -286,7 +288,7 @@ class DownloadWorkflow(object):
         except OSError as e:
             if e.errno == errno.ENOENT:
                 # Singularity is not installed
-                logging.error("Singularity is not installed!")
+                log.error("Singularity is not installed!")
             else:
                 # Something else went wrong with singularity command
                 raise e
@@ -294,7 +296,7 @@ class DownloadWorkflow(object):
     def compress_download(self):
         """Take the downloaded files and make a compressed .tar.gz archive.
         """
-        logging.debug("Creating archive: {}".format(self.output_filename))
+        log.debug("Creating archive: {}".format(self.output_filename))
 
         # .tar.gz and .tar.bz2 files
         if self.compress_type == "tar.gz" or self.compress_type == "tar.bz2":
@@ -302,7 +304,7 @@ class DownloadWorkflow(object):
             with tarfile.open(self.output_filename, "w:{}".format(ctype)) as tar:
                 tar.add(self.outdir, arcname=os.path.basename(self.outdir))
             tar_flags = "xzf" if ctype == "gz" else "xjf"
-            logging.info("Command to extract files: tar -{} {}".format(tar_flags, self.output_filename))
+            log.info("Command to extract files: tar -{} {}".format(tar_flags, self.output_filename))
 
         # .zip files
         if self.compress_type == "zip":
@@ -314,10 +316,10 @@ class DownloadWorkflow(object):
                         filePath = os.path.join(folderName, filename)
                         # Add file to zip
                         zipObj.write(filePath)
-            logging.info("Command to extract files: unzip {}".format(self.output_filename))
+            log.info("Command to extract files: unzip {}".format(self.output_filename))
 
         # Delete original files
-        logging.debug("Deleting uncompressed files: {}".format(self.outdir))
+        log.debug("Deleting uncompressed files: {}".format(self.outdir))
         shutil.rmtree(self.outdir)
 
         # Caclualte md5sum for output file
@@ -333,7 +335,7 @@ class DownloadWorkflow(object):
         Raises:
             IOError, if the md5sum does not match the remote sum.
         """
-        logging.debug("Validating image hash: {}".format(fname))
+        log.debug("Validating image hash: {}".format(fname))
 
         # Calculate the md5 for the file on disk
         hash_md5 = hashlib.md5()
@@ -343,9 +345,9 @@ class DownloadWorkflow(object):
         file_hash = hash_md5.hexdigest()
 
         if expected is None:
-            logging.info("MD5 checksum for {}: {}".format(fname, file_hash))
+            log.info("MD5 checksum for {}: {}".format(fname, file_hash))
         else:
             if file_hash == expected:
-                logging.debug("md5 sum of image matches expected: {}".format(expected))
+                log.debug("md5 sum of image matches expected: {}".format(expected))
             else:
                 raise IOError("{} md5 does not match remote: {} - {}".format(fname, expected, file_hash))

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -18,7 +18,7 @@ from zipfile import ZipFile
 import nf_core.list
 import nf_core.utils
 
-log = logging.getLogger("nfcore")
+log = logging.getLogger(__name__)
 
 
 class DownloadWorkflow(object):

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -18,7 +18,7 @@ import webbrowser
 
 import nf_core.schema, nf_core.utils
 
-log = logging.getLogger("nfcore")
+log = logging.getLogger(__name__)
 
 #
 # NOTE: WE ARE USING A PRE-RELEASE VERSION OF PYINQUIRER

--- a/nf_core/licences.py
+++ b/nf_core/licences.py
@@ -16,7 +16,7 @@ import rich.table
 
 import nf_core.lint
 
-log = logging.getLogger("nfcore")
+log = logging.getLogger(__name__)
 
 
 class WorkflowLicences(object):

--- a/nf_core/licences.py
+++ b/nf_core/licences.py
@@ -13,6 +13,8 @@ import yaml
 
 import nf_core.lint
 
+log = logging.getLogger("nfcore")
+
 
 class WorkflowLicences(object):
     """A nf-core workflow licenses collection.
@@ -41,7 +43,7 @@ class WorkflowLicences(object):
 
         # Check that the pipeline exists
         if response.status_code == 404:
-            logging.error("Couldn't find pipeline nf-core/{}".format(self.pipeline))
+            log.error("Couldn't find pipeline nf-core/{}".format(self.pipeline))
             raise LookupError("Couldn't find pipeline nf-core/{}".format(self.pipeline))
 
         lint_obj = nf_core.lint.PipelineLint(self.pipeline)
@@ -54,7 +56,7 @@ class WorkflowLicences(object):
                 elif isinstance(dep, dict):
                     lint_obj.check_pip_package(dep)
             except ValueError:
-                logging.error("Couldn't get licence information for {}".format(dep))
+                log.error("Couldn't get licence information for {}".format(dep))
 
         for dep, data in lint_obj.conda_package_info.items():
             try:
@@ -102,7 +104,7 @@ class WorkflowLicences(object):
         Args:
             as_json (boolean): Prints the information in JSON. Defaults to False.
         """
-        logging.info(
+        log.info(
             """Warning: This tool only prints licence information for the software tools packaged using conda.
         The pipeline may use other software and dependencies not described here. """
         )

--- a/nf_core/licences.py
+++ b/nf_core/licences.py
@@ -5,11 +5,14 @@ from __future__ import print_function
 
 import logging
 import json
+import os
 import re
 import requests
 import sys
 import tabulate
 import yaml
+import rich.console
+import rich.table
 
 import nf_core.lint
 
@@ -31,25 +34,49 @@ class WorkflowLicences(object):
 
     def __init__(self, pipeline):
         self.pipeline = pipeline
+        self.conda_config = None
         if self.pipeline.startswith("nf-core/"):
             self.pipeline = self.pipeline[8:]
+        self.conda_packages = {}
         self.conda_package_licences = {}
+        self.as_json = False
+
+    def run_licences(self):
+        """
+        Run the nf-core licences action
+        """
+        self.get_environment_file()
+        self.fetch_conda_licences()
+        return self.print_licences()
+
+    def get_environment_file(self):
+        """Get the conda environment file for the pipeline
+        """
+        if os.path.exists(self.pipeline):
+            env_filename = os.path.join(self.pipeline, "environment.yml")
+            if not os.path.exists(self.pipeline):
+                raise LookupError("Pipeline {} exists, but no environment.yml file found".format(self.pipeline))
+            with open(env_filename, "r") as fh:
+                self.conda_config = yaml.safe_load(fh)
+        else:
+            env_url = "https://raw.githubusercontent.com/nf-core/{}/master/environment.yml".format(self.pipeline)
+            log.debug("Fetching environment.yml file: {}".format(env_url))
+            response = requests.get(env_url)
+            # Check that the pipeline exists
+            if response.status_code == 404:
+                raise LookupError("Couldn't find pipeline nf-core/{}".format(self.pipeline))
+            self.conda_config = yaml.safe_load(response.text)
 
     def fetch_conda_licences(self):
         """Fetch package licences from Anaconda and PyPi.
         """
-        env_url = "https://raw.githubusercontent.com/nf-core/{}/master/environment.yml".format(self.pipeline)
-        response = requests.get(env_url)
-
-        # Check that the pipeline exists
-        if response.status_code == 404:
-            log.error("Couldn't find pipeline nf-core/{}".format(self.pipeline))
-            raise LookupError("Couldn't find pipeline nf-core/{}".format(self.pipeline))
 
         lint_obj = nf_core.lint.PipelineLint(self.pipeline)
-        lint_obj.conda_config = yaml.safe_load(response.text)
+        lint_obj.conda_config = self.conda_config
         # Check conda dependency list
-        for dep in lint_obj.conda_config.get("dependencies", []):
+        deps = lint_obj.conda_config.get("dependencies", [])
+        log.info("Fetching licence information for {} tools".format(len(deps)))
+        for dep in deps:
             try:
                 if isinstance(dep, str):
                     lint_obj.check_anaconda_package(dep)
@@ -98,20 +125,19 @@ class WorkflowLicences(object):
             clean_licences.append(l)
         return clean_licences
 
-    def print_licences(self, as_json=False):
+    def print_licences(self):
         """Prints the fetched license information.
 
         Args:
             as_json (boolean): Prints the information in JSON. Defaults to False.
         """
-        log.info(
-            """Warning: This tool only prints licence information for the software tools packaged using conda.
-        The pipeline may use other software and dependencies not described here. """
-        )
+        log.info("Warning: This tool only prints licence information for the software tools packaged using conda.")
+        log.info("The pipeline may use other software and dependencies not described here. ")
 
-        if as_json:
-            print(json.dumps(self.conda_package_licences, indent=4))
+        if self.as_json:
+            return json.dumps(self.conda_package_licences, indent=4)
         else:
+            table = rich.table.Table("Package Name", "Version", "Licence")
             licence_list = []
             for dep, licences in self.conda_package_licences.items():
                 depname, depver = dep.split("=", 1)
@@ -122,7 +148,7 @@ class WorkflowLicences(object):
                 licence_list.append([depname, depver, ", ".join(licences)])
             # Sort by licence, then package name
             licence_list = sorted(sorted(licence_list), key=lambda x: x[2])
-            # Print summary table
-            print("", file=sys.stderr)
-            print(tabulate.tabulate(licence_list, headers=["Package Name", "Version", "Licence"]))
-            print("", file=sys.stderr)
+            # Add table rows
+            for lic in licence_list:
+                table.add_row(*lic)
+            return table

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -1255,9 +1255,10 @@ class PipelineLint(object):
 
     def check_schema_lint(self):
         """ Lint the pipeline JSON schema file """
-        # Suppress log messages
-        logger = logging.getLogger("nfcore")
-        logger.disabled = True
+
+        # Only show error messages from schema
+        if log.getEffectiveLevel() == logging.INFO:
+            logging.getLogger("nfcore.schema").setLevel(logging.ERROR)
 
         # Lint the schema
         self.schema_obj = nf_core.schema.PipelineSchema()
@@ -1267,9 +1268,6 @@ class PipelineLint(object):
             self.passed.append((14, "Schema lint passed"))
         except AssertionError as e:
             self.failed.append((14, "Schema lint failed: {}".format(e)))
-
-        # Reset logger
-        logger.disabled = False
 
     def check_schema_params(self):
         """ Check that the schema describes all flat params in the pipeline """
@@ -1325,7 +1323,7 @@ class PipelineLint(object):
                 results.append("1. [https://nf-co.re/errors#{0}](https://nf-co.re/errors#{0}): {1}".format(eid, msg))
             return rich.markdown.Markdown("\n".join(results))
 
-        if len(self.passed) > 0 and logging.getLogger("nfcore").getEffectiveLevel() == logging.DEBUG:
+        if len(self.passed) > 0 and log.getEffectiveLevel() == logging.DEBUG:
             console.print()
             console.rule("[bold green][[\u2714]] Tests Passed", style="green")
             console.print(

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -27,7 +27,7 @@ import yaml
 import nf_core.utils
 import nf_core.schema
 
-log = logging.getLogger("nfcore")
+log = logging.getLogger(__name__)
 
 # Set up local caching for requests to speed up remote queries
 nf_core.utils.setup_requests_cachedir()

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -13,10 +13,11 @@ import logging
 import os
 import re
 import requests
-import rich.console
-import rich.markdown
-import rich.panel
+import rich
+from rich.console import Console
+from rich.markdown import Markdown
 import rich.progress
+from rich.table import Table
 import subprocess
 import textwrap
 
@@ -81,7 +82,6 @@ def run_linting(pipeline_dir, release_mode=False, md_fn=None, json_fn=None):
 
     # Exit code
     if len(lint_obj.failed) > 0:
-        log.error("Sorry, some tests failed - exiting with a non-zero error code...")
         if release_mode:
             log.info("Reminder: Lint tests were run in --release mode.")
 
@@ -491,11 +491,9 @@ class PipelineLint(object):
         # Check the variables that should be set to 'true'
         for k in ["timeline.enabled", "report.enabled", "trace.enabled", "dag.enabled"]:
             if self.config.get(k) == "true":
-                self.passed.append((4, "Config variable `{}` had correct value: {}".format(k, self.config.get(k))))
+                self.passed.append((4, "Config `{}` had correct value: `{}`".format(k, self.config.get(k))))
             else:
-                self.failed.append(
-                    (4, "Config variable `{}` did not have correct value: {}".format(k, self.config.get(k)))
-                )
+                self.failed.append((4, "Config `{}` did not have correct value: `{}`".format(k, self.config.get(k))))
 
         # Check that the pipeline name starts with nf-core
         try:
@@ -504,13 +502,13 @@ class PipelineLint(object):
             self.failed.append(
                 (
                     4,
-                    "Config variable `manifest.name` did not begin with nf-core/:\n    {}".format(
+                    "Config `manifest.name` did not begin with `nf-core/`:\n    {}".format(
                         self.config.get("manifest.name", "").strip("'\"")
                     ),
                 )
             )
         else:
-            self.passed.append((4, "Config variable `manifest.name` began with 'nf-core/'"))
+            self.passed.append((4, "Config `manifest.name` began with `nf-core/`"))
             self.pipeline_name = self.config.get("manifest.name", "").strip("'").replace("nf-core/", "")
 
         # Check that the homePage is set to the GitHub URL
@@ -526,14 +524,14 @@ class PipelineLint(object):
                 )
             )
         else:
-            self.passed.append((4, "Config variable `manifest.homePage` began with 'https://github.com/nf-core/'"))
+            self.passed.append((4, "Config variable `manifest.homePage` began with https://github.com/nf-core/"))
 
         # Check that the DAG filename ends in `.svg`
         if "dag.file" in self.config:
             if self.config["dag.file"].strip("'\"").endswith(".svg"):
-                self.passed.append((4, "Config variable `dag.file` ended with .svg"))
+                self.passed.append((4, "Config `dag.file` ended with `.svg`"))
             else:
-                self.failed.append((4, "Config variable `dag.file` did not end with .svg"))
+                self.failed.append((4, "Config `dag.file` did not end with `.svg`"))
 
         # Check that the minimum nextflowVersion is set properly
         if "manifest.nextflowVersion" in self.config:
@@ -549,7 +547,7 @@ class PipelineLint(object):
                 self.failed.append(
                     (
                         4,
-                        "Config variable `manifest.nextflowVersion` did not start with '>=' or '!>=' : `{}`".format(
+                        "Config `manifest.nextflowVersion` did not start with `>=` or `!>=` : `{}`".format(
                             self.config.get("manifest.nextflowVersion", "")
                         ).strip("\"'"),
                     )
@@ -572,7 +570,7 @@ class PipelineLint(object):
                     self.failed.append(
                         (
                             4,
-                            "Config variable process.container looks wrong. Should be `{}` but is `{}`".format(
+                            "Config `process.container` looks wrong. Should be `{}` but is `{}`".format(
                                 container_name, self.config.get("process.container", "").strip("'")
                             ),
                         )
@@ -581,35 +579,30 @@ class PipelineLint(object):
                     self.warned.append(
                         (
                             4,
-                            "Config variable process.container looks wrong. Should be `{}` but is `{}`. Fix this before you make a release of your pipeline!".format(
+                            "Config `process.container` looks wrong. Should be `{}` but is `{}`".format(
                                 container_name, self.config.get("process.container", "").strip("'")
                             ),
                         )
                     )
             else:
-                self.passed.append((4, "Config variable process.container looks correct: `{}`".format(container_name)))
+                self.passed.append((4, "Config `process.container` looks correct: `{}`".format(container_name)))
 
         # Check that the pipeline version contains `dev`
         if not self.release_mode and "manifest.version" in self.config:
             if self.config["manifest.version"].strip(" '\"").endswith("dev"):
                 self.passed.append(
-                    (4, "Config variable manifest.version ends in `dev`: `{}`".format(self.config["manifest.version"]))
+                    (4, "Config `manifest.version` ends in `dev`: `{}`".format(self.config["manifest.version"]))
                 )
             else:
                 self.warned.append(
-                    (
-                        4,
-                        "Config variable manifest.version should end in `dev`: `{}`".format(
-                            self.config["manifest.version"]
-                        ),
-                    )
+                    (4, "Config `manifest.version` should end in `dev`: `{}`".format(self.config["manifest.version"]),)
                 )
         elif "manifest.version" in self.config:
             if "dev" in self.config["manifest.version"]:
                 self.failed.append(
                     (
                         4,
-                        "Config variable manifest.version should not contain `dev` for a release: `{}`".format(
+                        "Config `manifest.version` should not contain `dev` for a release: `{}`".format(
                             self.config["manifest.version"]
                         ),
                     )
@@ -618,7 +611,7 @@ class PipelineLint(object):
                 self.passed.append(
                     (
                         4,
-                        "Config variable manifest.version does not contain `dev` for release: `{}`".format(
+                        "Config `manifest.version` does not contain `dev` for release: `{}`".format(
                             self.config["manifest.version"]
                         ),
                     )
@@ -661,23 +654,11 @@ class PipelineLint(object):
                     "PIPELINENAME", self.pipeline_name.lower()
                 )
                 if has_name and has_if and has_run:
-                    self.passed.append(
-                        (
-                            5,
-                            "GitHub Actions 'branch' workflow checks that forks don't submit PRs to master: `{}`".format(
-                                fn
-                            ),
-                        )
-                    )
+                    self.passed.append((5, "GitHub Actions 'branch' workflow looks good: `{}`".format(fn),))
                     break
             else:
                 self.failed.append(
-                    (
-                        5,
-                        "Couldn't find GitHub Actions 'branch' workflow step to check that forks don't submit PRs to master: `{}`".format(
-                            fn
-                        ),
-                    )
+                    (5, "Couldn't find GitHub Actions 'branch' check for PRs to master: `{}`".format(fn),)
                 )
 
     def check_actions_ci(self):
@@ -696,18 +677,9 @@ class PipelineLint(object):
                 # NB: YAML dict key 'on' is evaluated to a Python dict key True
                 assert ciwf[True] == expected
             except (AssertionError, KeyError, TypeError):
-                self.failed.append(
-                    (
-                        5,
-                        "GitHub Actions CI workflow is not triggered on expected GitHub Actions events: `{}`".format(
-                            fn
-                        ),
-                    )
-                )
+                self.failed.append((5, "GitHub Actions CI is not triggered on expected events: `{}`".format(fn),))
             else:
-                self.passed.append(
-                    (5, "GitHub Actions CI workflow is triggered on expected GitHub Actions events: `{}`".format(fn))
-                )
+                self.passed.append((5, "GitHub Actions CI is triggered on expected events: `{}`".format(fn)))
 
             # Check that we're pulling the right docker image and tagging it properly
             if self.config.get("process.container", ""):
@@ -721,15 +693,10 @@ class PipelineLint(object):
                     assert any([docker_build_cmd in step["run"] for step in steps if "run" in step.keys()])
                 except (AssertionError, KeyError, TypeError):
                     self.failed.append(
-                        (
-                            5,
-                            "CI is not building the correct docker image. Should be:\n    `{}`".format(
-                                docker_build_cmd
-                            ),
-                        )
+                        (5, "CI is not building the correct docker image. Should be: `{}`".format(docker_build_cmd),)
                     )
                 else:
-                    self.passed.append((5, "CI is building the correct docker image: {}".format(docker_build_cmd)))
+                    self.passed.append((5, "CI is building the correct docker image: `{}`".format(docker_build_cmd)))
 
                 # docker pull
                 docker_pull_cmd = "docker pull {}:dev".format(docker_notag)
@@ -738,7 +705,7 @@ class PipelineLint(object):
                     assert any([docker_pull_cmd in step["run"] for step in steps if "run" in step.keys()])
                 except (AssertionError, KeyError, TypeError):
                     self.failed.append(
-                        (5, "CI is not pulling the correct docker image. Should be:\n    `{}`".format(docker_pull_cmd))
+                        (5, "CI is not pulling the correct docker image. Should be: `{}`".format(docker_pull_cmd))
                     )
                 else:
                     self.passed.append((5, "CI is pulling the correct docker image: {}".format(docker_pull_cmd)))
@@ -750,7 +717,7 @@ class PipelineLint(object):
                     assert any([docker_tag_cmd in step["run"] for step in steps if "run" in step.keys()])
                 except (AssertionError, KeyError, TypeError):
                     self.failed.append(
-                        (5, "CI is not tagging docker image correctly. Should be:\n    `{}`".format(docker_tag_cmd))
+                        (5, "CI is not tagging docker image correctly. Should be: `{}`".format(docker_tag_cmd))
                     )
                 else:
                     self.passed.append((5, "CI is tagging docker image correctly: {}".format(docker_tag_cmd)))
@@ -762,9 +729,7 @@ class PipelineLint(object):
             except (KeyError, TypeError):
                 self.failed.append((5, "Continuous integration does not check minimum NF version: `{}`".format(fn)))
             except AssertionError:
-                self.failed.append(
-                    (5, "Minimum NF version differed from CI and what was set in the pipelines manifest: {}".format(fn))
-                )
+                self.failed.append((5, "Minimum NF version different in CI and pipelines manifest: `{}`".format(fn)))
             else:
                 self.passed.append((5, "Continuous integration checks minimum NF version: `{}`".format(fn)))
 
@@ -1013,9 +978,9 @@ class PipelineLint(object):
                 try:
                     assert dep.count("=") in [1, 2]
                 except AssertionError:
-                    self.failed.append((8, "Conda dependency did not have pinned version number: {}".format(dep)))
+                    self.failed.append((8, "Conda dependency did not have pinned version number: `{}`".format(dep)))
                 else:
-                    self.passed.append((8, "Conda dependency had pinned version number: {}".format(dep)))
+                    self.passed.append((8, "Conda dependency had pinned version number: `{}`".format(dep)))
 
                     try:
                         depname, depver = dep.split("=")[:2]
@@ -1298,47 +1263,60 @@ class PipelineLint(object):
             self.passed.append((15, "Schema matched params returned from nextflow config"))
 
     def print_results(self):
-        console = rich.console.Console()
-        console.print()
-        console.rule("[bold green] LINT RESULTS")
-        console.print()
-        console.print(
-            "  [green][[\u2714]] {:>4} tests passed\n  [yellow][[!]] {:>4} tests had warnings\n  [red][[\u2717]] {:>4} tests failed".format(
-                len(self.passed), len(self.warned), len(self.failed)
-            ),
-            overflow="ellipsis",
-            highlight=False,
-        )
-        if self.release_mode:
-            console.print("\n  Using --release mode linting tests")
+        console = Console()
 
         # Helper function to format test links nicely
-        def format_result(test_results):
+        def format_result(test_results, table):
             """
             Given an list of error message IDs and the message texts, return a nicely formatted
             string for the terminal with appropriate ASCII colours.
             """
-            results = []
             for eid, msg in test_results:
-                results.append("1. [https://nf-co.re/errors#{0}](https://nf-co.re/errors#{0}): {1}".format(eid, msg))
-            return rich.markdown.Markdown("\n".join(results))
+                table.add_row(
+                    Markdown("[https://nf-co.re/errors#{0}](https://nf-co.re/errors#{0}): {1}".format(eid, msg))
+                )
+            return table
 
+        def _s(some_list):
+            if len(some_list) > 1:
+                return "s"
+            return ""
+
+        # Table of passed tests
         if len(self.passed) > 0 and log.getEffectiveLevel() == logging.DEBUG:
-            console.print()
-            console.rule("[bold green][[\u2714]] Tests Passed", style="green")
-            console.print(
-                rich.panel.Panel(format_result(self.passed), style="green"), no_wrap=True, overflow="ellipsis"
+            table = Table(style="green", box=rich.box.ROUNDED)
+            table.add_column(
+                "[[\u2714]] {} Test{} Passed".format(len(self.passed), _s(self.passed)), no_wrap=True,
             )
+            table = format_result(self.passed, table)
+            console.print(table)
+
+        # Table of warning tests
         if len(self.warned) > 0:
-            console.print()
-            console.rule("[bold yellow][[!]] Test Warnings", style="yellow")
-            console.print(
-                rich.panel.Panel(format_result(self.warned), style="yellow"), no_wrap=True, overflow="ellipsis"
-            )
+            table = Table(style="yellow", box=rich.box.ROUNDED)
+            table.add_column("[[!]] {} Test Warning{}".format(len(self.warned), _s(self.warned)), no_wrap=True)
+            table = format_result(self.warned, table)
+            console.print(table)
+
+        # Table of failing tests
         if len(self.failed) > 0:
-            console.print()
-            console.rule("[bold red][[\u2717]] Test Failures", style="red")
-            console.print(rich.panel.Panel(format_result(self.failed), style="red"), no_wrap=True, overflow="ellipsis")
+            table = Table(style="red", box=rich.box.ROUNDED)
+            table.add_column(
+                "[[\u2717]] {} Test{} Failed".format(len(self.failed), _s(self.failed)), no_wrap=True,
+            )
+            table = format_result(self.failed, table)
+            console.print(table)
+
+        # Summary table
+
+        table = Table(box=rich.box.ROUNDED)
+        table.add_column("[bold green]LINT RESULTS SUMMARY".format(len(self.passed)), no_wrap=True)
+        table.add_row(
+            "[[\u2714]] {:>3} Test{} Passed".format(len(self.passed), _s(self.passed)), style="green",
+        )
+        table.add_row("[[!]] {:>3} Test Warning{}".format(len(self.warned), _s(self.warned)), style="yellow")
+        table.add_row("[[\u2717]] {:>3} Test{} Failed".format(len(self.failed), _s(self.failed)), style="red")
+        console.print(table)
 
     def get_results_md(self):
         """

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -199,6 +199,9 @@ class PipelineLint(object):
         Raises:
             If a critical problem is found, an ``AssertionError`` is raised.
         """
+        log.info("Testing pipeline: [magenta]{}".format(self.path), extra={"markup": True})
+        if self.release_mode:
+            log.info("Including --release mode tests")
         check_functions = [
             "check_files_exist",
             "check_licence",
@@ -1223,7 +1226,7 @@ class PipelineLint(object):
 
         # Only show error messages from schema
         if log.getEffectiveLevel() == logging.INFO:
-            logging.getLogger("nfcore.schema").setLevel(logging.ERROR)
+            logging.getLogger("nf_core.schema").setLevel(logging.ERROR)
 
         # Lint the schema
         self.schema_obj = nf_core.schema.PipelineSchema()

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -226,6 +226,7 @@ class PipelineLint(object):
             "[bold blue]{task.description}",
             rich.progress.BarColumn(bar_width=None),
             "[magenta]{task.completed} of {task.total}[reset] » [bold yellow]{task.fields[func_name]}",
+            transient=True,
         )
         with progress:
             lint_progress = progress.add_task(

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -1255,7 +1255,7 @@ class PipelineLint(object):
     def check_schema_lint(self):
         """ Lint the pipeline JSON schema file """
         # Suppress log messages
-        logger = log.getLogger()
+        logger = logging.getLogger("nfcore")
         logger.disabled = True
 
         # Lint the schema
@@ -1324,7 +1324,7 @@ class PipelineLint(object):
                 results.append("1. [https://nf-co.re/errors#{0}](https://nf-co.re/errors#{0}): {1}".format(eid, msg))
             return rich.markdown.Markdown("\n".join(results))
 
-        if len(self.passed) > 0 and log.getLogger().getEffectiveLevel() == log.DEBUG:
+        if len(self.passed) > 0 and logging.getLogger("nfcore").getEffectiveLevel() == logging.DEBUG:
             console.print()
             console.rule("[bold green][[\u2714]] Tests Passed", style="green")
             console.print(

--- a/nf_core/list.py
+++ b/nf_core/list.py
@@ -17,7 +17,6 @@ import rich.console
 import rich.table
 import subprocess
 import sys
-import tabulate
 
 import nf_core.utils
 

--- a/nf_core/list.py
+++ b/nf_core/list.py
@@ -20,7 +20,7 @@ import sys
 
 import nf_core.utils
 
-log = logging.getLogger("nfcore")
+log = logging.getLogger(__name__)
 
 # Set up local caching for requests to speed up remote queries
 nf_core.utils.setup_requests_cachedir()

--- a/nf_core/list.py
+++ b/nf_core/list.py
@@ -7,20 +7,21 @@ from collections import OrderedDict
 import click
 import datetime
 import errno
+import git
 import json
 import logging
 import os
 import re
+import requests
 import rich.console
 import rich.table
 import subprocess
 import sys
-
-import git
-import requests
 import tabulate
 
 import nf_core.utils
+
+log = logging.getLogger("nfcore")
 
 # Set up local caching for requests to speed up remote queries
 nf_core.utils.setup_requests_cachedir()
@@ -64,11 +65,11 @@ def get_local_wf(workflow, revision=None):
                     print_revision = "{} - {}".format(wf.branch, wf.commit_sha[:7])
                 else:
                     print_revision = wf.commit_sha
-                logging.info("Using local workflow: {} ({})".format(workflow, print_revision))
+                log.info("Using local workflow: {} ({})".format(workflow, print_revision))
                 return wf.local_path
 
     # Wasn't local, fetch it
-    logging.info("Downloading workflow: {} ({})".format(workflow, revision))
+    log.info("Downloading workflow: {} ({})".format(workflow, revision))
     try:
         with open(os.devnull, "w") as devnull:
             cmd = ["nextflow", "pull", workflow]
@@ -112,7 +113,7 @@ class Workflows(object):
         Remote workflows are stored in :attr:`self.remote_workflows` list.
         """
         # List all repositories at nf-core
-        logging.debug("Fetching list of nf-core workflows")
+        log.debug("Fetching list of nf-core workflows")
         nfcore_url = "https://nf-co.re/pipelines.json"
         response = requests.get(nfcore_url, timeout=10)
         if response.status_code == 200:
@@ -131,14 +132,14 @@ class Workflows(object):
         else:
             nextflow_wfdir = os.path.join(os.getenv("HOME"), ".nextflow", "assets")
         if os.path.isdir(nextflow_wfdir):
-            logging.debug("Guessed nextflow assets directory - pulling pipeline dirnames")
+            log.debug("Guessed nextflow assets directory - pulling pipeline dirnames")
             for org_name in os.listdir(nextflow_wfdir):
                 for wf_name in os.listdir(os.path.join(nextflow_wfdir, org_name)):
                     self.local_workflows.append(LocalWorkflow("{}/{}".format(org_name, wf_name)))
 
         # Fetch details about local cached pipelines with `nextflow list`
         else:
-            logging.debug("Getting list of local nextflow workflows")
+            log.debug("Getting list of local nextflow workflows")
             try:
                 with open(os.devnull, "w") as devnull:
                     nflist_raw = subprocess.check_output(["nextflow", "list"], stderr=devnull)
@@ -157,7 +158,7 @@ class Workflows(object):
                         self.local_workflows.append(LocalWorkflow(wf_name))
 
         # Find additional information about each workflow by checking its git history
-        logging.debug("Fetching extra info about {} local workflows".format(len(self.local_workflows)))
+        log.debug("Fetching extra info about {} local workflows".format(len(self.local_workflows)))
         for wf in self.local_workflows:
             wf.get_local_nf_workflow_details()
 
@@ -351,7 +352,7 @@ class LocalWorkflow(object):
             else:
                 nf_wfdir = os.path.join(os.getenv("HOME"), ".nextflow", "assets", self.full_name)
             if os.path.isdir(nf_wfdir):
-                logging.debug("Guessed nextflow assets workflow directory: {}".format(nf_wfdir))
+                log.debug("Guessed nextflow assets workflow directory: {}".format(nf_wfdir))
                 self.local_path = nf_wfdir
 
             # Use `nextflow info` to get more details about the workflow
@@ -378,7 +379,7 @@ class LocalWorkflow(object):
 
         # Pull information from the local git repository
         if self.local_path is not None:
-            logging.debug("Pulling git info from {}".format(self.local_path))
+            log.debug("Pulling git info from {}".format(self.local_path))
             try:
                 repo = git.Repo(self.local_path)
                 self.commit_sha = str(repo.head.commit.hexsha)
@@ -401,7 +402,7 @@ class LocalWorkflow(object):
 
             # I'm not sure that we need this any more, it predated the self.branch catch above for detacted HEAD
             except TypeError as e:
-                logging.error(
+                log.error(
                     "Could not fetch status of local Nextflow copy of {}:".format(self.full_name)
                     + "\n   {}".format(str(e))
                     + "\n\nIt's probably a good idea to delete this local copy and pull again:".format(self.local_path)

--- a/nf_core/modules.py
+++ b/nf_core/modules.py
@@ -12,7 +12,7 @@ import requests
 import sys
 import tempfile
 
-log = logging.getLogger("nfcore")
+log = logging.getLogger(__name__)
 
 
 class ModulesRepo(object):

--- a/nf_core/modules.py
+++ b/nf_core/modules.py
@@ -12,6 +12,8 @@ import requests
 import sys
 import tempfile
 
+log = logging.getLogger("nfcore")
+
 
 class ModulesRepo(object):
     """
@@ -46,11 +48,11 @@ class PipelineModules(object):
         return_str = ""
 
         if len(self.modules_avail_module_names) > 0:
-            logging.info("Modules available from {} ({}):\n".format(self.modules_repo.name, self.modules_repo.branch))
+            log.info("Modules available from {} ({}):\n".format(self.modules_repo.name, self.modules_repo.branch))
             # Print results to stdout
             return_str += "\n".join(self.modules_avail_module_names)
         else:
-            logging.info(
+            log.info(
                 "No available modules found in {} ({}):\n".format(self.modules_repo.name, self.modules_repo.branch)
             )
         return return_str
@@ -59,12 +61,12 @@ class PipelineModules(object):
 
         # Check that we were given a pipeline
         if self.pipeline_dir is None or not os.path.exists(self.pipeline_dir):
-            logging.error("Could not find pipeline: {}".format(self.pipeline_dir))
+            log.error("Could not find pipeline: {}".format(self.pipeline_dir))
             return False
         main_nf = os.path.join(self.pipeline_dir, "main.nf")
         nf_config = os.path.join(self.pipeline_dir, "nextflow.config")
         if not os.path.exists(main_nf) and not os.path.exists(nf_config):
-            logging.error("Could not find a main.nf or nextfow.config file in: {}".format(self.pipeline_dir))
+            log.error("Could not find a main.nf or nextfow.config file in: {}".format(self.pipeline_dir))
             return False
 
         # Get the available modules
@@ -72,35 +74,35 @@ class PipelineModules(object):
 
         # Check that the supplied name is an available module
         if module not in self.modules_avail_module_names:
-            logging.error("Module '{}' not found in list of available modules.".format(module))
-            logging.info("Use the command 'nf-core modules list' to view available software")
+            log.error("Module '{}' not found in list of available modules.".format(module))
+            log.info("Use the command 'nf-core modules list' to view available software")
             return False
-        logging.debug("Installing module '{}' at modules hash {}".format(module, self.modules_current_hash))
+        log.debug("Installing module '{}' at modules hash {}".format(module, self.modules_current_hash))
 
         # Check that we don't already have a folder for this module
         module_dir = os.path.join(self.pipeline_dir, "modules", "nf-core", "software", module)
         if os.path.exists(module_dir):
-            logging.error("Module directory already exists: {}".format(module_dir))
-            logging.info("To update an existing module, use the commands 'nf-core update' or 'nf-core fix'")
+            log.error("Module directory already exists: {}".format(module_dir))
+            log.info("To update an existing module, use the commands 'nf-core update' or 'nf-core fix'")
             return False
 
         # Download module files
         files = self.get_module_file_urls(module)
-        logging.debug("Fetching module files:\n - {}".format("\n - ".join(files.keys())))
+        log.debug("Fetching module files:\n - {}".format("\n - ".join(files.keys())))
         for filename, api_url in files.items():
             dl_filename = os.path.join(self.pipeline_dir, "modules", "nf-core", filename)
             self.download_gh_file(dl_filename, api_url)
 
     def update(self, module, force=False):
-        logging.error("This command is not yet implemented")
+        log.error("This command is not yet implemented")
         pass
 
     def remove(self, module):
-        logging.error("This command is not yet implemented")
+        log.error("This command is not yet implemented")
         pass
 
     def check_modules(self):
-        logging.error("This command is not yet implemented")
+        log.error("This command is not yet implemented")
         pass
 
     def get_modules_file_tree(self):
@@ -116,7 +118,7 @@ class PipelineModules(object):
         )
         r = requests.get(api_url)
         if r.status_code == 404:
-            logging.error(
+            log.error(
                 "Repository / branch not found: {} ({})\n{}".format(
                     self.modules_repo.name, self.modules_repo.branch, api_url
                 )

--- a/nf_core/modules.py
+++ b/nf_core/modules.py
@@ -59,6 +59,8 @@ class PipelineModules(object):
 
     def install(self, module):
 
+        log.info("Installing {}".format(module))
+
         # Check that we were given a pipeline
         if self.pipeline_dir is None or not os.path.exists(self.pipeline_dir):
             log.error("Could not find pipeline: {}".format(self.pipeline_dir))
@@ -92,6 +94,7 @@ class PipelineModules(object):
         for filename, api_url in files.items():
             dl_filename = os.path.join(self.pipeline_dir, "modules", "nf-core", filename)
             self.download_gh_file(dl_filename, api_url)
+        log.info("Downloaded {} files to {}".format(len(files), module_dir))
 
     def update(self, module, force=False):
         log.error("This command is not yet implemented")

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -19,7 +19,7 @@ import yaml
 
 import nf_core.list, nf_core.utils
 
-log = logging.getLogger("nfcore")
+log = logging.getLogger(__name__)
 
 
 class PipelineSchema(object):

--- a/nf_core/sync.py
+++ b/nf_core/sync.py
@@ -222,9 +222,9 @@ class PipelineSync(object):
         log.info("Making a new template pipeline using pipeline variables")
 
         # Suppress log messages from the pipeline creation method
-        orig_loglevel = log.getLogger().getEffectiveLevel()
+        orig_loglevel = logging.getLogger("nfcore").getEffectiveLevel()
         if orig_loglevel == getattr(logging, "INFO"):
-            log.getLogger().setLevel(log.ERROR)
+            logging.getLogger("nfcore").setLevel(logging.ERROR)
 
         nf_core.create.PipelineCreate(
             name=self.wf_config["manifest.name"].strip('"').strip("'"),
@@ -237,7 +237,7 @@ class PipelineSync(object):
         ).init_pipeline()
 
         # Reset logging
-        log.getLogger().setLevel(orig_loglevel)
+        logging.getLogger("nfcore").setLevel(orig_loglevel)
 
     def commit_template_changes(self):
         """If we have any changes with the new template files, make a git commit
@@ -377,9 +377,9 @@ def sync_all_pipelines(gh_username=None, gh_auth_token=None):
         assert repo
 
         # Suppress log messages from the pipeline creation method
-        orig_loglevel = log.getLogger().getEffectiveLevel()
+        orig_loglevel = logging.getLogger("nfcore").getEffectiveLevel()
         if orig_loglevel == getattr(logging, "INFO"):
-            log.getLogger().setLevel(log.ERROR)
+            logging.getLogger("nfcore").setLevel(logging.ERROR)
 
         # Sync the repo
         log.debug("Running template sync")
@@ -393,15 +393,15 @@ def sync_all_pipelines(gh_username=None, gh_auth_token=None):
         try:
             sync_obj.sync()
         except (SyncException, PullRequestException) as e:
-            log.getLogger().setLevel(orig_loglevel)  # Reset logging
+            logging.getLogger("nfcore").setLevel(orig_loglevel)  # Reset logging
             log.error("Sync failed for {}:\n{}".format(wf.full_name, e))
             failed_syncs.append(wf.name)
         except Exception as e:
-            log.getLogger().setLevel(orig_loglevel)  # Reset logging
+            logging.getLogger("nfcore").setLevel(orig_loglevel)  # Reset logging
             log.error("Something went wrong when syncing {}:\n{}".format(wf.full_name, e))
             failed_syncs.append(wf.name)
         else:
-            log.getLogger().setLevel(orig_loglevel)  # Reset logging
+            logging.getLogger("nfcore").setLevel(orig_loglevel)  # Reset logging
             log.info(
                 "[green]Sync successful for {}:[/] [blue][link={1}]{1}[/link]".format(
                     wf.full_name, sync_obj.gh_pr_returned_data.get("html_url")

--- a/nf_core/sync.py
+++ b/nf_core/sync.py
@@ -18,6 +18,8 @@ import nf_core.list
 import nf_core.sync
 import nf_core.utils
 
+log = logging.getLogger("nfcore")
+
 
 class SyncException(Exception):
     """Exception raised when there was an error with TEMPLATE branch synchronisation
@@ -82,7 +84,7 @@ class PipelineSync(object):
             config_log_msg += "\n  Using branch `{}` to fetch workflow variables".format(self.from_branch)
         if self.make_pr:
             config_log_msg += "\n  Will attempt to automatically create a pull request on GitHub.com"
-        logging.info(config_log_msg)
+        log.info(config_log_msg)
 
         self.inspect_sync_dir()
         self.get_wf_config()
@@ -103,9 +105,9 @@ class PipelineSync(object):
         self.reset_target_dir()
 
         if not self.made_changes:
-            logging.info("No changes made to TEMPLATE - sync complete")
+            log.info("No changes made to TEMPLATE - sync complete")
         elif not self.make_pr:
-            logging.info(
+            log.info(
                 "Now try to merge the updates in to your pipeline:\n  cd {}\n  git merge TEMPLATE".format(
                     self.pipeline_dir
                 )
@@ -123,7 +125,7 @@ class PipelineSync(object):
 
         # get current branch so we can switch back later
         self.original_branch = self.repo.active_branch.name
-        logging.debug("Original pipeline repository branch is '{}'".format(self.original_branch))
+        log.debug("Original pipeline repository branch is '{}'".format(self.original_branch))
 
         # Check to see if there are uncommitted changes on current branch
         if self.repo.is_dirty(untracked_files=True):
@@ -138,7 +140,7 @@ class PipelineSync(object):
         # Try to check out target branch (eg. `origin/dev`)
         try:
             if self.from_branch and self.repo.active_branch.name != self.from_branch:
-                logging.info("Checking out workflow branch '{}'".format(self.from_branch))
+                log.info("Checking out workflow branch '{}'".format(self.from_branch))
                 self.repo.git.checkout(self.from_branch)
         except git.exc.GitCommandError:
             raise SyncException("Branch `{}` not found!".format(self.from_branch))
@@ -148,7 +150,7 @@ class PipelineSync(object):
             try:
                 self.from_branch = self.repo.active_branch.name
             except git.exc.GitCommandError as e:
-                logging.error("Could not find active repo branch: ".format(e))
+                log.error("Could not find active repo branch: ".format(e))
 
         # Figure out the GitHub username and repo name from the 'origin' remote if we can
         try:
@@ -160,18 +162,18 @@ class PipelineSync(object):
             else:
                 raise AttributeError
         except AttributeError as e:
-            logging.debug(
+            log.debug(
                 "Could not find repository URL for remote called 'origin' from remote: {}".format(self.repo.remotes)
             )
         else:
-            logging.debug(
+            log.debug(
                 "Found username and repo from remote: {}, {} - {}".format(
                     self.gh_username, self.gh_repo, self.repo.remotes.origin.url
                 )
             )
 
         # Fetch workflow variables
-        logging.info("Fetching workflow config variables")
+        log.info("Fetching workflow config variables")
         self.wf_config = nf_core.utils.fetch_wf_config(self.pipeline_dir)
 
         # Check that we have the required variables
@@ -199,12 +201,12 @@ class PipelineSync(object):
         Delete all files in the TEMPLATE branch
         """
         # Delete everything
-        logging.info("Deleting all files in TEMPLATE branch")
+        log.info("Deleting all files in TEMPLATE branch")
         for the_file in os.listdir(self.pipeline_dir):
             if the_file == ".git":
                 continue
             file_path = os.path.join(self.pipeline_dir, the_file)
-            logging.debug("Deleting {}".format(file_path))
+            log.debug("Deleting {}".format(file_path))
             try:
                 if os.path.isfile(file_path):
                     os.unlink(file_path)
@@ -217,12 +219,12 @@ class PipelineSync(object):
         """
         Delete all files and make a fresh template using the workflow variables
         """
-        logging.info("Making a new template pipeline using pipeline variables")
+        log.info("Making a new template pipeline using pipeline variables")
 
         # Suppress log messages from the pipeline creation method
-        orig_loglevel = logging.getLogger().getEffectiveLevel()
+        orig_loglevel = log.getLogger().getEffectiveLevel()
         if orig_loglevel == getattr(logging, "INFO"):
-            logging.getLogger().setLevel(logging.ERROR)
+            log.getLogger().setLevel(log.ERROR)
 
         nf_core.create.PipelineCreate(
             name=self.wf_config["manifest.name"].strip('"').strip("'"),
@@ -235,21 +237,21 @@ class PipelineSync(object):
         ).init_pipeline()
 
         # Reset logging
-        logging.getLogger().setLevel(orig_loglevel)
+        log.getLogger().setLevel(orig_loglevel)
 
     def commit_template_changes(self):
         """If we have any changes with the new template files, make a git commit
         """
         # Check that we have something to commit
         if not self.repo.is_dirty(untracked_files=True):
-            logging.info("Template contains no changes - no new commit created")
+            log.info("Template contains no changes - no new commit created")
             return False
         # Commit changes
         try:
             self.repo.git.add(A=True)
             self.repo.index.commit("Template update for nf-core/tools version {}".format(nf_core.__version__))
             self.made_changes = True
-            logging.info("Committed changes to TEMPLATE branch")
+            log.info("Committed changes to TEMPLATE branch")
         except Exception as e:
             raise SyncException("Could not commit changes to TEMPLATE:\n{}".format(e))
         return True
@@ -259,7 +261,7 @@ class PipelineSync(object):
         and try to make a PR. If we don't have the auth token, try to figure out a URL
         for the PR and print this to the console.
         """
-        logging.info("Pushing TEMPLATE branch to remote")
+        log.info("Pushing TEMPLATE branch to remote")
         try:
             self.repo.git.push()
         except git.exc.GitCommandError as e:
@@ -282,14 +284,14 @@ class PipelineSync(object):
         try:
             assert self.gh_auth_token is not None
         except AssertionError:
-            logging.info(
+            log.info(
                 "Make a PR at the following URL:\n  https://github.com/{}/{}/compare/{}...TEMPLATE".format(
                     self.gh_username, self.gh_repo, self.original_branch
                 )
             )
             raise PullRequestException("No GitHub authentication token set - cannot make PR")
 
-        logging.info("Submitting a pull request via the GitHub API")
+        log.info("Submitting a pull request via the GitHub API")
 
         pr_body_text = """
             A new release of the main template in nf-core/tools has just been released.
@@ -331,14 +333,14 @@ class PipelineSync(object):
                 "GitHub API returned code {}: \n{}".format(r.status_code, returned_data_prettyprint)
             )
         else:
-            logging.debug("GitHub API PR worked:\n{}".format(returned_data_prettyprint))
-            logging.info("GitHub PR created: {}".format(self.gh_pr_returned_data["html_url"]))
+            log.debug("GitHub API PR worked:\n{}".format(returned_data_prettyprint))
+            log.info("GitHub PR created: {}".format(self.gh_pr_returned_data["html_url"]))
 
     def reset_target_dir(self):
         """
         Reset the target pipeline directory. Check out the original branch.
         """
-        logging.debug("Checking out original branch: '{}'".format(self.original_branch))
+        log.debug("Checking out original branch: '{}'".format(self.original_branch))
         try:
             self.repo.git.checkout(self.original_branch)
         except git.exc.GitCommandError as e:
@@ -362,12 +364,12 @@ def sync_all_pipelines(gh_username=None, gh_auth_token=None):
     # Let's do some updating!
     for wf in wfs.remote_workflows:
 
-        logging.info("Syncing {}".format(wf.full_name))
+        log.info("Syncing {}".format(wf.full_name))
 
         # Make a local working directory
         wf_local_path = os.path.join(tmpdir, wf.name)
         os.mkdir(wf_local_path)
-        logging.debug("Sync working directory: {}".format(wf_local_path))
+        log.debug("Sync working directory: {}".format(wf_local_path))
 
         # Clone the repo
         wf_remote_url = "https://{}@github.com/nf-core/{}".format(gh_auth_token, wf.name)
@@ -375,12 +377,12 @@ def sync_all_pipelines(gh_username=None, gh_auth_token=None):
         assert repo
 
         # Suppress log messages from the pipeline creation method
-        orig_loglevel = logging.getLogger().getEffectiveLevel()
+        orig_loglevel = log.getLogger().getEffectiveLevel()
         if orig_loglevel == getattr(logging, "INFO"):
-            logging.getLogger().setLevel(logging.ERROR)
+            log.getLogger().setLevel(log.ERROR)
 
         # Sync the repo
-        logging.debug("Running template sync")
+        log.debug("Running template sync")
         sync_obj = nf_core.sync.PipelineSync(
             pipeline_dir=wf_local_path,
             from_branch="dev",
@@ -391,38 +393,36 @@ def sync_all_pipelines(gh_username=None, gh_auth_token=None):
         try:
             sync_obj.sync()
         except (SyncException, PullRequestException) as e:
-            logging.getLogger().setLevel(orig_loglevel)  # Reset logging
-            logging.error(click.style("Sync failed for {}:\n{}".format(wf.full_name, e), fg="red"))
+            log.getLogger().setLevel(orig_loglevel)  # Reset logging
+            log.error("Sync failed for {}:\n{}".format(wf.full_name, e))
             failed_syncs.append(wf.name)
         except Exception as e:
-            logging.getLogger().setLevel(orig_loglevel)  # Reset logging
-            logging.error(click.style("Something went wrong when syncing {}:\n{}".format(wf.full_name, e), fg="red"))
+            log.getLogger().setLevel(orig_loglevel)  # Reset logging
+            log.error("Something went wrong when syncing {}:\n{}".format(wf.full_name, e))
             failed_syncs.append(wf.name)
         else:
-            logging.getLogger().setLevel(orig_loglevel)  # Reset logging
-            logging.info(
-                click.style(
-                    "Sync successful for {}: {}".format(
-                        wf.full_name, click.style(sync_obj.gh_pr_returned_data.get("html_url"), fg="blue")
-                    ),
-                    fg="green",
-                )
+            log.getLogger().setLevel(orig_loglevel)  # Reset logging
+            log.info(
+                "[green]Sync successful for {}:[/] [blue][link={1}]{1}[/link]".format(
+                    wf.full_name, sync_obj.gh_pr_returned_data.get("html_url")
+                ),
+                extra={"markup": True},
             )
             successful_syncs.append(wf.name)
 
         # Clean up
-        logging.debug("Removing work directory: {}".format(wf_local_path))
+        log.debug("Removing work directory: {}".format(wf_local_path))
         shutil.rmtree(wf_local_path)
 
     if len(successful_syncs) > 0:
-        logging.info(
-            click.style("Finished. Successfully synchronised {} pipelines".format(len(successful_syncs)), fg="green")
+        log.info(
+            "[green]Finished. Successfully synchronised {} pipelines".format(len(successful_syncs)),
+            extra={"markup": True},
         )
 
     if len(failed_syncs) > 0:
         failed_list = "\n - ".join(failed_syncs)
-        logging.error(
-            click.style(
-                "Errors whilst synchronising {} pipelines:\n - {}".format(len(failed_syncs), failed_list), fg="red"
-            )
+        log.error(
+            "[red]Errors whilst synchronising {} pipelines:\n - {}".format(len(failed_syncs), failed_list),
+            extra={"markup": True},
         )

--- a/nf_core/sync.py
+++ b/nf_core/sync.py
@@ -223,7 +223,7 @@ class PipelineSync(object):
 
         # Only show error messages from pipeline creation
         if log.getEffectiveLevel() == logging.INFO:
-            logging.getLogger("nfcore.create").setLevel(logging.ERROR)
+            logging.getLogger("nf_core.create").setLevel(logging.ERROR)
 
         nf_core.create.PipelineCreate(
             name=self.wf_config["manifest.name"].strip('"').strip("'"),
@@ -374,7 +374,7 @@ def sync_all_pipelines(gh_username=None, gh_auth_token=None):
 
         # Only show error messages from pipeline creation
         if log.getEffectiveLevel() == logging.INFO:
-            logging.getLogger("nfcore.create").setLevel(logging.ERROR)
+            logging.getLogger("nf_core.create").setLevel(logging.ERROR)
 
         # Sync the repo
         log.debug("Running template sync")

--- a/nf_core/sync.py
+++ b/nf_core/sync.py
@@ -18,7 +18,7 @@ import nf_core.list
 import nf_core.sync
 import nf_core.utils
 
-log = logging.getLogger("nfcore")
+log = logging.getLogger(__name__)
 
 
 class SyncException(Exception):

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -17,7 +17,7 @@ import sys
 import time
 from distutils import version
 
-log = logging.getLogger("nfcore")
+log = logging.getLogger(__name__)
 
 
 def check_if_outdated(current_version=None, remote_version=None, source_url="https://nf-co.re/tools_version"):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -196,7 +196,7 @@ class TestSchema(unittest.TestCase):
         params_removed = self.schema_obj.remove_schema_notfound_configs()
         assert len(self.schema_obj.schema["properties"]) == 0
         assert len(params_removed) == 1
-        assert click.style("foo", fg="white", bold=True) in params_removed
+        assert "foo" in params_removed
 
     def test_remove_schema_notfound_configs_childobj(self):
         """
@@ -211,7 +211,7 @@ class TestSchema(unittest.TestCase):
         params_removed = self.schema_obj.remove_schema_notfound_configs()
         assert len(self.schema_obj.schema["properties"]["parent"]["properties"]) == 0
         assert len(params_removed) == 1
-        assert click.style("foo", fg="white", bold=True) in params_removed
+        assert "foo" in params_removed
 
     def test_add_schema_found_configs(self):
         """ Try adding a new parameter to the schema from the config """
@@ -221,7 +221,7 @@ class TestSchema(unittest.TestCase):
         params_added = self.schema_obj.add_schema_found_configs()
         assert len(self.schema_obj.schema["properties"]) == 1
         assert len(params_added) == 1
-        assert click.style("foo", fg="white", bold=True) in params_added
+        assert "foo" in params_added
 
     def test_build_schema_param_str(self):
         """ Build a new schema param from a config value (string) """


### PR DESCRIPTION
Trying to strip out `click.style` from the codebase and use `rich` instead.

* Use `rich` for logging
* Use a named log handler
* Go through systematically removing `click.style()` everywhere

There's a couple of instances left, that's because they are currently used in a `click.confirm` call (not logs).

This PR needs a lot of care and testing, as I've changed just about every file. So I'm a bit scared that I will have broken lots of stuff 😱 

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated