### PR TITLE
Add Dockstore config file to template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ making a pull-request. See [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md) 
 * Fix `markdown_to_html.py` to work with Python 2 and 3.
 * Change `params.reads` -> `params.input`
 * Change `params.readPaths` -> `params.input_paths`
+* Added a `.github/.dockstore.yml` config file for automatic workflow registration with [dockstore.org](https://dockstore.org/)
 
 ### Linting
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/.dockstore.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/.dockstore.yml
@@ -1,0 +1,5 @@
+# Dockstore config version, not pipeline version
+version: 1.2
+workflows:
+  - subclass: nfl
+    primaryDescriptorPath: /nextflow.config


### PR DESCRIPTION
Added a `.github/.dockstore.yml` config file for automatic registration with [dockstore.org](https://dockstore.org/)

Many thanks to @agduncan94 for working on this and suggesting this route for us.

Please wait to merge until we have confirmation that having the config file inside the `.github` directory will be supported by Dockstore.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated