### PR TITLE
Lint fail push_dockerhub.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   * Branch protection and linting results should now show on all PRs
 * Updated GitHub issue templates, which had stopped working
 * Refactored GitHub Actions so that the AWS full-scale tests are triggered after docker build is finished
+  * DockerHub push workflow split into two - one for dev, one for releases
 
 ### Linting
 

--- a/docs/lint_errors.md
+++ b/docs/lint_errors.md
@@ -47,6 +47,8 @@ The following files will cause a failure if the _are_ present (to fix, delete th
     deleted and new `nextflow_schema.json` files created instead.
 * `bin/markdown_to_html.r`
   * The old markdown to HTML conversion script, now replaced by `markdown_to_html.py`
+* `.github/workflows/push_dockerhub.yml`
+  * The old dockerhub build script, now split into `.github/workflows/push_dockerhub_dev.yml` and `.github/workflows/push_dockerhub_release.yml`
 
 ## Error #2 - Docker file check failed ## {#2}
 

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -274,7 +274,7 @@ class PipelineLint(object):
 
             'Singularity',
             'parameters.settings.json',
-            'bin/markdown_to_html.r'.
+            'bin/markdown_to_html.r',
             '.github/workflows/push_dockerhub.yml'
 
         Files that *should not* be present::

--- a/nf_core/lint.py
+++ b/nf_core/lint.py
@@ -274,7 +274,8 @@ class PipelineLint(object):
 
             'Singularity',
             'parameters.settings.json',
-            'bin/markdown_to_html.r'
+            'bin/markdown_to_html.r'.
+            '.github/workflows/push_dockerhub.yml'
 
         Files that *should not* be present::
 
@@ -309,7 +310,12 @@ class PipelineLint(object):
         ]
 
         # List of strings. Dails / warns if any of the strings exist.
-        files_fail_ifexists = ["Singularity", "parameters.settings.json", os.path.join("bin", "markdown_to_html.r")]
+        files_fail_ifexists = [
+            "Singularity",
+            "parameters.settings.json",
+            os.path.join("bin", "markdown_to_html.r"),
+            os.path.join(".github", "workflows", "push_dockerhub.yml"),
+        ]
         files_warn_ifexists = [".travis.yml"]
 
         def pf(file_path):

--- a/tests/lint_examples/minimalworkingexample/.github/workflows/ci.yml
+++ b/tests/lint_examples/minimalworkingexample/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
-        nxf_ver: ['19.10.0', '']
+        nxf_ver: ['20.04.0', '']
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2

--- a/tests/lint_examples/minimalworkingexample/README.md
+++ b/tests/lint_examples/minimalworkingexample/README.md
@@ -1,5 +1,5 @@
 # The pipeline readme file
 
-[![Nextflow](https://img.shields.io/badge/nextflow-%E2%89%A519.10.0-brightgreen.svg)](https://www.nextflow.io/)
+[![Nextflow](https://img.shields.io/badge/nextflow-%E2%89%A520.04.0-brightgreen.svg)](https://www.nextflow.io/)
 
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](https://bioconda.github.io/)

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -57,7 +57,7 @@ def test_multiple_patterns_found(datafiles):
 def test_successfull_nextflow_version_bump(datafiles):
     lint_obj = nf_core.lint.PipelineLint(str(datafiles))
     lint_obj.pipeline_name = "tools"
-    lint_obj.config["manifest.nextflowVersion"] = "19.10.0"
+    lint_obj.config["manifest.nextflowVersion"] = "20.04.0"
     nf_core.bump_version.bump_nextflow_version(lint_obj, "0.40")
     lint_obj_new = nf_core.lint.PipelineLint(str(datafiles))
     lint_obj_new.check_nextflow_config()

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -45,7 +45,7 @@ PATHS_WRONG_LICENSE_EXAMPLE = [
 ]
 
 # The maximum sum of passed tests currently possible
-MAX_PASS_CHECKS = 84
+MAX_PASS_CHECKS = 85
 # The additional tests passed for releases
 ADD_PASS_RELEASE = 1
 
@@ -114,7 +114,7 @@ class TestLint(unittest.TestCase):
         """Tests for missing files like Dockerfile or LICENSE"""
         lint_obj = nf_core.lint.PipelineLint(PATH_FAILING_EXAMPLE)
         lint_obj.check_files_exist()
-        expectations = {"failed": 6, "warned": 2, "passed": 13}
+        expectations = {"failed": 6, "warned": 2, "passed": 14}
         self.assess_lint_status(lint_obj, **expectations)
 
     def test_mit_licence_example_pass(self):

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -170,7 +170,7 @@ class TestLint(unittest.TestCase):
     def test_actions_wf_ci_pass(self):
         """Tests that linting for GitHub Actions CI workflow works for a good example"""
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
-        lint_obj.minNextflowVersion = "19.10.0"
+        lint_obj.minNextflowVersion = "20.04.0"
         lint_obj.pipeline_name = "tools"
         lint_obj.config["process.container"] = "'nfcore/tools:0.4'"
         lint_obj.check_actions_ci()
@@ -180,7 +180,7 @@ class TestLint(unittest.TestCase):
     def test_actions_wf_ci_fail(self):
         """Tests that linting for GitHub Actions CI workflow fails for a bad example"""
         lint_obj = nf_core.lint.PipelineLint(PATH_FAILING_EXAMPLE)
-        lint_obj.minNextflowVersion = "19.10.0"
+        lint_obj.minNextflowVersion = "20.04.0"
         lint_obj.pipeline_name = "tools"
         lint_obj.config["process.container"] = "'nfcore/tools:0.4'"
         lint_obj.check_actions_ci()
@@ -257,7 +257,7 @@ class TestLint(unittest.TestCase):
     def test_readme_pass(self):
         """Tests that the pipeline README file checks work with a good example"""
         lint_obj = nf_core.lint.PipelineLint(PATH_WORKING_EXAMPLE)
-        lint_obj.minNextflowVersion = "19.10.0"
+        lint_obj.minNextflowVersion = "20.04.0"
         lint_obj.files = ["environment.yml"]
         lint_obj.check_readme()
         expectations = {"failed": 0, "warned": 0, "passed": 2}


### PR DESCRIPTION
Add in lint test for old `push_dockerhub.yml` file to make sure that it is removed after the pipeline sync.

See https://github.com/nf-core/tools/pull/770 for refactoring.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Documentation in `docs` is updated
