### PR TITLE
Make some lint messages shorter

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,8 +478,8 @@ $ nf-core lint .
 │ [!] 3 Test Warnings                                                                                      │
 ├──────────────────────────────────────────────────────────────────────────────────────────────────────────┤
 │ https://nf-co.re/errors#5: GitHub Actions AWS full test should test full datasets: nf-core-testpipeline… │
-│ https://nf-co.re/errors#8: Conda package is not latest available: bioconda::fastqc=0.11.8, 0.11.9 avail… │
-│ https://nf-co.re/errors#8: Conda package is not latest available: bioconda::multiqc=1.7, 1.9 available   │
+│ https://nf-co.re/errors#8: Conda dep outdated: bioconda::fastqc=0.11.8, 0.11.9 available                 │
+│ https://nf-co.re/errors#8: Conda dep outdated: bioconda::multiqc=1.7, 1.9 available                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭───────────────────────╮
 │ LINT RESULTS SUMMARY  │

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -1015,9 +1015,9 @@ class PipelineLint(object):
                 try:
                     assert dep.count("=") in [1, 2]
                 except AssertionError:
-                    self.failed.append((8, "Conda dependency did not have pinned version number: `{}`".format(dep)))
+                    self.failed.append((8, "Conda dep did not have pinned version number: `{}`".format(dep)))
                 else:
-                    self.passed.append((8, "Conda dependency had pinned version number: `{}`".format(dep)))
+                    self.passed.append((8, "Conda dep had pinned version number: `{}`".format(dep)))
 
                     try:
                         depname, depver = dep.split("=")[:2]
@@ -1027,16 +1027,14 @@ class PipelineLint(object):
                     else:
                         # Check that required version is available at all
                         if depver not in self.conda_package_info[dep].get("versions"):
-                            self.failed.append((8, "Conda dependency had an unknown version: {}".format(dep)))
+                            self.failed.append((8, "Conda dep had unknown version: {}".format(dep)))
                             continue  # No need to test for latest version, continue linting
                         # Check version is latest available
                         last_ver = self.conda_package_info[dep].get("latest_version")
                         if last_ver is not None and last_ver != depver:
-                            self.warned.append(
-                                (8, "Conda package is not latest available: `{}`, `{}` available".format(dep, last_ver))
-                            )
+                            self.warned.append((8, "Conda dep outdated: `{}`, `{}` available".format(dep, last_ver)))
                         else:
-                            self.passed.append((8, "Conda package is latest available: `{}`".format(dep)))
+                            self.passed.append((8, "Conda package is the latest available: `{}`".format(dep)))
 
             elif isinstance(dep, dict):
                 for pip_dep in dep.get("pip", []):
@@ -1203,7 +1201,7 @@ class PipelineLint(object):
                                 .replace("TODO nf-core: ", "")
                                 .strip()
                             )
-                            self.warned.append((10, "TODO string found in `{}`: _{}_".format(fname, l)))
+                            self.warned.append((10, "TODO string in `{}`: _{}_".format(fname, l)))
 
     def check_pipeline_name(self):
         """Check whether pipeline name adheres to lower case/no hyphen naming convention"""


### PR DESCRIPTION
The GitHub Actions "terminal" window is pretty narrow. At least the Rich output for it is. This PR just makes a couple of common lint messages shorter so that they can be read without being truncated.

Currently I get a lot of this, which is not super helpful:

```
│ https://nf-co.re/errors#8: Conda package is not latest available: conda-for… │
│ https://nf-co.re/errors#8: Conda package is not latest available: conda-for… │
│ https://nf-co.re/errors#8: Conda package is not latest available: conda-for… │
│ https://nf-co.re/errors#8: Conda package is not latest available: bioconda:… │
```

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Documentation in `docs` is updated
