### PR TITLE
Logging - force colours if certain env vars are set.

### DIFF
--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -28,13 +28,18 @@ import nf_core.utils
 # Submodules should all traverse back to this
 log = logging.getLogger()
 
+# Should we force coloured output from Rich?
+rich_force_colors = None
+if os.getenv("GITHUB_ACTIONS") or os.getenv("FORCE_COLOR") or os.getenv("PY_COLORS"):
+    rich_force_colors = True
+
 
 def run_nf_core():
     # Set up the rich traceback
     rich.traceback.install(width=200, word_wrap=True)
 
     # Print nf-core header to STDERR
-    stderr = rich.console.Console(file=sys.stderr)
+    stderr = rich.console.Console(file=sys.stderr, force_terminal=rich_force_colors)
     stderr.print("\n[green]{},--.[grey39]/[green],-.".format(" " * 42), highlight=False)
     stderr.print("[blue]          ___     __   __   __   ___     [green]/,-._.--~\\", highlight=False)
     stderr.print("[blue]    |\ | |__  __ /  ` /  \ |__) |__      [yellow]   }  {", highlight=False)
@@ -114,7 +119,7 @@ def nf_core_cli(verbose, log_file):
     log.addHandler(
         rich.logging.RichHandler(
             level=logging.DEBUG if verbose else logging.INFO,
-            console=rich.console.Console(file=sys.stderr),
+            console=rich.console.Console(file=sys.stderr, force_terminal=rich_force_colors),
             show_time=False,
             markup=True,
         )

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -28,18 +28,13 @@ import nf_core.utils
 # Submodules should all traverse back to this
 log = logging.getLogger()
 
-# Should we force coloured output from Rich?
-rich_force_colors = None
-if os.getenv("GITHUB_ACTIONS") or os.getenv("FORCE_COLOR") or os.getenv("PY_COLORS"):
-    rich_force_colors = True
-
 
 def run_nf_core():
     # Set up the rich traceback
     rich.traceback.install(width=200, word_wrap=True)
 
     # Print nf-core header to STDERR
-    stderr = rich.console.Console(file=sys.stderr, force_terminal=rich_force_colors)
+    stderr = rich.console.Console(file=sys.stderr, force_terminal=nf_core.utils.rich_force_colors())
     stderr.print("\n[green]{},--.[grey39]/[green],-.".format(" " * 42), highlight=False)
     stderr.print("[blue]          ___     __   __   __   ___     [green]/,-._.--~\\", highlight=False)
     stderr.print("[blue]    |\ | |__  __ /  ` /  \ |__) |__      [yellow]   }  {", highlight=False)
@@ -119,7 +114,7 @@ def nf_core_cli(verbose, log_file):
     log.addHandler(
         rich.logging.RichHandler(
             level=logging.DEBUG if verbose else logging.INFO,
-            console=rich.console.Console(file=sys.stderr, force_terminal=rich_force_colors),
+            console=rich.console.Console(file=sys.stderr, force_terminal=nf_core.utils.rich_force_colors()),
             show_time=False,
             markup=True,
         )

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -640,7 +640,7 @@ class Launch(object):
     def print_param_header(self, param_id, param_obj):
         if "description" not in param_obj and "help_text" not in param_obj:
             return
-        console = Console()
+        console = Console(nf_core.utils.rich_force_colors())
         console.print("\n")
         console.print(param_obj.get("title", param_id), style="bold")
         if "description" in param_obj:

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -1307,7 +1307,7 @@ class PipelineLint(object):
     def print_results(self, show_passed=False):
 
         log.debug("Printing final results")
-        console = Console()
+        console = Console(force_terminal=nf_core.utils.rich_force_colors())
 
         # Helper function to format test links nicely
         def format_result(test_results, table):

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -43,6 +43,15 @@ def check_if_outdated(current_version=None, remote_version=None, source_url="htt
     return (is_outdated, current_version, remote_version)
 
 
+def rich_force_colors():
+    """
+    Check if any environment variables are set to force Rich to use coloured output
+    """
+    if os.getenv("GITHUB_ACTIONS") or os.getenv("FORCE_COLOR") or os.getenv("PY_COLORS"):
+        return True
+    return None
+
+
 def fetch_wf_config(wf_path):
     """Uses Nextflow to retrieve the the configuration variables
     from a Nextflow workflow.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@
 
 import nf_core.utils
 
+import os
 import unittest
 
 
@@ -39,3 +40,15 @@ class TestUtils(unittest.TestCase):
         remote_version = "1.11"
         is_outdated, current, remote = nf_core.utils.check_if_outdated(current_version, remote_version)
         assert is_outdated
+
+    def test_rich_force_colours_false(self):
+        os.environ.pop("GITHUB_ACTIONS", None)
+        os.environ.pop("FORCE_COLOR", None)
+        os.environ.pop("PY_COLORS", None)
+        assert nf_core.utils.rich_force_colors() is None
+
+    def test_rich_force_colours_true(self):
+        os.environ["GITHUB_ACTIONS"] = True
+        os.environ.pop("FORCE_COLOR", None)
+        os.environ.pop("PY_COLORS", None)
+        assert nf_core.utils.rich_force_colors() is True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -48,7 +48,7 @@ class TestUtils(unittest.TestCase):
         assert nf_core.utils.rich_force_colors() is None
 
     def test_rich_force_colours_true(self):
-        os.environ["GITHUB_ACTIONS"] = True
+        os.environ["GITHUB_ACTIONS"] = "1"
         os.environ.pop("FORCE_COLOR", None)
         os.environ.pop("PY_COLORS", None)
         assert nf_core.utils.rich_force_colors() is True


### PR DESCRIPTION
Should hopefully make GitHub Actions logs show coloured output. Especially useful for `nf-core lint` results.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [x] Added new tests