### PR TITLE
Don't lint for dockerfile base image if running nf-core/tools dev version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Linting
 
 * Updated code to display colours in GitHub Actions log output
+* Allow tests to pass with dev version of nf-core/tools (previous failure due to base image version)
 
 ### Other
 

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -1165,12 +1165,14 @@ class PipelineLint(object):
             return
 
         expected_strings = [
-            "FROM nfcore/base:{}".format("dev" if "dev" in self.version else self.version),
             "COPY environment.yml /",
             "RUN conda env create --quiet -f /environment.yml && conda clean -a",
             "RUN conda env export --name {} > {}.yml".format(self.conda_config["name"], self.conda_config["name"]),
             "ENV PATH /opt/conda/envs/{}/bin:$PATH".format(self.conda_config["name"]),
         ]
+
+        if "dev" not in self.version:
+            expected_strings.append("FROM nfcore/base:{}".format(self.version))
 
         difference = set(expected_strings) - set(self.dockerfile)
         if not difference:


### PR DESCRIPTION
Currently, linting _always_ fails if you are using the development version of nf-core/tools, as it wants every pipeline to have the Dockerfile start with `FROM nfcore/base:dev`. In practice, what we actually want is the latest stable version.

This PR only checks for that string if we're running a stable version. That way, tests still pass locally with the dev version of tools but will fail when running on CI with a stable version.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
