### PR TITLE
Hotfix for broken PR

### DIFF
--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -35,12 +35,12 @@ def run_nf_core():
 
     # Print nf-core header to STDERR
     stderr = rich.console.Console(file=sys.stderr)
-    stderr.print(r"\n[green]{},--.[grey39]/[green],-.".format(" " * 42), highlight=False)
-    stderr.print(r"[blue]          ___     __   __   __   ___     [green]/,-._.--~\\", highlight=False)
-    stderr.print(r"[blue]    |\ | |__  __ /  ` /  \ |__) |__      [yellow]   }  {", highlight=False)
-    stderr.print(r"[blue]    | \| |       \__, \__/ |  \ |___     [green]\`-._,-`-,", highlight=False)
-    stderr.print(r"[green]                                          `._,._,'\n", highlight=False)
-    stderr.print(r"[grey39]    nf-core/tools version {}".format(nf_core.__version__), highlight=False)
+    stderr.print("\n[green]{},--.[grey39]/[green],-.".format(" " * 42), highlight=False)
+    stderr.print("[blue]          ___     __   __   __   ___     [green]/,-._.--~\\", highlight=False)
+    stderr.print("[blue]    |\ | |__  __ /  ` /  \ |__) |__      [yellow]   }  {", highlight=False)
+    stderr.print("[blue]    | \| |       \__, \__/ |  \ |___     [green]\`-._,-`-,", highlight=False)
+    stderr.print("[green]                                          `._,._,'\n", highlight=False)
+    stderr.print("[grey39]    nf-core/tools version {}".format(nf_core.__version__), highlight=False)
     try:
         is_outdated, current_vers, remote_vers = nf_core.utils.check_if_outdated()
         if is_outdated:

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -1319,7 +1319,7 @@ class PipelineLint(object):
         if len(self.passed) > 0 and show_passed:
             table = Table(style="green", box=rich.box.ROUNDED)
             table.add_column(
-                "\[\u2714] {} Test{} Passed".format(len(self.passed), _s(self.passed)),
+                r"\[✔] {} Test{} Passed".format(len(self.passed), _s(self.passed)),
                 no_wrap=True,
             )
             table = format_result(self.passed, table)
@@ -1328,7 +1328,7 @@ class PipelineLint(object):
         # Table of warning tests
         if len(self.warned) > 0:
             table = Table(style="yellow", box=rich.box.ROUNDED)
-            table.add_column("\[!] {} Test Warning{}".format(len(self.warned), _s(self.warned)), no_wrap=True)
+            table.add_column(r"\[!] {} Test Warning{}".format(len(self.warned), _s(self.warned)), no_wrap=True)
             table = format_result(self.warned, table)
             console.print(table)
 
@@ -1336,7 +1336,7 @@ class PipelineLint(object):
         if len(self.failed) > 0:
             table = Table(style="red", box=rich.box.ROUNDED)
             table.add_column(
-                "\[\u2717] {} Test{} Failed".format(len(self.failed), _s(self.failed)),
+                r"\[✗] {} Test{} Failed".format(len(self.failed), _s(self.failed)),
                 no_wrap=True,
             )
             table = format_result(self.failed, table)
@@ -1347,11 +1347,11 @@ class PipelineLint(object):
         table = Table(box=rich.box.ROUNDED)
         table.add_column("[bold green]LINT RESULTS SUMMARY".format(len(self.passed)), no_wrap=True)
         table.add_row(
-            "\[\u2714] {:>3} Test{} Passed".format(len(self.passed), _s(self.passed)),
+            r"\[✔] {:>3} Test{} Passed".format(len(self.passed), _s(self.passed)),
             style="green",
         )
-        table.add_row("\[!] {:>3} Test Warning{}".format(len(self.warned), _s(self.warned)), style="yellow")
-        table.add_row("\[\u2717] {:>3} Test{} Failed".format(len(self.failed), _s(self.failed)), style="red")
+        table.add_row(r"\[!] {:>3} Test Warning{}".format(len(self.warned), _s(self.warned)), style="yellow")
+        table.add_row(r"\[✗] {:>3} Test{} Failed".format(len(self.failed), _s(self.failed)), style="red")
         console.print(table)
 
     def get_results_md(self):

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -1319,7 +1319,7 @@ class PipelineLint(object):
         if len(self.passed) > 0 and show_passed:
             table = Table(style="green", box=rich.box.ROUNDED)
             table.add_column(
-                r"\[\u2714] {} Test{} Passed".format(len(self.passed), _s(self.passed)),
+                "\[\u2714] {} Test{} Passed".format(len(self.passed), _s(self.passed)),
                 no_wrap=True,
             )
             table = format_result(self.passed, table)
@@ -1328,7 +1328,7 @@ class PipelineLint(object):
         # Table of warning tests
         if len(self.warned) > 0:
             table = Table(style="yellow", box=rich.box.ROUNDED)
-            table.add_column(r"\[!] {} Test Warning{}".format(len(self.warned), _s(self.warned)), no_wrap=True)
+            table.add_column("\[!] {} Test Warning{}".format(len(self.warned), _s(self.warned)), no_wrap=True)
             table = format_result(self.warned, table)
             console.print(table)
 
@@ -1336,7 +1336,7 @@ class PipelineLint(object):
         if len(self.failed) > 0:
             table = Table(style="red", box=rich.box.ROUNDED)
             table.add_column(
-                r"\[\u2717] {} Test{} Failed".format(len(self.failed), _s(self.failed)),
+                "\[\u2717] {} Test{} Failed".format(len(self.failed), _s(self.failed)),
                 no_wrap=True,
             )
             table = format_result(self.failed, table)
@@ -1345,13 +1345,13 @@ class PipelineLint(object):
         # Summary table
 
         table = Table(box=rich.box.ROUNDED)
-        table.add_column(r"\[bold green]LINT RESULTS SUMMARY".format(len(self.passed)), no_wrap=True)
+        table.add_column("[bold green]LINT RESULTS SUMMARY".format(len(self.passed)), no_wrap=True)
         table.add_row(
-            r"\[\u2714] {:>3} Test{} Passed".format(len(self.passed), _s(self.passed)),
+            "\[\u2714] {:>3} Test{} Passed".format(len(self.passed), _s(self.passed)),
             style="green",
         )
-        table.add_row(r"\[!] {:>3} Test Warning{}".format(len(self.warned), _s(self.warned)), style="yellow")
-        table.add_row(r"\[\u2717] {:>3} Test{} Failed".format(len(self.failed), _s(self.failed)), style="red")
+        table.add_row("\[!] {:>3} Test Warning{}".format(len(self.warned), _s(self.warned)), style="yellow")
+        table.add_row("\[\u2717] {:>3} Test{} Failed".format(len(self.failed), _s(self.failed)), style="red")
         console.print(table)
 
     def get_results_md(self):


### PR DESCRIPTION
Quick fix for stuff I broke in https://github.com/nf-core/tools/pull/748

I had checked the pytest results but hadn’t tried running the linting in the console again after adding some of that. Turns out that it broke a bunch of rendering.

I think this PR treads the line where pytest no longer throws warnings, but the output still looks as intended.