### PR TITLE
Do not use pre-release PyInquirer

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,15 +18,29 @@ is as follows:
 
 If you're not used to this workflow with git, you can start with some [basic docs from GitHub](https://help.github.com/articles/fork-a-repo/).
 
+## Installing dev requirements
+
+If you want to work with developing the nf-core/tools code, you'll need a couple of extra Python packages.
+These are listed in `requirements-dev.txt` and can be installed as follows:
+
+```bash
+pip install --upgrade -r requirements-dev.txt
+```
+
+Then install your local fork of nf-core/tools:
+
+```bash
+pip install -e .
+```
+
 ## Code formatting with Black
 
 All Python code in nf-core/tools must be passed through the [Black Python code formatter](https://black.readthedocs.io/en/stable/).
 This ensures a harmonised code formatting style throughout the package, from all contributors.
 
-You can run Black on the command line - first install using `pip` and then run recursively on the whole repository:
+You can run Black on the command line (it's included in `requirements-dev.txt`) - eg. to run recursively on the whole repository:
 
 ```bash
-pip install black
 black .
 ```
 
@@ -61,8 +75,6 @@ New features should also come with new tests, to keep the test-coverage high (we
 You can try running the tests locally before pushing code using the following command:
 
 ```bash
-pip install -r requirements-dev.txt
-pip install -e .
 pytest --color=yes tests/
 ```
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -61,7 +61,8 @@ New features should also come with new tests, to keep the test-coverage high (we
 You can try running the tests locally before pushing code using the following command:
 
 ```bash
-pip install --upgrade pip pytest pytest-datafiles pytest-cov mock
+pip install -r requirements-dev.txt
+pip install -e .
 pytest --color=yes tests/
 ```
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,8 +28,8 @@ jobs:
 
     - name: Install python dependencies
       run: |
-        python -m pip install --upgrade pip pytest pytest-datafiles pytest-cov mock jsonschema
-        pip install .
+        python -m pip install --upgrade pip -r requirements-dev.txt
+        pip install -e .
 
     - name: Install Nextflow
       run: |

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ pip install --upgrade --force-reinstall git+https://github.com/nf-core/tools.git
 ```
 
 If you intend to make edits to the code, first make a fork of the repository and then clone it locally.
-Go to the cloned directory and either install with pip:
+Go to the cloned directory and install with pip (also installs development requirements):
 
 ```bash
-pip install -e .
+pip install --upgrade -r requirements-dev.txt -e .
 ```
 
 ### Using a specific Python interpreter

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -628,7 +628,7 @@ class Launch(object):
 
         # WORKAROUND - PyInquirer <1.0.3 cannot have a default position in a list
         # For now, move the default option to the top.
-        # TODO: Delete this code when PyInquirer <1.0.3 is released.
+        # TODO: Delete this code when PyInquirer >=1.0.3 is released.
         if question["type"] == "list" and "default" in question:
             try:
                 question["choices"].remove(question["default"])

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -460,7 +460,7 @@ class Launch(object):
                         req_default = self.schema_obj.input_params.get(p_required, "")
                         req_answer = answers.get(p_required, "")
                         if req_default == "" and req_answer == "":
-                            log.error("Error - [bold]'{}'[/] is required.".format(p_required), extra={"markup": True})
+                            log.error("'{}' is required.".format(p_required))
                             while_break = False
             else:
                 child_param = answer[param_id]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-cov
+mock

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pytest
-pytest-cov
 pytest-datafiles
+pytest-cov
 mock
 black

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 pytest
 pytest-cov
+pytest-datafiles
 mock
 black

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-cov
 mock
+black

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,7 @@ setup(
         "GitPython",
         "jinja2",
         "jsonschema",
-        # 'PyInquirer>1.0.3',
-        # Need the new release of PyInquirer, see nf_core/launch.py for details
-        "PyInquirer @ https://github.com/CITGuru/PyInquirer/archive/master.zip",
+        "PyInquirer",
         "pyyaml",
         "requests",
         "requests_cache",

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "pyyaml",
         "requests",
         "requests_cache",
-        "rich",
+        "rich>=3.4.0",
         "tabulate",
     ],
     setup_requires=["twine>=1.11.0", "setuptools>=38.6."],

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "GitPython",
         "jinja2",
         "jsonschema",
-        "PyInquirer",
+        "PyInquirer==1.0.2",
         "pyyaml",
         "requests",
         "requests_cache",

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -29,8 +29,8 @@ class TestLaunch(unittest.TestCase):
         """ Test the main launch function """
         self.launcher.launch_pipeline()
 
-    @mock.patch("click.confirm", side_effect=[False])
-    def test_launch_file_exists(self, mock_click_confirm):
+    @mock.patch.object(nf_core.launch.Confirm, "ask", side_effect=[False])
+    def test_launch_file_exists(self, mock_confirm):
         """ Test that we detect an existing params file and return """
         # Make an empty params file to be overwritten
         open(self.nf_params_fn, "a").close()

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -39,8 +39,8 @@ class TestLaunch(unittest.TestCase):
 
     @mock.patch.object(nf_core.launch.Launch, "prompt_web_gui", side_effect=[True])
     @mock.patch.object(nf_core.launch.Launch, "launch_web_gui")
-    @mock.patch("click.confirm", side_effect=[True])
-    def test_launch_file_exists_overwrite(self, mock_webbrowser, mock_lauch_web_gui, mock_click_confirm):
+    @mock.patch.object(nf_core.launch.Confirm, "ask", side_effect=[False])
+    def test_launch_file_exists_overwrite(self, mock_webbrowser, mock_lauch_web_gui, mock_confirm):
         """ Test that we detect an existing params file and we overwrite it """
         # Make an empty params file to be overwritten
         open(self.nf_params_fn, "a").close()

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -104,12 +104,12 @@ class TestLaunch(unittest.TestCase):
         result = self.launcher.single_param_to_pyinquirer("input", sc_obj)
         assert result == {"type": "input", "name": "input", "message": "input", "default": "data/*{1,2}.fastq.gz"}
 
-    @mock.patch("PyInquirer.prompt.prompt", side_effect=[{"use_web_gui": "Web based"}])
+    @mock.patch("PyInquirer.prompt", side_effect=[{"use_web_gui": "Web based"}])
     def test_prompt_web_gui_true(self, mock_prompt):
         """ Check the prompt to launch the web schema or use the cli """
         assert self.launcher.prompt_web_gui() == True
 
-    @mock.patch("PyInquirer.prompt.prompt", side_effect=[{"use_web_gui": "Command line"}])
+    @mock.patch("PyInquirer.prompt", side_effect=[{"use_web_gui": "Command line"}])
     def test_prompt_web_gui_false(self, mock_prompt):
         """ Check the prompt to launch the web schema or use the cli """
         assert self.launcher.prompt_web_gui() == False


### PR DESCRIPTION
Remove the pre-release functionality from PyInquirer so that we don't have to wait for v1.0.3. Reverts to stable 1.0.2 version for now. 

Tested with the latest version of `master` code for PyInquirer and this breaks, as they have merged in some fairly major structural changes. So I've pinned `PyInquirer==1.0.2` for now.

This will hopefully be stable enough for a release of tools. Can look into switching to Questionary / another tool at a later date still. I'm not writing that out.

_Sidenote: I tested Questionary and the switch was easy, but it has the same two problems that PyInquirer has, yet without any fixes in the pipeline._