### PR TITLE
Dockerhub ci actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ pip-log.txt
 pip-delete-this-directory.txt
 
 # Unit test / coverage reports
+testing*
 htmlcov/
 .tox/
 .coverage
@@ -107,4 +108,4 @@ ENV/
 
 # backup files
 *~
-*?
+*\?

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/ci.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/ci.yml
@@ -1,6 +1,5 @@
 name: nf-core CI
-# This workflow is triggered on releases and pull-requests.
-# It runs the pipeline with the minimal test dataset to check that it completes without any syntax errors
+# This workflow runs the pipeline with the minimal test dataset to check that it completes without any syntax errors
 on:
   push:
     branches:
@@ -54,35 +53,3 @@ jobs:
         # Remember that you can parallelise this by using strategy.matrix
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile test,docker
-
-  push_dockerhub:
-    name: Push new Docker image to Docker Hub
-    runs-on: ubuntu-latest
-    # Only run if the tests passed
-    needs: test
-    # Only run for the nf-core repo, for releases and merged PRs
-    if: {% raw %}${{{% endraw %} github.repository == '{{ cookiecutter.name }}' && (github.event_name == 'release' || github.event_name == 'push') {% raw %}}}{% endraw %}
-    env:
-      DOCKERHUB_USERNAME: {% raw %}${{ secrets.DOCKERHUB_USERNAME }}{% endraw %}
-      DOCKERHUB_PASS: {% raw %}${{ secrets.DOCKERHUB_PASS }}{% endraw %}
-    steps:
-      - name: Check out pipeline code
-        uses: actions/checkout@v2
-
-      - name: Build new docker image
-        run: docker build --no-cache . -t {{ cookiecutter.name_docker }}:latest
-
-      - name: Push Docker image to DockerHub (dev)
-        if: {% raw %}${{ github.event_name == 'push' }}{% endraw %}
-        run: |
-          echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-          docker tag {{ cookiecutter.name_docker }}:latest {{ cookiecutter.name_docker }}:dev
-          docker push {{ cookiecutter.name_docker }}:dev
-
-      - name: Push Docker image to DockerHub (release)
-        if: {% raw %}${{ github.event_name == 'release' }}{% endraw %}
-        run: |
-          echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-          docker push {{ cookiecutter.name_docker }}:latest
-          docker tag {{ cookiecutter.name_docker }}:latest {{ cookiecutter.name_docker }}:{% raw %}${{ github.event.release.tag_name }}{% endraw %}
-          docker push {{ cookiecutter.name_docker }}:{% raw %}${{ github.event.release.tag_name }}{% endraw %}

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/push_dockerhub.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/push_dockerhub.yml
@@ -1,0 +1,39 @@
+name: nf-core CI
+# This builds the docker image and pushes it to DockerHub
+# Runs on nf-core repo releases and push event to 'dev' branch (PR merges)
+on:
+  push:
+    branches:
+      - dev
+  release:
+    types: [published]
+
+push_dockerhub:
+  name: Push new Docker image to Docker Hub
+  runs-on: ubuntu-latest
+  # Only run for the nf-core repo, for releases and merged PRs
+  if: {% raw %}${{{% endraw %} github.repository == '{{ cookiecutter.name }}' {% raw %}}}{% endraw %}
+  env:
+    DOCKERHUB_USERNAME: {% raw %}${{ secrets.DOCKERHUB_USERNAME }}{% endraw %}
+    DOCKERHUB_PASS: {% raw %}${{ secrets.DOCKERHUB_PASS }}{% endraw %}
+  steps:
+    - name: Check out pipeline code
+      uses: actions/checkout@v2
+
+    - name: Build new docker image
+      run: docker build --no-cache . -t {{ cookiecutter.name_docker }}:latest
+
+    - name: Push Docker image to DockerHub (dev)
+      if: {% raw %}${{ github.event_name == 'push' }}{% endraw %}
+      run: |
+        echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+        docker tag {{ cookiecutter.name_docker }}:latest {{ cookiecutter.name_docker }}:dev
+        docker push {{ cookiecutter.name_docker }}:dev
+
+    - name: Push Docker image to DockerHub (release)
+      if: {% raw %}${{ github.event_name == 'release' }}{% endraw %}
+      run: |
+        echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+        docker push {{ cookiecutter.name_docker }}:latest
+        docker tag {{ cookiecutter.name_docker }}:latest {{ cookiecutter.name_docker }}:{% raw %}${{ github.event.release.tag_name }}{% endraw %}
+        docker push {{ cookiecutter.name_docker }}:{% raw %}${{ github.event.release.tag_name }}{% endraw %}

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/push_dockerhub.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/push_dockerhub.yml
@@ -1,4 +1,4 @@
-name: nf-core CI
+name: nf-core Docker push
 # This builds the docker image and pushes it to DockerHub
 # Runs on nf-core repo releases and push event to 'dev' branch (PR merges)
 on:

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.gitignore
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.gitignore
@@ -5,4 +5,5 @@ results/
 .DS_Store
 tests/
 testing/
+testing*
 *.pyc


### PR DESCRIPTION
Move the new DockerHub GitHub action out into its own file.

Means that it now runs even if tests are failing. However, PRs shouldn't be merged / pipelines shouldn't be released with failing tests, so can't see that it will be a problem. In fact, release tests are failing at the moment because of broken CI, so it's probably actually a good thing.

Main reason for moving was that it was showing up as being skipped on every PR, causing some confusion (https://github.com/nf-core/chipseq/pull/171#issuecomment-664989452). If in its own file like this then it doesn't show at all unless it's running.

Also fixed a broken `.gitignore` pattern that I added recently, which was matching _all_ files 🤦🏻 