### PR TITLE
Updated github actions

### DIFF
--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/awsfulltest.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/awsfulltest.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Miniconda
-        uses: goanpeca/setup-miniconda@v1.0.2
+        uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           python-version: 3.7

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/awstest.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/awstest.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Miniconda
-        uses: goanpeca/setup-miniconda@v1.0.2
+        uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           python-version: 3.7

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/ci.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check if Dockerfile or Conda environment changed
-        uses: technote-space/get-diff-action@v1
+        uses: technote-space/get-diff-action@v4
         with:
-          PREFIX_FILTER: |
+          FILES: |
             Dockerfile
             environment.yml
 


### PR DESCRIPTION


PR to fix #739 

Changed the actions in awstest.yml and awsmegatest.yml to
`conda-incubator/setup-miniconda@v2`

and switched version of `get-diff-action@v1` to `get-diff-action@v4` in ci.yml.
Also changed the PREFIX_FILTER to FILES command in ci.yml, because the former is deprecated.

These changes fix the problems of deprecated `set-env` commands in GitHub actions.

## PR checklist

 - [x ] This comment contains a description of changes (with reason)
 