### PR TITLE
Added notice to top of docs markdown files to use the website.

### DIFF
--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/output.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/output.md
@@ -1,6 +1,6 @@
 # {{ cookiecutter.name }}: Output
 
-## :warning: Please read this documentation on the nf-core website: [https://nf-co.re/{{ cookiecutter.short_name }}](https://nf-co.re/{{ cookiecutter.short_name }})
+## :warning: Please read this documentation on the nf-core website: [https://nf-co.re/{{ cookiecutter.short_name }}/output](https://nf-co.re/{{ cookiecutter.short_name }}/output)
 
 > _Documentation of pipeline parameters is generated automatically from the pipeline schema and can no longer be found in markdown files._
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/output.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/output.md
@@ -1,5 +1,11 @@
 # {{ cookiecutter.name }}: Output
 
+## :warning: Please read this documentation on the nf-core website: [https://nf-co.re/{{ cookiecutter.short_name }}](https://nf-co.re/{{ cookiecutter.short_name }})
+
+> _Documentation of pipeline parameters is generated automatically from the pipeline schema and can no longer be found in markdown files._
+
+## Introduction
+
 This document describes the output produced by the pipeline. Most of the plots are taken from the MultiQC report, which summarises results at the end of the pipeline.
 
 The directories listed below will be created in the results directory after the pipeline has finished. All paths are relative to the top-level results directory.
@@ -40,7 +46,7 @@ For more information about how to use MultiQC reports, see [https://multiqc.info
 
 **Output files:**
 
-* `multiqc/`  
+* `multiqc/`
   * `multiqc_report.html`: a standalone HTML file that can be viewed in your web browser.
   * `multiqc_data/`: directory containing parsed statistics from the different tools used in the pipeline.
   * `multiqc_plots/`: directory containing static images from the report in various formats.

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
@@ -1,6 +1,6 @@
 # {{ cookiecutter.name }}: Usage
 
-## :warning: Please read this documentation on the nf-core website: [https://nf-co.re/{{ cookiecutter.short_name }}](https://nf-co.re/{{ cookiecutter.short_name }})
+## :warning: Please read this documentation on the nf-core website: [https://nf-co.re/{{ cookiecutter.short_name }}/usage](https://nf-co.re/{{ cookiecutter.short_name }}/usage)
 
 > _Documentation of pipeline parameters is generated automatically from the pipeline schema and can no longer be found in markdown files._
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
@@ -1,5 +1,9 @@
 # {{ cookiecutter.name }}: Usage
 
+## :warning: Please read this documentation on the nf-core website: [https://nf-co.re/{{ cookiecutter.short_name }}](https://nf-co.re/{{ cookiecutter.short_name }})
+
+> _Documentation of pipeline parameters is generated automatically from the pipeline schema and can no longer be found in markdown files._
+
 ## Introduction
 
 <!-- TODO nf-core: Add documentation about anything specific to running your pipeline. For general topics, please point to (and add to) the main nf-core website. -->


### PR DESCRIPTION
Notice added to the top of the markdown files that shows when viewing on GitHub but is not rendered on the nf-core website (as long as you have the `## Introduction` header below it).

Example: https://github.com/ewels/nf-core-methylseq/blob/usage-md-notice/docs/usage.md

![image](https://user-images.githubusercontent.com/465550/96932558-5ad2b700-14bf-11eb-9340-1cbc9a4860b2.png)

Fixes nf-core/tools#727

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
