### PR TITLE
Lint TODO - ignore editor files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ ENV/
 
 # backup files
 *~
+*?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ making a pull-request. See [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md) 
 * Fail if `params.input` isn't defined.
 * Beautiful new progress bar to look at whilst linting is running and awesome new formatted output on the command line :heart_eyes:
   * All made using the excellent [`rich` python library](https://github.com/willmcgugan/rich) - check it out!
+* Tests looking for `TODO` strings should now ignore editor backup files. [#477](https://github.com/nf-core/tools/issues/477)
 
 ### nf-core/tools Continuous Integration
 

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -5,7 +5,11 @@ Tests Nextflow-based pipelines to check that they adhere to
 the nf-core community guidelines.
 """
 
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.table import Table
 import datetime
+import fnmatch
 import git
 import io
 import json
@@ -14,10 +18,7 @@ import os
 import re
 import requests
 import rich
-from rich.console import Console
-from rich.markdown import Markdown
 import rich.progress
-from rich.table import Table
 import subprocess
 import textwrap
 
@@ -1155,10 +1156,8 @@ class PipelineLint(object):
         for root, dirs, files in os.walk(self.path):
             # Ignore files
             for i in ignore:
-                if i in dirs:
-                    dirs.remove(i)
-                if i in files:
-                    files.remove(i)
+                dirs = [d for d in dirs if not fnmatch.fnmatch(os.path.join(root, d), i)]
+                files = [f for f in files if not fnmatch.fnmatch(os.path.join(root, f), i)]
             for fname in files:
                 with io.open(os.path.join(root, fname), "rt", encoding="latin1") as fh:
                     for l in fh:


### PR DESCRIPTION
Use `fnmatch` to properly apply glob expressions found in the `.gitignore` file when searching all pipeline files for `TODO` strings.

Closes https://github.com/nf-core/tools/issues/477

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated
