### PR TITLE
Update rich to >=9 and update [] escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Linting
 
+* Update `rich` package dependency and use new markup escaping to change `[[!]]` back to `[!]` again
+
 ### Other
 
 * Pipeline sync - fetch full repo when checking out before sync

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -35,12 +35,12 @@ def run_nf_core():
 
     # Print nf-core header to STDERR
     stderr = rich.console.Console(file=sys.stderr)
-    stderr.print("\n[green]{},--.[grey39]/[green],-.".format(" " * 42), highlight=False)
-    stderr.print("[blue]          ___     __   __   __   ___     [green]/,-._.--~\\", highlight=False)
-    stderr.print("[blue]    |\ | |__  __ /  ` /  \ |__) |__      [yellow]   }  {", highlight=False)
-    stderr.print("[blue]    | \| |       \__, \__/ |  \ |___     [green]\`-._,-`-,", highlight=False)
-    stderr.print("[green]                                          `._,._,'\n", highlight=False)
-    stderr.print("[grey39]    nf-core/tools version {}".format(nf_core.__version__), highlight=False)
+    stderr.print(r"\n[green]{},--.[grey39]/[green],-.".format(" " * 42), highlight=False)
+    stderr.print(r"[blue]          ___     __   __   __   ___     [green]/,-._.--~\\", highlight=False)
+    stderr.print(r"[blue]    |\ | |__  __ /  ` /  \ |__) |__      [yellow]   }  {", highlight=False)
+    stderr.print(r"[blue]    | \| |       \__, \__/ |  \ |___     [green]\`-._,-`-,", highlight=False)
+    stderr.print(r"[green]                                          `._,._,'\n", highlight=False)
+    stderr.print(r"[grey39]    nf-core/tools version {}".format(nf_core.__version__), highlight=False)
     try:
         is_outdated, current_vers, remote_vers = nf_core.utils.check_if_outdated()
         if is_outdated:
@@ -503,7 +503,7 @@ def lint(schema_path):
         try:
             schema_obj.validate_schema_title_description()
         except AssertionError as e:
-            log.warn(e)
+            log.warning(e)
     except AssertionError as e:
         sys.exit(1)
 

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -1345,7 +1345,7 @@ class PipelineLint(object):
         # Summary table
 
         table = Table(box=rich.box.ROUNDED)
-        table.add_column("[bold green]LINT RESULTS SUMMARY".format(len(self.passed)), no_wrap=True)
+        table.add_column(r"\[bold green]LINT RESULTS SUMMARY".format(len(self.passed)), no_wrap=True)
         table.add_row(
             r"\[\u2714] {:>3} Test{} Passed".format(len(self.passed), _s(self.passed)),
             style="green",

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -148,6 +148,7 @@ class PipelineLint(object):
     def __init__(self, path):
         """ Initialise linting object """
         self.release_mode = False
+        self.version = nf_core.__version__
         self.path = path
         self.git_sha = None
         self.files = []
@@ -1153,7 +1154,7 @@ class PipelineLint(object):
             return
 
         expected_strings = [
-            "FROM nfcore/base:{}".format("dev" if "dev" in nf_core.__version__ else nf_core.__version__),
+            "FROM nfcore/base:{}".format("dev" if "dev" in self.version else self.version),
             "COPY environment.yml /",
             "RUN conda env create --quiet -f /environment.yml && conda clean -a",
             "RUN conda env export --name {} > {}.yml".format(self.conda_config["name"], self.conda_config["name"]),

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -1318,7 +1318,7 @@ class PipelineLint(object):
         if len(self.passed) > 0 and show_passed:
             table = Table(style="green", box=rich.box.ROUNDED)
             table.add_column(
-                "[[\u2714]] {} Test{} Passed".format(len(self.passed), _s(self.passed)),
+                "\[\u2714] {} Test{} Passed".format(len(self.passed), _s(self.passed)),
                 no_wrap=True,
             )
             table = format_result(self.passed, table)
@@ -1327,7 +1327,7 @@ class PipelineLint(object):
         # Table of warning tests
         if len(self.warned) > 0:
             table = Table(style="yellow", box=rich.box.ROUNDED)
-            table.add_column("[[!]] {} Test Warning{}".format(len(self.warned), _s(self.warned)), no_wrap=True)
+            table.add_column("\[!] {} Test Warning{}".format(len(self.warned), _s(self.warned)), no_wrap=True)
             table = format_result(self.warned, table)
             console.print(table)
 
@@ -1335,7 +1335,7 @@ class PipelineLint(object):
         if len(self.failed) > 0:
             table = Table(style="red", box=rich.box.ROUNDED)
             table.add_column(
-                "[[\u2717]] {} Test{} Failed".format(len(self.failed), _s(self.failed)),
+                "\[\u2717] {} Test{} Failed".format(len(self.failed), _s(self.failed)),
                 no_wrap=True,
             )
             table = format_result(self.failed, table)
@@ -1346,11 +1346,11 @@ class PipelineLint(object):
         table = Table(box=rich.box.ROUNDED)
         table.add_column("[bold green]LINT RESULTS SUMMARY".format(len(self.passed)), no_wrap=True)
         table.add_row(
-            "[[\u2714]] {:>3} Test{} Passed".format(len(self.passed), _s(self.passed)),
+            "\[\u2714] {:>3} Test{} Passed".format(len(self.passed), _s(self.passed)),
             style="green",
         )
-        table.add_row("[[!]] {:>3} Test Warning{}".format(len(self.warned), _s(self.warned)), style="yellow")
-        table.add_row("[[\u2717]] {:>3} Test{} Failed".format(len(self.failed), _s(self.failed)), style="red")
+        table.add_row("\[!] {:>3} Test Warning{}".format(len(self.warned), _s(self.warned)), style="yellow")
+        table.add_row("\[\u2717] {:>3} Test{} Failed".format(len(self.failed), _s(self.failed)), style="red")
         console.print(table)
 
     def get_results_md(self):

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -1318,7 +1318,7 @@ class PipelineLint(object):
         if len(self.passed) > 0 and show_passed:
             table = Table(style="green", box=rich.box.ROUNDED)
             table.add_column(
-                "\[\u2714] {} Test{} Passed".format(len(self.passed), _s(self.passed)),
+                r"\[\u2714] {} Test{} Passed".format(len(self.passed), _s(self.passed)),
                 no_wrap=True,
             )
             table = format_result(self.passed, table)
@@ -1327,7 +1327,7 @@ class PipelineLint(object):
         # Table of warning tests
         if len(self.warned) > 0:
             table = Table(style="yellow", box=rich.box.ROUNDED)
-            table.add_column("\[!] {} Test Warning{}".format(len(self.warned), _s(self.warned)), no_wrap=True)
+            table.add_column(r"\[!] {} Test Warning{}".format(len(self.warned), _s(self.warned)), no_wrap=True)
             table = format_result(self.warned, table)
             console.print(table)
 
@@ -1335,7 +1335,7 @@ class PipelineLint(object):
         if len(self.failed) > 0:
             table = Table(style="red", box=rich.box.ROUNDED)
             table.add_column(
-                "\[\u2717] {} Test{} Failed".format(len(self.failed), _s(self.failed)),
+                r"\[\u2717] {} Test{} Failed".format(len(self.failed), _s(self.failed)),
                 no_wrap=True,
             )
             table = format_result(self.failed, table)
@@ -1346,11 +1346,11 @@ class PipelineLint(object):
         table = Table(box=rich.box.ROUNDED)
         table.add_column("[bold green]LINT RESULTS SUMMARY".format(len(self.passed)), no_wrap=True)
         table.add_row(
-            "\[\u2714] {:>3} Test{} Passed".format(len(self.passed), _s(self.passed)),
+            r"\[\u2714] {:>3} Test{} Passed".format(len(self.passed), _s(self.passed)),
             style="green",
         )
-        table.add_row("\[!] {:>3} Test Warning{}".format(len(self.warned), _s(self.warned)), style="yellow")
-        table.add_row("\[\u2717] {:>3} Test{} Failed".format(len(self.failed), _s(self.failed)), style="red")
+        table.add_row(r"\[!] {:>3} Test Warning{}".format(len(self.warned), _s(self.warned)), style="yellow")
+        table.add_row(r"\[\u2717] {:>3} Test{} Failed".format(len(self.failed), _s(self.failed)), style="red")
         console.print(table)
 
     def get_results_md(self):
@@ -1507,7 +1507,7 @@ class PipelineLint(object):
                         log.info("Posted GitHub comment: {}".format(r_json["html_url"]))
                         log.debug(response_pp)
                     else:
-                        log.warn("Could not post GitHub comment: '{}'\n{}".format(r.status_code, response_pp))
+                        log.warning("Could not post GitHub comment: '{}'\n{}".format(r.status_code, response_pp))
 
         except Exception as e:
             log.warning("Could not post GitHub comment: {}\n{}".format(os.environ["GITHUB_COMMENTS_URL"], e))

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow_schema.json
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft-07/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/{{ cookiecutter.name }}/master/nextflow_schema.json",
     "title": "{{ cookiecutter.name }} pipeline parameters",
     "description": "{{ cookiecutter.description }}",

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -79,13 +79,13 @@ class PipelineSchema(object):
             self.load_schema()
             num_params = self.validate_schema()
             self.get_schema_defaults()
-            log.info("[green][[✓]] Pipeline schema looks valid[/] [dim](found {} params)".format(num_params))
+            log.info("[green]\[✓] Pipeline schema looks valid[/] [dim](found {} params)".format(num_params))
         except json.decoder.JSONDecodeError as e:
             error_msg = "[bold red]Could not parse schema JSON:[/] {}".format(e)
             log.error(error_msg)
             raise AssertionError(error_msg)
         except AssertionError as e:
-            error_msg = "[red][[✗]] Pipeline schema does not follow nf-core specs:\n {}".format(e)
+            error_msg = "[red]\[✗] Pipeline schema does not follow nf-core specs:\n {}".format(e)
             log.error(error_msg)
             raise AssertionError(error_msg)
 
@@ -159,12 +159,12 @@ class PipelineSchema(object):
             assert self.schema is not None
             jsonschema.validate(self.input_params, self.schema)
         except AssertionError:
-            log.error("[red][[✗]] Pipeline schema not found")
+            log.error("[red]\[✗] Pipeline schema not found")
             return False
         except jsonschema.exceptions.ValidationError as e:
-            log.error("[red][[✗]] Input parameters are invalid: {}".format(e.message))
+            log.error("[red]\[✗] Input parameters are invalid: {}".format(e.message))
             return False
-        log.info("[green][[✓]] Input parameters look valid")
+        log.info("[green]\[✓] Input parameters look valid")
         return True
 
     def validate_schema(self, schema=None):

--- a/nf_core/sync.py
+++ b/nf_core/sync.py
@@ -337,12 +337,12 @@ class PipelineSync(object):
                 return True
             # Something went wrong
             else:
-                log.warn("Could not update PR ('{}'):\n{}\n{}".format(r.status_code, pr_update_api_url, r_pp))
+                log.warning("Could not update PR ('{}'):\n{}\n{}".format(r.status_code, pr_update_api_url, r_pp))
                 return False
 
         # Something went wrong
         else:
-            log.warn("Could not list open PRs ('{}')\n{}\n{}".format(r.status_code, list_prs_url, r_pp))
+            log.warning("Could not list open PRs ('{}')\n{}\n{}".format(r.status_code, list_prs_url, r_pp))
             return False
 
     def submit_pull_request(self, pr_title, pr_body_text):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
 [tool.black]
 line-length = 120
 target_version = ['py36','py37','py38']
+
+[tool.pytest.ini_options]
+markers = [
+    "datafiles: load datafiles"
+]

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "pyyaml",
         "requests",
         "requests_cache",
-        "rich>=4.2.1",
+        "rich>=9",
         "tabulate",
     ],
     setup_requires=["twine>=1.11.0", "setuptools>=38.6."],

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -76,7 +76,7 @@ class TestLint(unittest.TestCase):
         This should not result in any exception for the minimal
         working example"""
         old_nfcore_version = nf_core.__version__
-        nf_core.__version__ = '1.11.0'
+        nf_core.__version__ = "1.11.0"
         lint_obj = nf_core.lint.run_linting(PATH_WORKING_EXAMPLE, False)
         nf_core.__version__ = old_nfcore_version
         expectations = {"failed": 0, "warned": 5, "passed": MAX_PASS_CHECKS - 1}
@@ -93,7 +93,7 @@ class TestLint(unittest.TestCase):
     def test_call_lint_pipeline_release(self):
         """Test the main execution function of PipelineLint when running with --release"""
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
-        lint_obj.version = '1.11.0'
+        lint_obj.version = "1.11.0"
         lint_obj.lint_pipeline(release_mode=True)
         expectations = {"failed": 0, "warned": 4, "passed": MAX_PASS_CHECKS + ADD_PASS_RELEASE}
         self.assess_lint_status(lint_obj, **expectations)
@@ -388,7 +388,7 @@ class TestLint(unittest.TestCase):
     def test_conda_dockerfile_pass(self):
         """ Tests the conda Dockerfile test works with a working example """
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
-        lint_obj.version = '1.11.0'
+        lint_obj.version = "1.11.0"
         lint_obj.files = ["environment.yml"]
         with open(os.path.join(PATH_WORKING_EXAMPLE, "Dockerfile"), "r") as fh:
             lint_obj.dockerfile = fh.read().splitlines()
@@ -400,7 +400,7 @@ class TestLint(unittest.TestCase):
     def test_conda_dockerfile_fail(self):
         """ Tests the conda Dockerfile test fails with a bad example """
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
-        lint_obj.version = '1.11.0'
+        lint_obj.version = "1.11.0"
         lint_obj.files = ["environment.yml"]
         lint_obj.conda_config["name"] = "nf-core-tools-0.4"
         lint_obj.dockerfile = ["fubar"]

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -75,7 +75,10 @@ class TestLint(unittest.TestCase):
         """Test the main execution function of PipelineLint (pass)
         This should not result in any exception for the minimal
         working example"""
+        old_nfcore_version = nf_core.__version__
+        nf_core.__version__ = '1.11.0'
         lint_obj = nf_core.lint.run_linting(PATH_WORKING_EXAMPLE, False)
+        nf_core.__version__ = old_nfcore_version
         expectations = {"failed": 0, "warned": 5, "passed": MAX_PASS_CHECKS - 1}
         self.assess_lint_status(lint_obj, **expectations)
 
@@ -90,6 +93,7 @@ class TestLint(unittest.TestCase):
     def test_call_lint_pipeline_release(self):
         """Test the main execution function of PipelineLint when running with --release"""
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
+        lint_obj.version = '1.11.0'
         lint_obj.lint_pipeline(release_mode=True)
         expectations = {"failed": 0, "warned": 4, "passed": MAX_PASS_CHECKS + ADD_PASS_RELEASE}
         self.assess_lint_status(lint_obj, **expectations)
@@ -384,6 +388,7 @@ class TestLint(unittest.TestCase):
     def test_conda_dockerfile_pass(self):
         """ Tests the conda Dockerfile test works with a working example """
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
+        lint_obj.version = '1.11.0'
         lint_obj.files = ["environment.yml"]
         with open(os.path.join(PATH_WORKING_EXAMPLE, "Dockerfile"), "r") as fh:
             lint_obj.dockerfile = fh.read().splitlines()
@@ -395,6 +400,7 @@ class TestLint(unittest.TestCase):
     def test_conda_dockerfile_fail(self):
         """ Tests the conda Dockerfile test fails with a bad example """
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
+        lint_obj.version = '1.11.0'
         lint_obj.files = ["environment.yml"]
         lint_obj.conda_config["name"] = "nf-core-tools-0.4"
         lint_obj.dockerfile = ["fubar"]


### PR DESCRIPTION
Minor bump to Rich, as a change to how it does escaping meant that all of the square brackets in the logs were showing up as double square brackets.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
