### PR TITLE
Schema lint - warn about invalid title + description

### DIFF
--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -482,6 +482,11 @@ def lint(schema_path):
     try:
         schema_obj.get_schema_path(schema_path)
         schema_obj.load_lint_schema()
+        # Validate title and description - just warnings as schema should still work fine
+        try:
+            schema_obj.validate_schema_title_description()
+        except AssertionError as e:
+            log.warn(e)
     except AssertionError as e:
         sys.exit(1)
 

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -1237,6 +1237,14 @@ class PipelineLint(object):
         except AssertionError as e:
             self.failed.append((14, "Schema lint failed: {}".format(e)))
 
+        # Check the title and description - gives warnings instead of fail
+        if self.schema_obj.schema is not None:
+            try:
+                self.schema_obj.validate_schema_title_description()
+                self.passed.append((14, "Schema title + description lint passed"))
+            except AssertionError as e:
+                self.warned.append((14, e))
+
     def check_schema_params(self):
         """ Check that the schema describes all flat params in the pipeline """
 

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -190,11 +190,11 @@ class PipelineSchema(object):
             for allOf in schema["allOf"]:
                 if allOf["$ref"] == "#/definitions/{}".format(d_key):
                     in_allOf = True
-            assert in_allOf, "Definition subschema '{}' not included in schema 'allOf'".format(d_key)
+            assert in_allOf, "Definition subschema `{}` not included in schema `allOf`".format(d_key)
 
             for d_param_id in d_schema.get("properties", {}):
                 # Check that we don't have any duplicate parameter IDs in different definitions
-                assert d_param_id not in param_keys, "Duplicate parameter found in schema 'definitions': '{}'".format(
+                assert d_param_id not in param_keys, "Duplicate parameter found in schema `definitions`: `{}`".format(
                     d_param_id
                 )
                 param_keys.append(d_param_id)
@@ -204,15 +204,12 @@ class PipelineSchema(object):
         for allOf in schema.get("allOf", []):
             assert "definitions" in schema, "Schema has allOf, but no definitions"
             def_key = allOf["$ref"][14:]
-            assert def_key in schema["definitions"], "Subschema '{}' found in 'allOf' but not 'definitions'".format(
+            assert def_key in schema["definitions"], "Subschema `{}` found in `allOf` but not `definitions`".format(
                 def_key
             )
 
         # Check that the schema describes at least one parameter
         assert num_params > 0, "No parameters found in schema"
-
-        # Validate title and description
-        self.validate_schema_title_description(schema)
 
         return num_params
 
@@ -227,9 +224,9 @@ class PipelineSchema(object):
             log.debug("Pipeline schema not set - skipping validation of top-level attributes")
             return None
 
-        assert "$schema" in self.schema, "Schema missing top-level '$schema' attribute"
+        assert "$schema" in self.schema, "Schema missing top-level `$schema` attribute"
         schema_attr = "https://json-schema.org/draft-07/schema"
-        assert self.schema["$schema"] == schema_attr, "Schema '$schema' should be '{}'\n Found '{}'".format(
+        assert self.schema["$schema"] == schema_attr, "Schema `$schema` should be `{}`\n Found `{}`".format(
             schema_attr, self.schema["$schema"]
         )
 
@@ -237,20 +234,20 @@ class PipelineSchema(object):
             self.get_wf_params()
 
         if "name" not in self.pipeline_manifest:
-            log.debug("Pipeline manifest 'name' not known - skipping validation of schema id and title")
+            log.debug("Pipeline manifest `name` not known - skipping validation of schema id and title")
         else:
-            assert "$id" in self.schema, "Schema missing top-level '$id' attribute"
-            assert "title" in self.schema, "Schema missing top-level 'title' attribute"
+            assert "$id" in self.schema, "Schema missing top-level `$id` attribute"
+            assert "title" in self.schema, "Schema missing top-level `title` attribute"
             # Validate that id, title and description match the pipeline manifest
             id_attr = "https://raw.githubusercontent.com/{}/master/nextflow_schema.json".format(
                 self.pipeline_manifest["name"].strip("\"'")
             )
-            assert self.schema["$id"] == id_attr, "Schema '$id' should be '{}'\n Found '{}'".format(
+            assert self.schema["$id"] == id_attr, "Schema `$id` should be `{}`\n Found `{}`".format(
                 id_attr, self.schema["$id"]
             )
 
             title_attr = "{} pipeline parameters".format(self.pipeline_manifest["name"].strip("\"'"))
-            assert self.schema["title"] == title_attr, "Schema 'title' should be '{}'\n Found: '{}'".format(
+            assert self.schema["title"] == title_attr, "Schema `title` should be `{}`\n Found: `{}`".format(
                 title_attr, self.schema["title"]
             )
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -45,7 +45,7 @@ PATHS_WRONG_LICENSE_EXAMPLE = [
 ]
 
 # The maximum sum of passed tests currently possible
-MAX_PASS_CHECKS = 83
+MAX_PASS_CHECKS = 84
 # The additional tests passed for releases
 ADD_PASS_RELEASE = 1
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -161,7 +161,7 @@ class TestSchema(unittest.TestCase):
             self.schema_obj.validate_schema(self.schema_obj.schema)
             raise UserWarning("Expected AssertionError")
         except AssertionError as e:
-            assert e.args[0] == "Duplicate parameter found in schema 'definitions': 'foo'"
+            assert e.args[0] == "Duplicate parameter found in schema `definitions`: `foo`"
 
     def test_validate_schema_fail_missing_def(self):
         """
@@ -175,7 +175,7 @@ class TestSchema(unittest.TestCase):
             self.schema_obj.validate_schema(self.schema_obj.schema)
             raise UserWarning("Expected AssertionError")
         except AssertionError as e:
-            assert e.args[0] == "Definition subschema 'groupTwo' not included in schema 'allOf'"
+            assert e.args[0] == "Definition subschema `groupTwo` not included in schema `allOf`"
 
     def test_validate_schema_fail_unexpected_allof(self):
         """
@@ -193,7 +193,7 @@ class TestSchema(unittest.TestCase):
             self.schema_obj.validate_schema(self.schema_obj.schema)
             raise UserWarning("Expected AssertionError")
         except AssertionError as e:
-            assert e.args[0] == "Subschema 'groupThree' found in 'allOf' but not 'definitions'"
+            assert e.args[0] == "Subschema `groupThree` found in `allOf` but not `definitions`"
 
     def test_make_skeleton_schema(self):
         """ Test making a new schema skeleton """


### PR DESCRIPTION
Schema linting - split out the title + description checks:

* Don't call as part of the main schema validation function
  * This means that `nf-core launch` and other tools that require a valid schema to work still launch even if you have a typo in your schema description
* `nf-core schema validate` throws log warnings to the command line about this check
* `nf-core lint` throws lint warnings about this check

