### PR TITLE
Use new Rich syntax for markup logs.

### DIFF
--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -108,7 +108,7 @@ def nf_core_cli(verbose):
         level=logging.DEBUG if verbose else logging.INFO,
         format="%(message)s",
         datefmt=".",
-        handlers=[rich.logging.RichHandler(console=stderr)],
+        handlers=[rich.logging.RichHandler(console=stderr, markup=True)],
     )
 
 

--- a/nf_core/bump_version.py
+++ b/nf_core/bump_version.py
@@ -160,8 +160,7 @@ def update_file_version(filename, lint_obj, pattern, newstr, allow_multiple=Fals
     log.info(
         "Updating version in {}\n".format(filename)
         + "[red] - {}\n".format("\n - ".join(matches_pattern).strip())
-        + "[green] + {}\n".format("\n + ".join(matches_newstr).strip()),
-        extra={"markup": True},
+        + "[green] + {}\n".format("\n + ".join(matches_newstr).strip())
     )
 
     with open(fn, "w") as fh:

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -63,8 +63,7 @@ class PipelineCreate(object):
             "[green bold]!!!!!! IMPORTANT !!!!!!\n\n"
             + "[green not bold]If you are interested in adding your pipeline to the nf-core community,\n"
             + "PLEASE COME AND TALK TO US IN THE NF-CORE SLACK BEFORE WRITING ANY CODE!\n\n"
-            + "[default]Please read: [link=https://nf-co.re/developers/adding_pipelines#join-the-community]https://nf-co.re/developers/adding_pipelines#join-the-community[/link]",
-            extra={"markup": True},
+            + "[default]Please read: [link=https://nf-co.re/developers/adding_pipelines#join-the-community]https://nf-co.re/developers/adding_pipelines#join-the-community[/link]"
         )
 
     def run_cookiecutter(self):
@@ -149,7 +148,6 @@ class PipelineCreate(object):
             "Done. Remember to add a remote and push to GitHub:\n"
             + "[white on grey23] cd {} \n".format(self.outdir)
             + " git remote add origin git@github.com:USERNAME/REPO_NAME.git \n"
-            + " git push --all origin                                       ",
-            extra={"markup": True},
+            + " git push --all origin                                       "
         )
         log.info("This will also push your newly created dev branch and the TEMPLATE branch for syncing.")

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -245,8 +245,7 @@ class Launch(object):
     def prompt_web_gui(self):
         """ Ask whether to use the web-based or cli wizard to collect params """
         log.info(
-            "[magenta]Would you like to enter pipeline parameters using a web-based interface or a command-line wizard?",
-            extra={"markup": True},
+            "[magenta]Would you like to enter pipeline parameters using a web-based interface or a command-line wizard?"
         )
         question = {
             "type": "list",
@@ -703,10 +702,8 @@ class Launch(object):
 
     def launch_workflow(self):
         """ Launch nextflow if required  """
-        log.info(
-            "[bold underline]Nextflow command:[/]\n[magenta]{}\n\n".format(self.nextflow_cmd), extra={"markup": True},
-        )
+        log.info("[bold underline]Nextflow command:[/]\n[magenta]{}\n\n".format(self.nextflow_cmd))
 
         if Confirm.ask("Do you want to run this command now? "):
-            log.info("Launching workflow! :rocket:", extra={"markup": True})
+            log.info("Launching workflow! :rocket:")
             subprocess.call(self.nextflow_cmd, shell=True)

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -199,7 +199,7 @@ class PipelineLint(object):
         Raises:
             If a critical problem is found, an ``AssertionError`` is raised.
         """
-        log.info("Testing pipeline: [magenta]{}".format(self.path), extra={"markup": True})
+        log.info("Testing pipeline: [magenta]{}".format(self.path))
         if self.release_mode:
             log.info("Including --release mode tests")
         check_functions = [

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -84,7 +84,7 @@ class PipelineSchema(object):
             raise AssertionError(error_msg)
         except AssertionError as e:
             error_msg = "[red][[✗]] JSON Schema does not follow nf-core specs:\n {}".format(e)
-            log.error(error_msg, extra={"markup": True})
+            log.error(error_msg)
             raise AssertionError(error_msg)
         else:
             try:
@@ -93,10 +93,10 @@ class PipelineSchema(object):
                 self.validate_schema(self.flat_schema)
             except AssertionError as e:
                 error_msg = "[red][[✗]] Flattened JSON Schema does not follow nf-core specs:\n {}".format(e)
-                log.error(error_msg, extra={"markup": True})
+                log.error(error_msg)
                 raise AssertionError(error_msg)
             else:
-                log.info("[green][[✓]] Pipeline schema looks valid", extra={"markup": True})
+                log.info("[green][[✓]] Pipeline schema looks valid")
 
     def load_schema(self):
         """ Load a JSON Schema from a file """
@@ -170,12 +170,12 @@ class PipelineSchema(object):
             assert self.flat_schema is not None
             jsonschema.validate(self.input_params, self.flat_schema)
         except AssertionError:
-            log.error("[red][[✗]] Flattened JSON Schema not found", extra={"markup": True})
+            log.error("[red][[✗]] Flattened JSON Schema not found")
             return False
         except jsonschema.exceptions.ValidationError as e:
-            log.error("[red][[✗]] Input parameters are invalid: {}".format(e.message), extra={"markup": True})
+            log.error("[red][[✗]] Input parameters are invalid: {}".format(e.message))
             return False
-        log.info("[green][[✓]] Input parameters look valid", extra={"markup": True})
+        log.info("[green][[✓]] Input parameters look valid")
         return True
 
     def validate_schema(self, schema):

--- a/nf_core/sync.py
+++ b/nf_core/sync.py
@@ -397,8 +397,7 @@ def sync_all_pipelines(gh_username=None, gh_auth_token=None):
             log.info(
                 "[green]Sync successful for {}:[/] [blue][link={1}]{1}[/link]".format(
                     wf.full_name, sync_obj.gh_pr_returned_data.get("html_url")
-                ),
-                extra={"markup": True},
+                )
             )
             successful_syncs.append(wf.name)
 
@@ -407,14 +406,8 @@ def sync_all_pipelines(gh_username=None, gh_auth_token=None):
         shutil.rmtree(wf_local_path)
 
     if len(successful_syncs) > 0:
-        log.info(
-            "[green]Finished. Successfully synchronised {} pipelines".format(len(successful_syncs)),
-            extra={"markup": True},
-        )
+        log.info("[green]Finished. Successfully synchronised {} pipelines".format(len(successful_syncs)))
 
     if len(failed_syncs) > 0:
         failed_list = "\n - ".join(failed_syncs)
-        log.error(
-            "[red]Errors whilst synchronising {} pipelines:\n - {}".format(len(failed_syncs), failed_list),
-            extra={"markup": True},
-        )
+        log.error("[red]Errors whilst synchronising {} pipelines:\n - {}".format(len(failed_syncs), failed_list))

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "pyyaml",
         "requests",
         "requests_cache",
-        "rich>=3.4.0",
+        "rich>=4.0.0",
         "tabulate",
     ],
     setup_requires=["twine>=1.11.0", "setuptools>=38.6."],


### PR DESCRIPTION
Use new argument for the Rich logging handler. Removed all of the `extra={"markup":True}` statements in various logging calls.

See https://github.com/willmcgugan/rich/issues/171 - thanks for the super-fast feature addition @willmcgugan!

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated