### PR TITLE
remove outdated TODO in template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Fix command error in `awstest.yml` GitHub Action workflow.
 * Allow manual triggering of AWS test GitHub Action workflows.
+* Remove TODO item, which was proposing the usage of additional files beside `usage.md` and `output.md` for documentation.
 
 ### Linting
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/CONTRIBUTING.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/CONTRIBUTING.md
@@ -54,4 +54,4 @@ These tests are run both with the latest available version of `Nextflow` and als
 
 ## Getting help
 
-For further information/help, please consult the [{{ cookiecutter.name }} documentation](https://nf-co.re/{{ cookiecutter.short_name }}/docs) and don't hesitate to get in touch on the nf-core Slack [#{{ cookiecutter.short_name }}](https://nfcore.slack.com/channels/{{ cookiecutter.short_name }}) channel ([join our Slack here](https://nf-co.re/join/slack)).
+For further information/help, please consult the [{{ cookiecutter.name }} documentation](https://nf-co.re/{{ cookiecutter.short_name }}/usage) and don't hesitate to get in touch on the nf-core Slack [#{{ cookiecutter.short_name }}](https://nfcore.slack.com/channels/{{ cookiecutter.short_name }}) channel ([join our Slack here](https://nf-co.re/join/slack)).

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
@@ -40,7 +40,7 @@ See [usage docs](docs/usage.md) for all of the available options when running th
 
 ## Documentation
 
-The {{ cookiecutter.name }} pipeline comes with documentation about the pipeline which you can read at [https://nf-core/{{ cookiecutter.short_name }}/docs](https://nf-core/{{ cookiecutter.short_name }}/docs) or find in the [`docs/` directory](docs).
+The {{ cookiecutter.name }} pipeline comes with documentation about the pipeline which you can read at [https://nf-co.re/{{ cookiecutter.short_name }}/usage](https://nf-co.re/{{ cookiecutter.short_name }}/usage) or find in the [`docs/` directory](docs).
 
 <!-- TODO nf-core: Add a brief overview of what the pipeline does and how it works -->
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/README.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/README.md
@@ -2,8 +2,6 @@
 
 The {{ cookiecutter.name }} documentation is split into the following pages:
 
-<!-- TODO nf-core: If you write more documentation pages, add them to the docs index page here -->
-
 * [Usage](usage.md)
   * An overview of how the pipeline works, how to run it and a description of all of the different command-line flags.
 * [Output](output.md)


### PR DESCRIPTION
- As shortly discussed on slack, removing the TODO mentioning the option of additional doc files besides `usage.md` and `output.md`.
- Fix now dead `/docs` links

## PR checklist

 - [x] This comment contains a description of changes (with reason)