### PR TITLE
Use v4 of the GH get-diff-action due to deprecated env usage

### DIFF
--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/ci.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check if Dockerfile or Conda environment changed
-        uses: technote-space/get-diff-action@v1
+        uses: technote-space/get-diff-action@v4
         with:
           PREFIX_FILTER: |
             Dockerfile


### PR DESCRIPTION
Otherwise you get `Unable to process command '::set-env name=GIT_DIFF::' successfully.`

Since GH now fully deprecated their set-env commands.

## PR checklist

 - [X] This comment contains a description of changes (with reason)
