### PR TITLE
New GitHub Actions workflow to add lint results to a PR as a comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@
 
 ### Template
 
-* Make branch-protection CI comments work with PRs from forks [[#765](https://github.com/nf-core/tools/issues/765)]
+* Make CI comments work with PRs from forks [[#765](https://github.com/nf-core/tools/issues/765)]
+  * Branch protection and linting results should now show on all PRs
 * Updated GitHub issue templates, which had stopped working
 
 ### Linting
 
 * Updated code to display colours in GitHub Actions log output
 * Allow tests to pass with dev version of nf-core/tools (previous failure due to base image version)
+* Lint code no longer tries to post GitHub PR comments. This is now done in a GitHub Action only.
 
 ### Other
 

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -78,9 +78,6 @@ def run_linting(pipeline_dir, release_mode=False, show_passed=False, md_fn=None,
     if json_fn is not None:
         lint_obj.save_json_results(json_fn)
 
-    # Try to post comment to a GitHub PR
-    lint_obj.github_comment()
-
     # Exit code
     if len(lint_obj.failed) > 0:
         if release_mode:
@@ -1469,60 +1466,6 @@ class PipelineLint(object):
         }
         with open(json_fn, "w") as fh:
             json.dump(results, fh, indent=4)
-
-    def github_comment(self):
-        """
-        If we are running in a GitHub PR, try to post results as a comment
-        """
-        if os.environ.get("GITHUB_TOKEN", "") == "":
-            log.debug("Environment variable GITHUB_TOKEN not found")
-            return
-        if os.environ.get("GITHUB_COMMENTS_URL", "") == "":
-            log.debug("Environment variable GITHUB_COMMENTS_URL not found")
-            return
-        try:
-            headers = {"Authorization": "token {}".format(os.environ["GITHUB_TOKEN"])}
-            # Get existing comments - GET
-            get_r = requests.get(url=os.environ["GITHUB_COMMENTS_URL"], headers=headers)
-            if get_r.status_code == 200:
-
-                # Look for an existing comment to update
-                update_url = False
-                for comment in get_r.json():
-                    if comment["user"]["login"] == "github-actions[bot]" and comment["body"].startswith(
-                        "\n#### `nf-core lint` overall result"
-                    ):
-                        # Update existing comment - PATCH
-                        log.info("Updating GitHub comment")
-                        update_r = requests.patch(
-                            url=comment["url"],
-                            data=json.dumps({"body": self.get_results_md().replace("Posted", "**Updated**")}),
-                            headers=headers,
-                        )
-                        return
-
-                # Create new comment - POST
-                if len(self.warned) > 0 or len(self.failed) > 0:
-                    r = requests.post(
-                        url=os.environ["GITHUB_COMMENTS_URL"],
-                        data=json.dumps({"body": self.get_results_md()}),
-                        headers=headers,
-                    )
-                    try:
-                        r_json = json.loads(r.content)
-                        response_pp = json.dumps(r_json, indent=4)
-                    except:
-                        r_json = r.content
-                        response_pp = r.content
-
-                    if r.status_code == 201:
-                        log.info("Posted GitHub comment: {}".format(r_json["html_url"]))
-                        log.debug(response_pp)
-                    else:
-                        log.warning("Could not post GitHub comment: '{}'\n{}".format(r.status_code, response_pp))
-
-        except Exception as e:
-            log.warning("Could not post GitHub comment: {}\n{}".format(os.environ["GITHUB_COMMENTS_URL"], e))
 
     def _wrap_quotes(self, files):
         if not isinstance(files, list):

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -1372,8 +1372,10 @@ class PipelineLint(object):
             overall_result = "Failed :x:"
 
         # List of tests for details
+        test_failure_count = ""
         test_failures = ""
         if len(self.failed) > 0:
+            test_failure_count = "\n-| ❌ {:3d} tests failed       |-".format(len(self.failed))
             test_failures = "### :x: Test failures:\n\n{}\n\n".format(
                 "\n".join(
                     [
@@ -1383,8 +1385,10 @@ class PipelineLint(object):
                 )
             )
 
+        test_warning_count = ""
         test_warnings = ""
         if len(self.warned) > 0:
+            test_warning_count = "\n!| ❗ {:3d} tests had warnings |!".format(len(self.warned))
             test_warnings = "### :heavy_exclamation_mark: Test warnings:\n\n{}\n\n".format(
                 "\n".join(
                     [
@@ -1394,8 +1398,10 @@ class PipelineLint(object):
                 )
             )
 
+        test_passe_count = ""
         test_passes = ""
         if len(self.passed) > 0:
+            test_passed_count = "\n+| ✅ {:3d} tests passed       |+".format(len(self.passed))
             test_passes = "### :white_check_mark: Tests passed:\n\n{}\n\n".format(
                 "\n".join(
                     [
@@ -1413,10 +1419,7 @@ class PipelineLint(object):
 
         {}
 
-        ```diff
-        +| ✅ {:2d} tests passed       |+
-        !| ❗ {:2d} tests had warnings |!
-        -| ❌ {:2d} tests failed       |-
+        ```diff{}{}{}
         ```
 
         <details>
@@ -1431,9 +1434,9 @@ class PipelineLint(object):
         ).format(
             overall_result,
             "Posted for pipeline commit {}".format(self.git_sha[:7]) if self.git_sha is not None else "",
-            len(self.passed),
-            len(self.warned),
-            len(self.failed),
+            test_passed_count,
+            test_warning_count,
+            test_failure_count,
             test_failures,
             test_warnings,
             test_passes,

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/linting.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/linting.yml
@@ -57,12 +57,19 @@ jobs:
           GITHUB_COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_COMMIT: ${{ github.event.pull_request.head.sha }}
-        run: nf-core -l lint_log.txt lint ${GITHUB_WORKSPACE}
+        run: nf-core -l lint_log.txt lint ${GITHUB_WORKSPACE} --markdown lint_results.md
+
+      - name: Save PR number
+        if: ${{ always() }}
+        run: echo ${{ github.event.pull_request.number }} > PR_number.txt
 
       - name: Upload linting log file artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
           name: linting-log-file
-          path: lint_log.txt
+          path: |
+            lint_log.txt
+            lint_results.md
+            PR_number.txt
 {% endraw %}

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/linting_comment.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/linting_comment.yml
@@ -1,0 +1,27 @@
+name: nf-core linting comment
+# This workflow is triggered after the linting action is complete
+# It posts an automated comment to the PR, even if the PR is coming from a fork
+
+on:
+  workflow_run:
+    workflows: ["nf-core linting"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download lint results
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: linting.yml
+
+      - name: Get PR number
+        id: pr_number
+        run: echo "::set-output name=pr_number::$(cat linting-logs/PR_number.txt)"
+
+      - name: Post PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ steps.pr_number.outputs.pr_number }}
+          path: linting-logs/lint_results.md

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/linting_comment.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/linting_comment.yml
@@ -1,3 +1,4 @@
+{% raw %}
 name: nf-core linting comment
 # This workflow is triggered after the linting action is complete
 # It posts an automated comment to the PR, even if the PR is coming from a fork
@@ -25,3 +26,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ steps.pr_number.outputs.pr_number }}
           path: linting-logs/lint_results.md
+{% endraw %}

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -587,34 +587,3 @@ class TestLint(unittest.TestCase):
                     return []
 
         return MockResponse(kwargs["url"])
-
-    @mock.patch("requests.get", side_effect=mock_gh_get_comments)
-    @mock.patch("requests.post")
-    def test_gh_comment_post(self, mock_get, mock_post):
-        """
-        Test updating a Github comment with the lint results
-        """
-        os.environ["GITHUB_COMMENTS_URL"] = "https://github.com"
-        os.environ["GITHUB_TOKEN"] = "testing"
-        os.environ["GITHUB_PR_COMMIT"] = "abcdefg"
-        # Don't run testing, just fake some testing results
-        lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
-        lint_obj.failed.append((1, "This test failed"))
-        lint_obj.passed.append((2, "This test also passed"))
-        lint_obj.warned.append((2, "This test gave a warning"))
-        lint_obj.github_comment()
-
-    @mock.patch("requests.get", side_effect=mock_gh_get_comments)
-    @mock.patch("requests.post")
-    def test_gh_comment_update(self, mock_get, mock_post):
-        """
-        Test updating a Github comment with the lint results
-        """
-        os.environ["GITHUB_COMMENTS_URL"] = "existing_comment"
-        os.environ["GITHUB_TOKEN"] = "testing"
-        # Don't run testing, just fake some testing results
-        lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
-        lint_obj.failed.append((1, "This test failed"))
-        lint_obj.passed.append((2, "This test also passed"))
-        lint_obj.warned.append((2, "This test gave a warning"))
-        lint_obj.github_comment()


### PR DESCRIPTION
Post comment about linting results to a PR, even when that PR comes from a fork. See https://github.com/nf-core/tools/issues/765

This is complex, as the GitHub Actions event that posts the comment cannot come from the PR base - the forked repo. So here we introduce a new workflow specifically for the comment that is triggered when the lint action is complete.

Tested here: https://github.com/ewels/nf-core-testpipeline/pull/2

## To do

- [x] Write new GitHub Actions workflow to post comment
- [x] Do tonnes of trial and error to get the action to fire properly
- [x] Check that this works properly on PRs that are not against `master`
- [x] Make sure that it only fires on the correct events (PR, not push etc)
- [x] Refactor linting code to delete code that tries to post comments
- [x] _(Bonus)_ Update comment to only show summary counts > 0

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
