### PR TITLE
Bump version to 1.13dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # nf-core/tools: Changelog
 
+## v1.13dev
+
+_..nothing yet.._
+
 ## [v1.12.1 - Silver Dolphin](https://github.com/nf-core/tools/releases/tag/1.12.1) - [2020-12-03]
 
 ### Template

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 import sys
 
-version = "1.12.1"
+version = "1.13dev"
 
 with open("README.md") as f:
     readme = f.read()


### PR DESCRIPTION
Bump to development version number on `dev` again after the 1.12.1 release.