### PR TITLE
Ignore the gitignore for sphinx docs

### DIFF
--- a/.github/workflows/tools-api-docs.yml
+++ b/.github/workflows/tools-api-docs.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           git checkout --orphan api-doc
           git rm -r --cache .
+          rm .gitignore
           git config user.email "core@nf-co.re"
           git config user.name "nf-core-bot"
           git add docs


### PR DESCRIPTION
The built docs are ignored by gitignore now, so need to ignore the gitignore so that the built docs are not ignored.