### PR TITLE
GitHub Actions sync - add manual 'workflow' trigger

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -2,6 +2,7 @@ name: Sync template
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   get-pipelines:
@@ -21,7 +22,6 @@ jobs:
       matrix: ${{fromJson(needs.get-pipelines.outputs.matrix)}}
       fail-fast: false
     steps:
-
       - uses: actions/checkout@v2
         name: Check out nf-core/tools
 
@@ -32,7 +32,7 @@ jobs:
           ref: dev
           token: ${{ secrets.nf_core_bot_auth_token }}
           path: nf-core/${{ matrix.pipeline }}
-          fetch-depth: '0'
+          fetch-depth: "0"
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v1
@@ -63,7 +63,6 @@ jobs:
             --pull-request \
             --username nf-core-bot \
             --repository nf-core/${{ matrix.pipeline }}
-
 
       - name: Upload sync log file artifact
         if: ${{ always() }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Other
 
 * Pipeline sync - fetch full repo when checking out before sync
+* Sync - Add GitHub actions manual trigger option
 
 ## [v1.10.2 - Copper Camel _(brought back from the dead)_](https://github.com/nf-core/tools/releases/tag/1.10.2) - [2020-07-31]
 


### PR DESCRIPTION
I'm not really sure how to test this and see how it works? But hopefully means that we can manually kick off the template sync GitHub action if ever we need to.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
