### PR TITLE
Revert extra whitespace for schema web builder prompt

### DIFF
--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -321,7 +321,7 @@ class PipelineSchema(object):
 
         # If running interactively, send to the web for customisation
         if not self.no_prompts:
-            if Confirm.ask("           :rocket:  Launch web builder for customisation and editing?"):
+            if Confirm.ask(":rocket:  Launch web builder for customisation and editing?"):
                 try:
                     self.launch_web_builder()
                 except AssertionError as e:


### PR DESCRIPTION
Reverting the whitespace padding for the launch prompt, as it looks weird when you have lots of prompts about adding and removing params:

![image](https://user-images.githubusercontent.com/465550/88849019-8b20f700-d1e9-11ea-8df2-be9f563ed3d5.png)

And to be honest, I'm not sure that I love it even when it's just `INFO` statements.. 🤔 For me it is a prompt and not a log statement, so I find it a bit jarring if it has the same indentation as a log message. But I am _very_ used to looking at these logs which most people aren't.