### PR TITLE
Fix new Branch CI GitHub Actions

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check PRs
         if: github.repository == 'nf-core/tools'
         run: |
-          { [[ ${{github.event.pull_request_target.head.repo.full_name}} == nf-core/tools ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
+          { [[ ${{github.event.pull_request.head.repo.full_name}} == nf-core/tools ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
 
       # If the above check failed, post a comment on the PR explaining the failure
       - name: Post PR comment
@@ -21,9 +21,9 @@ jobs:
         uses: mshick/add-pr-comment@v1
         with:
           message: |
-            Hi @${{ github.event.pull_request_target.user.login }},
+            Hi @${{ github.event.pull_request.user.login }},
 
-            It looks like this pull-request has been made against the ${{github.event.pull_request_target.head.repo.full_name}} `master` branch. The `master` branch on nf-core repositories should always contain code from the latest release. Because of this, PRs to `master` are only allowed if they come from the ${{github.event.pull_request_target.head.repo.full_name}} `dev` branch.
+            It looks like this pull-request has been made against the ${{github.event.pull_request.head.repo.full_name}} `master` branch. The `master` branch on nf-core repositories should always contain code from the latest release. Because of this, PRs to `master` are only allowed if they come from the ${{github.event.pull_request.head.repo.full_name}} `dev` branch.
 
             You do not need to close this PR, you can change the target branch to `dev` by clicking the _"Edit"_ button at the top of this page.
 

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -665,7 +665,7 @@ class PipelineLint(object):
                 # Don't use .format() as the squiggly brackets get ridiculous
                 has_run = step.get(
                     "run", ""
-                ).strip() == '{ [[ ${{github.event.pull_request_target.head.repo.full_name}} == nf-core/PIPELINENAME ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]'.replace(
+                ).strip() == '{ [[ ${{github.event.pull_request.head.repo.full_name}} == nf-core/PIPELINENAME ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]'.replace(
                     "PIPELINENAME", self.pipeline_name.lower()
                 )
                 if has_name and has_if and has_run:

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/branch.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/branch.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check PRs
         if: github.repository == '{{cookiecutter.name}}'
         run: |
-          { [[ {% raw %}${{github.event.pull_request_target.head.repo.full_name}}{% endraw %} == {{cookiecutter.name}} ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
+          { [[ {% raw %}${{github.event.pull_request.head.repo.full_name}}{% endraw %} == {{cookiecutter.name}} ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
 
 {% raw %}
       # If the above check failed, post a comment on the PR explaining the failure
@@ -23,11 +23,11 @@ jobs:
         uses: mshick/add-pr-comment@v1
         with:
           message: |
-            Hi @${{ github.event.pull_request_target.user.login }},
+            Hi @${{ github.event.pull_request.user.login }},
 
-            It looks like this pull-request is has been made against the ${{github.event.pull_request_target.head.repo.full_name}} `master` branch.
+            It looks like this pull-request is has been made against the ${{github.event.pull_request.head.repo.full_name}} `master` branch.
             The `master` branch on nf-core repositories should always contain code from the latest release.
-            Because of this, PRs to `master` are only allowed if they come from the ${{github.event.pull_request_target.head.repo.full_name}} `dev` branch.
+            Because of this, PRs to `master` are only allowed if they come from the ${{github.event.pull_request.head.repo.full_name}} `dev` branch.
 
             You do not need to close this PR, you can change the target branch to `dev` by clicking the _"Edit"_ button at the top of this page.
 

--- a/tests/lint_examples/minimalworkingexample/.github/workflows/branch.yml
+++ b/tests/lint_examples/minimalworkingexample/.github/workflows/branch.yml
@@ -13,4 +13,4 @@ jobs:
       - name: Check PRs
         if: github.repository == 'nf-core/tools'
         run: |
-          { [[ ${{github.event.pull_request_target.head.repo.full_name}} == nf-core/tools ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
+          { [[ ${{github.event.pull_request.head.repo.full_name}} == nf-core/tools ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]


### PR DESCRIPTION
In https://github.com/nf-core/tools/pull/766 we started using the `pull_request_target` workflow event, which is awesome. It allows us to have automated comments on PRs even when coming from forked repos.

After testing on the new nf-core/testpipeline we found that (a) it works well but (b) the actions _payload_ name is unchanged. So to get the variables in the comment we need to revert `github.event.pull_request_target` back to `github.event.pull_request`

Tested and working on `master` in https://github.com/nf-core/testpipeline/pull/6#issuecomment-724876835

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
