### PR TITLE
Use NXF_HOME env var for nextflow home directory, if set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Tools helper code
 
+* Respect `$NXF_HOME` when looking for pipelines with `nf-core list` [[#798](https://github.com/nf-core/tools/issues/798)]
+
 ### Template
 
 ### Linting

--- a/nf_core/list.py
+++ b/nf_core/list.py
@@ -128,7 +128,7 @@ class Workflows(object):
         # Try to guess the local cache directory (much faster than calling nextflow)
         if len(os.environ.get("NXF_ASSETS", "")) > 0:
             nextflow_wfdir = os.environ.get("NXF_ASSETS")
-        else if len(os.environ.get("NXF_HOME", "")) > 0:
+        elif len(os.environ.get("NXF_HOME", "")) > 0:
             nextflow_wfdir = os.path.join(os.environ.get("NXF_HOME"), "assets")
         else:
             nextflow_wfdir = os.path.join(os.getenv("HOME"), ".nextflow", "assets")
@@ -350,7 +350,7 @@ class LocalWorkflow(object):
             # Try to guess the local cache directory
             if len(os.environ.get("NXF_ASSETS", "")) > 0:
                 nf_wfdir = os.path.join(os.environ.get("NXF_ASSETS"), self.full_name)
-            else if len(os.environ.get("NXF_HOME", "")) > 0:
+            elif len(os.environ.get("NXF_HOME", "")) > 0:
                 nf_wfdir = os.path.join(os.environ.get("NXF_HOME"), "assets")
             else:
                 nf_wfdir = os.path.join(os.getenv("HOME"), ".nextflow", "assets", self.full_name)

--- a/nf_core/list.py
+++ b/nf_core/list.py
@@ -128,6 +128,8 @@ class Workflows(object):
         # Try to guess the local cache directory (much faster than calling nextflow)
         if len(os.environ.get("NXF_ASSETS", "")) > 0:
             nextflow_wfdir = os.environ.get("NXF_ASSETS")
+        else if len(os.environ.get("NXF_HOME", "")) > 0:
+            nextflow_wfdir = os.path.join(os.environ.get("NXF_HOME"), "assets")
         else:
             nextflow_wfdir = os.path.join(os.getenv("HOME"), ".nextflow", "assets")
         if os.path.isdir(nextflow_wfdir):
@@ -348,6 +350,8 @@ class LocalWorkflow(object):
             # Try to guess the local cache directory
             if len(os.environ.get("NXF_ASSETS", "")) > 0:
                 nf_wfdir = os.path.join(os.environ.get("NXF_ASSETS"), self.full_name)
+            else if len(os.environ.get("NXF_HOME", "")) > 0:
+                nf_wfdir = os.path.join(os.environ.get("NXF_HOME"), "assets")
             else:
                 nf_wfdir = os.path.join(os.getenv("HOME"), ".nextflow", "assets", self.full_name)
             if os.path.isdir(nf_wfdir):

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -68,9 +68,12 @@ def fetch_wf_config(wf_path):
     cache_basedir = None
     cache_path = None
 
+    # Nextflow home directory - use env var if set, or default to ~/.nextflow
+    nxf_home = os.environ.get("NXF_HOME", os.path.join(os.getenv("HOME"), ".nextflow"))
+
     # Build a cache directory if we can
-    if os.path.isdir(os.path.join(os.getenv("HOME"), ".nextflow")):
-        cache_basedir = os.path.join(os.getenv("HOME"), ".nextflow", "nf-core")
+    if os.path.isdir(nxf_home):
+        cache_basedir = os.path.join(nxf_home, "nf-core")
         if not os.path.isdir(cache_basedir):
             os.mkdir(cache_basedir)
 


### PR DESCRIPTION
Look for and use `$NXF_HOME` for stuff if set, before defaulting to `~/.nextflow`

Closes nf-core/tools#798

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
