### PR TITLE
Lint updates - Dockerfile give a warn, fail for old R script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Linting
 
+* Made a base-level `Dockerfile` a warning instead of failure
+* Added a lint failure if the old `bin/markdown_to_html.r` script is found
 * Update `rich` package dependency and use new markup escaping to change `[[!]]` back to `[!]` again
 
 ### Other

--- a/docs/lint_errors.md
+++ b/docs/lint_errors.md
@@ -10,8 +10,8 @@ The lint test looks for the following required files:
 
 * `nextflow.config`
   * The main nextflow config file
-* `Dockerfile`
-  * A docker build script to generate a docker image with the required software
+* `nextflow_schema.json`
+  * A JSON schema describing pipeline parameters, generated using `nf-core schema build`
 * Continuous integration tests with [GitHub Actions](https://github.com/features/actions)
   * GitHub Actions workflows for CI of your pipeline (`.github/workflows/ci.yml`), branch protection (`.github/workflows/branch.yml`) and nf-core best practice linting (`.github/workflows/linting.yml`)
 * `LICENSE`, `LICENSE.md`, `LICENCE.md` or `LICENCE.md`
@@ -27,8 +27,14 @@ The following files are suggested but not a hard requirement. If they are missin
 
 * `main.nf`
   * It's recommended that the main workflow script is called `main.nf`
+* `environment.yml`
+  * A conda environment file describing the required software
+* `Dockerfile`
+  * A docker build script to generate a docker image with the required software
 * `conf/base.config`
   * A `conf` directory with at least one config called `base.config`
+* `.github/workflows/awstest.yml` and `.github/workflows/awsfulltest.yml`
+  * GitHub workflow scripts used for automated tests on AWS
 
 The following files will cause a failure if the _are_ present (to fix, delete them):
 
@@ -39,12 +45,17 @@ The following files will cause a failure if the _are_ present (to fix, delete th
 * `parameters.settings.json`
   * The syntax for pipeline schema has changed - old `parameters.settings.json` should be
     deleted and new `nextflow_schema.json` files created instead.
+* `bin/markdown_to_html.r`
+  * The old markdown to HTML conversion script, now replaced by `markdown_to_html.py`
 
 ## Error #2 - Docker file check failed ## {#2}
 
-Pipelines should have a files called `Dockerfile` in their root directory.
+DSL1 pipelines should have a file called `Dockerfile` in their root directory.
 The file is used for automated docker image builds. This test checks that the file
 exists and contains at least the string `FROM` (`Dockerfile`).
+
+Some pipelines, especially DSL2, may not have a `Dockerfile`. In this case a warning
+will be generated which can be safely ignored.
 
 ## Error #3 - Licence check failed ## {#3}
 
@@ -298,7 +309,7 @@ If a workflow has a conda `environment.yml` file (see above), the `Dockerfile` s
 to create the container. Such `Dockerfile`s can usually be very short, eg:
 
 ```Dockerfile
-FROM nfcore/base:1.7
+FROM nfcore/base:1.11
 MAINTAINER Rocky Balboa <your@email.com>
 LABEL authors="your@email.com" \
     description="Docker image containing all requirements for the nf-core mypipeline pipeline"

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -254,7 +254,6 @@ class PipelineLint(object):
 
             'nextflow.config',
             'nextflow_schema.json',
-            'Dockerfile',
             ['LICENSE', 'LICENSE.md', 'LICENCE', 'LICENCE.md'], # NB: British / American spelling
             'README.md',
             'CHANGELOG.md',
@@ -269,13 +268,16 @@ class PipelineLint(object):
 
             'main.nf',
             'environment.yml',
+            'Dockerfile',
             'conf/base.config',
             '.github/workflows/awstest.yml',
             '.github/workflows/awsfulltest.yml'
 
         Files that *must not* be present::
 
-            'Singularity'
+            'Singularity',
+            'parameters.settings.json',
+            'bin/markdown_to_html.r'
 
         Files that *should not* be present::
 
@@ -290,7 +292,6 @@ class PipelineLint(object):
         files_fail = [
             ["nextflow.config"],
             ["nextflow_schema.json"],
-            ["Dockerfile"],
             ["LICENSE", "LICENSE.md", "LICENCE", "LICENCE.md"],  # NB: British / American spelling
             ["README.md"],
             ["CHANGELOG.md"],
@@ -304,13 +305,14 @@ class PipelineLint(object):
         files_warn = [
             ["main.nf"],
             ["environment.yml"],
+            ["Dockerfile"],
             [os.path.join("conf", "base.config")],
             [os.path.join(".github", "workflows", "awstest.yml")],
             [os.path.join(".github", "workflows", "awsfulltest.yml")],
         ]
 
         # List of strings. Dails / warns if any of the strings exist.
-        files_fail_ifexists = ["Singularity", "parameters.settings.json"]
+        files_fail_ifexists = ["Singularity", "parameters.settings.json", os.path.join("bin", "markdown_to_html.r")]
         files_warn_ifexists = [".travis.yml"]
 
         def pf(file_path):
@@ -358,6 +360,9 @@ class PipelineLint(object):
 
     def check_docker(self):
         """Checks that Dockerfile contains the string ``FROM``."""
+        if "Dockerfile" not in self.files:
+            return
+
         fn = os.path.join(self.path, "Dockerfile")
         content = ""
         with open(fn, "r") as fh:
@@ -1150,7 +1155,7 @@ class PipelineLint(object):
             * dependency versions are pinned
             * dependency versions are the latest available
         """
-        if "environment.yml" not in self.files or len(self.dockerfile) == 0:
+        if "environment.yml" not in self.files or "Dockerfile" not in self.files or len(self.dockerfile) == 0:
             return
 
         expected_strings = [

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -45,7 +45,7 @@ PATHS_WRONG_LICENSE_EXAMPLE = [
 ]
 
 # The maximum sum of passed tests currently possible
-MAX_PASS_CHECKS = 84
+MAX_PASS_CHECKS = 85
 # The additional tests passed for releases
 ADD_PASS_RELEASE = 1
 
@@ -101,6 +101,7 @@ class TestLint(unittest.TestCase):
     def test_failing_dockerfile_example(self):
         """Tests for empty Dockerfile"""
         lint_obj = nf_core.lint.PipelineLint(PATH_FAILING_EXAMPLE)
+        lint_obj.files = ["Dockerfile"]
         lint_obj.check_docker()
         self.assess_lint_status(lint_obj, failed=1)
 
@@ -113,7 +114,7 @@ class TestLint(unittest.TestCase):
         """Tests for missing files like Dockerfile or LICENSE"""
         lint_obj = nf_core.lint.PipelineLint(PATH_FAILING_EXAMPLE)
         lint_obj.check_files_exist()
-        expectations = {"failed": 6, "warned": 2, "passed": 12}
+        expectations = {"failed": 6, "warned": 2, "passed": 13}
         self.assess_lint_status(lint_obj, **expectations)
 
     def test_mit_licence_example_pass(self):
@@ -281,6 +282,7 @@ class TestLint(unittest.TestCase):
     def test_dockerfile_pass(self):
         """Tests if a valid Dockerfile passes the lint checks"""
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
+        lint_obj.files = ["Dockerfile"]
         lint_obj.check_docker()
         expectations = {"failed": 0, "warned": 0, "passed": 1}
         self.assess_lint_status(lint_obj, **expectations)
@@ -389,7 +391,7 @@ class TestLint(unittest.TestCase):
         """ Tests the conda Dockerfile test works with a working example """
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         lint_obj.version = "1.11.0"
-        lint_obj.files = ["environment.yml"]
+        lint_obj.files = ["environment.yml", "Dockerfile"]
         with open(os.path.join(PATH_WORKING_EXAMPLE, "Dockerfile"), "r") as fh:
             lint_obj.dockerfile = fh.read().splitlines()
         lint_obj.conda_config["name"] = "nf-core-tools-0.4"
@@ -401,7 +403,7 @@ class TestLint(unittest.TestCase):
         """ Tests the conda Dockerfile test fails with a bad example """
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
         lint_obj.version = "1.11.0"
-        lint_obj.files = ["environment.yml"]
+        lint_obj.files = ["environment.yml", "Dockerfile"]
         lint_obj.conda_config["name"] = "nf-core-tools-0.4"
         lint_obj.dockerfile = ["fubar"]
         lint_obj.check_conda_dockerfile()


### PR DESCRIPTION
* Warn if `Dockerfile` doesn't exist, instead of failure
* Fail if the old markdown to HTML R script is found
* Update documentation to describe missing files in this lint test

Closes nf-core/tools#367

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Documentation in `docs` is updated
