### PR TITLE
Add minimum version for prompt_toolkit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "jinja2",
         "jsonschema",
         "questionary>=1.8.0",
-        "prompt_toolkit",
+        "prompt_toolkit>=3.0.3",
         "pyyaml",
         "requests",
         "requests_cache",


### PR DESCRIPTION
I just switched computers and for some reason, `pip` was quite happy to install the dev code here without updating prompt-toolkit. To make it work I had to uninstall pyinquirer and then manually update prompt-toolkit.

As we can assume that most people will have the old version of nf-core/tools installed, and so the same pyinquirer / prompt-toolkit versions that I did, I'm a bit worried that this will happen to other people.

To try to help avoid that, I've added a minimum version of prompt-toolkit to our `setup.py`. This should already be set in questionary, but it uses poetry instead of setuptools so that could be one reason why stuff is being strange. Hopefully this addition may avoid some issues with `pip` installation.

Phil