### PR TITLE
[FIX] Doc links in Readme template

### DIFF
--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
@@ -40,7 +40,7 @@ See [usage docs](https://nf-co.re/{{ cookiecutter.short_name }}/usage) for all o
 
 ## Documentation
 
-The {{ cookiecutter.name }} pipeline comes with documentation about the pipeline which you can read at [https://nf-co.re/{{ cookiecutter.short_name }}](https://nf-co.re/{{ cookiecutter.short_name }}) or partly find in the [`docs/` directory](docs).
+The {{ cookiecutter.name }} pipeline comes with documentation about the pipeline which you can read at [https://nf-co.re/{{ cookiecutter.short_name }}](https://nf-co.re/{{ cookiecutter.short_name }}).
 
 <!-- TODO nf-core: Add a brief overview of what the pipeline does and how it works -->
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
@@ -40,7 +40,7 @@ See [usage docs](https://nf-co.re/{{ cookiecutter.short_name }}/usage) for all o
 
 ## Documentation
 
-The {{ cookiecutter.name }} pipeline comes with documentation about the pipeline which you can read at [https://nf-co.re/{{ cookiecutter.short_name }}](https://nf-core/{{ cookiecutter.short_name }}) or partly find in the [`docs/` directory](docs).
+The {{ cookiecutter.name }} pipeline comes with documentation about the pipeline which you can read at [https://nf-co.re/{{ cookiecutter.short_name }}](https://nf-co.re/{{ cookiecutter.short_name }}) or partly find in the [`docs/` directory](docs).
 
 <!-- TODO nf-core: Add a brief overview of what the pipeline does and how it works -->
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
@@ -36,11 +36,11 @@ The pipeline is built using [Nextflow](https://www.nextflow.io), a workflow tool
     nextflow run {{ cookiecutter.name }} -profile <docker/singularity/conda/institute> --input '*_R{1,2}.fastq.gz' --genome GRCh37
     ```
 
-See [usage docs](docs/usage.md) for all of the available options when running the pipeline.
+See [usage docs](https://nf-co.re/{{ cookiecutter.short_name }}/usage) for all of the available options when running the pipeline.
 
 ## Documentation
 
-The {{ cookiecutter.name }} pipeline comes with documentation about the pipeline which you can read at [https://nf-core/{{ cookiecutter.short_name }}/docs](https://nf-core/{{ cookiecutter.short_name }}/docs) or find in the [`docs/` directory](docs).
+The {{ cookiecutter.name }} pipeline comes with documentation about the pipeline which you can read at [https://nf-co.re/{{ cookiecutter.short_name }}](https://nf-core/{{ cookiecutter.short_name }}) or partly find in the [`docs/` directory](docs).
 
 <!-- TODO nf-core: Add a brief overview of what the pipeline does and how it works -->
 


### PR DESCRIPTION
I am not sure, but it seems like the template readme does not really fit the auto-generation of the usage docs anymore.
Also, the link to the general docs was broken ("." missing).

# PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Documentation in `docs` is updated
