### PR TITLE
CI Docker diffs - use env.MATCHED_FILES

### DIFF
--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/ci.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/ci.yml
@@ -33,11 +33,11 @@ jobs:
             environment.yml
 
       - name: Build new docker image
-        if: env.GIT_DIFF
+        if: env.MATCHED_FILES
         run: docker build --no-cache . -t {{ cookiecutter.name_docker }}:dev
 
       - name: Pull docker image
-        if: {% raw %}${{ !env.GIT_DIFF }}{% endraw %}
+        if: {% raw %}${{ !env.MATCHED_FILES }}{% endraw %}
         run: |
           docker pull {{ cookiecutter.name_docker }}:dev
           docker tag {{ cookiecutter.name_docker }}:dev {{ cookiecutter.name_docker }}:dev


### PR DESCRIPTION
In https://github.com/nf-core/tools/pull/774 @KevinMenden updated the `technote-space/get-diff-action` so that GitHub Actions runs with the new security settings rolled out by GitHub.

This fixed the GitHub Actions and got things running again. However, I noticed in https://github.com/nf-core/methylseq/pull/177 that when I copied over the changes, the Docker image was building even though I hadn't touched any of the listed files.

I had a look over the [docs for the action](https://github.com/marketplace/actions/get-diff-action#examples-of-env) and I think that we need to switch `env.GIT_DIFF` to `env.MATCHED_FILES`. This then returns true if any of the files listed under `FILES` have been changed. `env.GIT_DIFF` now basically always returns true, so currently the Docker image always builds.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
