### PR TITLE
Split docker push GHA workflows, update trigger for AWS full test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Make CI comments work with PRs from forks [[#765](https://github.com/nf-core/tools/issues/765)]
   * Branch protection and linting results should now show on all PRs
 * Updated GitHub issue templates, which had stopped working
+* Refactored GitHub Actions so that the AWS full-scale tests are triggered after docker build is finished
 
 ### Linting
 

--- a/docs/lint_errors.md
+++ b/docs/lint_errors.md
@@ -238,13 +238,14 @@ You can trigger the tests by going to the `Actions` tab on the pipeline GitHub r
 Additionally, we provide the possibility of testing the pipeline on full size datasets on AWS.
 This should ensure that the pipeline runs as expected on AWS and provide a resource estimation.
 The GitHub Actions workflow is `awsfulltest.yml`, and it can be found in the `.github/workflows/` directory.
-This workflow incurrs higher AWS costs, therefore it should only be triggered on `release` and `workflow_dispatch`.
+This workflow incurrs higher AWS costs, therefore it should only be triggered for releases (`workflow_run` - after the docker hub release workflow) and `workflow_dispatch`.
 You can trigger the tests by going to the `Actions` tab on the pipeline GitHub repository and selecting the `nf-core AWS full size tests` workflow on the left.
 For tests on full data prior to release, [Nextflow Tower](https://tower.nf) launch feature can be employed.
 
 `awsfulltest.yml`: Triggers full sized tests run on AWS batch after releasing.
 
-* Must be only turned on for `release` and `workflow_dispatch`.
+* Must be turned on `workflow_dispatch`.
+* Must be turned on for `workflow_run` with `workflows: ["nf-core Docker push (release)"]` and `types: [completed]`
 * Should run the profile `test_full` that should be edited to provide the links to full-size datasets. If it runs the profile `test` a warning is given.
 
 ## Error #6 - Repository `README.md` tests ## {#6}

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -843,11 +843,10 @@ class PipelineLint(object):
 
             # Check that the action is only turned on for published releases
             try:
-                assert "release" in wf[True]
-                assert "published" in wf[True]["release"]["types"]
+                assert "workflow_run" in wf[True]
+                assert wf[True]["workflow_run"]["workflows"] == ["nf-core Docker push (release)"]
+                assert wf[True]["workflow_run"]["types"] == ["completed"]
                 assert "workflow_dispatch" in wf[True]
-                assert "push" not in wf[True]
-                assert "pull_request" not in wf[True]
             except (AssertionError, KeyError, TypeError):
                 self.failed.append(
                     (

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/awsfulltest.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/awsfulltest.yml
@@ -4,8 +4,9 @@ name: nf-core AWS full size tests
 # It runs the -profile 'test_full' on AWS batch
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["nf-core Docker push (release)"]
+    types: [completed]
   workflow_dispatch:
 
 jobs:

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/push_dockerhub_dev.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/push_dockerhub_dev.yml
@@ -1,0 +1,28 @@
+name: nf-core Docker push (dev)
+# This builds the docker image and pushes it to DockerHub
+# Runs on nf-core repo releases and push event to 'dev' branch (PR merges)
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  push_dockerhub:
+    name: Push new Docker image to Docker Hub (dev)
+    runs-on: ubuntu-latest
+    # Only run for the nf-core repo, for releases and merged PRs
+    if: {% raw %}${{{% endraw %} github.repository == '{{ cookiecutter.name }}' {% raw %}}}{% endraw %}
+    env:
+      DOCKERHUB_USERNAME: {% raw %}${{ secrets.DOCKERHUB_USERNAME }}{% endraw %}
+      DOCKERHUB_PASS: {% raw %}${{ secrets.DOCKERHUB_PASS }}{% endraw %}
+    steps:
+      - name: Check out pipeline code
+        uses: actions/checkout@v2
+
+      - name: Build new docker image
+        run: docker build --no-cache . -t {{ cookiecutter.name_docker }}:dev
+
+      - name: Push Docker image to DockerHub (dev)
+        run: |
+          echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+          docker push {{ cookiecutter.name_docker }}:dev

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/push_dockerhub_release.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/push_dockerhub_release.yml
@@ -1,16 +1,13 @@
-name: nf-core Docker push
+name: nf-core Docker push (release)
 # This builds the docker image and pushes it to DockerHub
 # Runs on nf-core repo releases and push event to 'dev' branch (PR merges)
 on:
-  push:
-    branches:
-      - dev
   release:
     types: [published]
 
 jobs:
   push_dockerhub:
-    name: Push new Docker image to Docker Hub
+    name: Push new Docker image to Docker Hub (release)
     runs-on: ubuntu-latest
     # Only run for the nf-core repo, for releases and merged PRs
     if: {% raw %}${{{% endraw %} github.repository == '{{ cookiecutter.name }}' {% raw %}}}{% endraw %}
@@ -24,15 +21,7 @@ jobs:
       - name: Build new docker image
         run: docker build --no-cache . -t {{ cookiecutter.name_docker }}:latest
 
-      - name: Push Docker image to DockerHub (dev)
-        if: {% raw %}${{ github.event_name == 'push' }}{% endraw %}
-        run: |
-          echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-          docker tag {{ cookiecutter.name_docker }}:latest {{ cookiecutter.name_docker }}:dev
-          docker push {{ cookiecutter.name_docker }}:dev
-
       - name: Push Docker image to DockerHub (release)
-        if: {% raw %}${{ github.event_name == 'release' }}{% endraw %}
         run: |
           echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
           docker push {{ cookiecutter.name_docker }}:latest

--- a/tests/lint_examples/minimalworkingexample/.github/workflows/awsfulltest.yml
+++ b/tests/lint_examples/minimalworkingexample/.github/workflows/awsfulltest.yml
@@ -3,8 +3,9 @@ name: nf-core AWS full size tests
 # It runs the -profile 'test_full' on AWS batch
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["nf-core Docker push (release)"]
+    types: [completed]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Trying to fix the GitHub Actions full-scale AWS tests. Problem was that the trigger went immediately after release, before the Docker Hub images were ready.

This PR splits the docker hub builds into two (one for `dev`, one for releases). The AWS full test workflow is then triggered by the release workflow.

The key point is that I removed the branch filtering from the workflow trigger on the full tests. I think that the release event does not have branch information.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
