### PR TITLE
Quietly install Nextflow in CI

### DIFF
--- a/.github/workflows/create-lint-wf.yml
+++ b/.github/workflows/create-lint-wf.yml
@@ -19,6 +19,8 @@ jobs:
           pip install .
 
       - name: Install Nextflow
+        env:
+          CAPSULE_LOG: none
         run: |
           mkdir /tmp/nextflow
           cd /tmp/nextflow

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,6 +32,8 @@ jobs:
         pip install -e .
 
     - name: Install Nextflow
+      env:
+          CAPSULE_LOG: none
       run: |
         mkdir /tmp/nextflow
         cd /tmp/nextflow

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -45,6 +45,8 @@ jobs:
           pip install .
 
       - name: Install Nextflow
+        env:
+          CAPSULE_LOG: none
         run: |
           mkdir /tmp/nextflow
           cd /tmp/nextflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Added config import for `test_full` in `nextflow.config`
 * Switched depreciated `$baseDir` to `$projectDir`
 * Updated minimum Nextflow version to `20.04.10`
+* Make Nextflow installation less verbose in GitHub Actions [[#780](https://github.com/nf-core/tools/pull/780)]
 
 ### Linting
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/ci.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
           docker tag {{ cookiecutter.name_docker }}:dev {{ cookiecutter.name_docker }}:dev
 
       - name: Install Nextflow
+        env:
+          CAPSULE_LOG: none
         run: |
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/linting.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/linting.yml
@@ -38,6 +38,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Nextflow
+        env:
+          CAPSULE_LOG: none
         run: |
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/

--- a/tests/lint_examples/minimalworkingexample/.github/workflows/ci.yml
+++ b/tests/lint_examples/minimalworkingexample/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
           docker tag nfcore/tools:dev nfcore/tools:0.4
 
       - name: Install Nextflow
+        env:
+          CAPSULE_LOG: none
         run: |
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/

--- a/tests/lint_examples/minimalworkingexample/.github/workflows/linting.yml
+++ b/tests/lint_examples/minimalworkingexample/.github/workflows/linting.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install Nextflow
+        env:
+          CAPSULE_LOG: none
         run: |
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/


### PR DESCRIPTION
Reduce the GitHub Actions CI logs for the Nextflow installation from 5,186 lines to 10.

See https://github.com/nextflow-io/nextflow/issues/1800

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
