### PR TITLE
remove docs from README Template and simplify Documentation section

### DIFF
--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
@@ -40,7 +40,7 @@ See [usage docs](https://nf-co.re/{{ cookiecutter.short_name }}/usage) for all o
 
 ## Documentation
 
-The {{ cookiecutter.name }} pipeline comes with documentation about the pipeline which you can read at [https://nf-co.re/{{ cookiecutter.short_name }}/usage](https://nf-co.re/{{ cookiecutter.short_name }}/usage) and [https://nf-co.re/{{ cookiecutter.short_name }}/output](https://nf-co.re/{{ cookiecutter.short_name }}/output) or find in the [`docs/` directory](docs) in the repository.
+The {{ cookiecutter.name }} pipeline comes with documentation about the pipeline: [{{ cookiecutter.short_name }}/usage]({{ cookiecutter.short_name }}/usage) and [{{ cookiecutter.short_name }}/output]({{ cookiecutter.short_name }}/output).
 
 <!-- TODO nf-core: Add a brief overview of what the pipeline does and how it works -->
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
@@ -40,7 +40,7 @@ See [usage docs](https://nf-co.re/{{ cookiecutter.short_name }}/usage) for all o
 
 ## Documentation
 
-The {{ cookiecutter.name }} pipeline comes with documentation about the pipeline: [{{ cookiecutter.short_name }}/usage]({{ cookiecutter.short_name }}/usage) and [{{ cookiecutter.short_name }}/output]({{ cookiecutter.short_name }}/output).
+The {{ cookiecutter.name }} pipeline comes with documentation about the pipeline: [docs/usage](docs/usage.md) and [docs/output](docs/output.md).
 
 <!-- TODO nf-core: Add a brief overview of what the pipeline does and how it works -->
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/README.md
@@ -40,7 +40,7 @@ See [usage docs](https://nf-co.re/{{ cookiecutter.short_name }}/usage) for all o
 
 ## Documentation
 
-The {{ cookiecutter.name }} pipeline comes with documentation about the pipeline: [docs/usage](docs/usage.md) and [docs/output](docs/output.md).
+The {{ cookiecutter.name }} pipeline comes with documentation about the pipeline: [usage](https://nf-co.re/{{ cookiecutter.short_name }}/usage) and [output](https://nf-co.re/{{ cookiecutter.short_name }}/output).
 
 <!-- TODO nf-core: Add a brief overview of what the pipeline does and how it works -->
 


### PR DESCRIPTION
The link to the folder docs in the Documentation section is not working:

https://nf-co.re/rnaseq/dev#documentation
-> https://nf-co.re/rnaseq/dev/docs

I propose to actually remove the mention of this folder, and link directly the md files which should simplify the whole section.

Only issue, I would want to link `docs/usage.md` and `docs/output.md` which are not accessible in the current website from this README.

Any idea on how to improve all that?

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

 - [ ] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
