### PR TITLE
Better UI for command line launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v1.13dev
 
+### Tools helper code
+
+* Fixed some bugs in the command line interface for `nf-core launch` and improved formatting [[#829](https://github.com/nf-core/tools/pull/829)]
+
 ### Linting
 
 * Added schema validation of GitHub action workflows to lint function [[#795](https://github.com/nf-core/tools/issues/795)]

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -34,6 +34,9 @@ nfcore_question_style = prompt_toolkit.styles.Style(
         ("instruction", ""),  # user instructions for select, rawselect, checkbox
         ("text", ""),  # plain text
         ("disabled", "fg:gray italic"),  # disabled choices for select and checkbox prompts
+        ("choice-default", "fg:ansiblack"),
+        ("choice-default-changed", "fg:ansiyellow"),
+        ("choice-required", "fg:ansired"),
     ]
 )
 
@@ -437,11 +440,16 @@ class Launch(object):
 
             for param_id, param in group_obj["properties"].items():
                 if not param.get("hidden", False) or self.show_hidden:
-                    q_title = param_id
-                    if param_id in answers:
-                        q_title += "  [{}]".format(answers[param_id])
+                    q_title = [("", param_id)]
+                    # If already filled in, show value
+                    if param_id in answers and answers.get(param_id) != param.get("default"):
+                        q_title.append(("class:choice-default-changed", "  [{}]".format(answers[param_id])))
+                    # If the schema has a default, show default
                     elif "default" in param:
-                        q_title += "  [{}]".format(param["default"])
+                        q_title.append(("class:choice-default", "  [{}]".format(param["default"])))
+                    # Show that it's required if not filled in and no default
+                    elif param_id in group_obj.get("required", []):
+                        q_title.append(("class:choice-required", "  (required)"))
                     question["choices"].append(questionary.Choice(title=q_title, value=param_id))
 
             # Skip if all questions hidden

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -430,9 +430,12 @@ class Launch(object):
         """
         while_break = False
         answers = {}
-        first_ask = True
         error_msgs = []
         while not while_break:
+
+            if len(error_msgs) == 0:
+                self.print_param_header(group_id, group_obj, True)
+
             question = {
                 "type": "list",
                 "name": group_id,
@@ -469,9 +472,6 @@ class Launch(object):
             if len(question["choices"]) == 2:
                 return {}
 
-            if first_ask:
-                self.print_param_header(group_id, group_obj)
-            first_ask = False
             answer = questionary.unsafe_prompt([question], style=nfcore_question_style)
             if answer[group_id] == "Continue >>":
                 while_break = True
@@ -504,7 +504,7 @@ class Launch(object):
         if answers is None:
             answers = {}
 
-        question = {"type": "input", "name": param_id, "message": param_id}
+        question = {"type": "input", "name": param_id, "message": ""}
 
         # Print the name, description & help text
         if print_help:
@@ -615,7 +615,7 @@ class Launch(object):
 
         return question
 
-    def print_param_header(self, param_id, param_obj):
+    def print_param_header(self, param_id, param_obj, is_group=False):
         if "description" not in param_obj and "help_text" not in param_obj:
             return
         console = Console(force_terminal=nf_core.utils.rich_force_colors())
@@ -627,7 +627,8 @@ class Launch(object):
         if "help_text" in param_obj:
             help_md = Markdown(param_obj["help_text"].strip())
             console.print(help_md, style="dim")
-        console.print("(Use arrow keys)", style="italic", highlight=False)
+        if is_group:
+            console.print("(Use arrow keys)", style="italic", highlight=False)
 
     def strip_default_params(self):
         """ Strip parameters if they have not changed from the default """

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -388,7 +388,7 @@ class Launch(object):
         for param_id, param_obj in self.schema_obj.schema.get("properties", {}).items():
             if not param_obj.get("hidden", False) or self.show_hidden:
                 is_required = param_id in self.schema_obj.schema.get("required", [])
-                answers.update(self.prompt_param(param_id, param_obj, is_required, answers))
+                answers = self.prompt_param(param_id, param_obj, is_required, answers)
 
         # Split answers into core nextflow options and params
         for key, answer in answers.items():
@@ -412,10 +412,18 @@ class Launch(object):
             log.error("'–-{}' is required".format(param_id))
             answer = questionary.unsafe_prompt([question], style=nfcore_question_style)
 
-        # Don't return empty answers
+        # Ignore if empty
         if answer[param_id] == "":
-            return {}
-        return answer
+            answer = {}
+
+        # Previously entered something but this time we deleted it
+        if param_id not in answer and param_id in answers:
+            answers.pop(param_id)
+        # Everything else (first time answer no response or normal response)
+        else:
+            answers.update(answer)
+
+        return answers
 
     def prompt_group(self, group_id, group_obj):
         """
@@ -485,7 +493,7 @@ class Launch(object):
             else:
                 param_id = answer[group_id]
                 is_required = param_id in group_obj.get("required", [])
-                answers.update(self.prompt_param(param_id, group_obj["properties"][param_id], is_required, answers))
+                answers = self.prompt_param(param_id, group_obj["properties"][param_id], is_required, answers)
 
         return answers
 

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -100,7 +100,7 @@ class TestLaunch(unittest.TestCase):
             "default": "data/*{1,2}.fastq.gz",
         }
         result = self.launcher.single_param_to_questionary("input", sc_obj)
-        assert result == {"type": "input", "name": "input", "message": "input", "default": "data/*{1,2}.fastq.gz"}
+        assert result == {"type": "input", "name": "input", "message": "", "default": "data/*{1,2}.fastq.gz"}
 
     @mock.patch("questionary.unsafe_prompt", side_effect=[{"use_web_gui": "Web based"}])
     def test_prompt_web_gui_true(self, mock_prompt):
@@ -207,7 +207,7 @@ class TestLaunch(unittest.TestCase):
         result = self.launcher.single_param_to_questionary("single_end", sc_obj)
         assert result["type"] == "list"
         assert result["name"] == "single_end"
-        assert result["message"] == "single_end"
+        assert result["message"] == ""
         assert result["choices"] == ["True", "False"]
         assert result["default"] == "True"
         print(type(True))


### PR DESCRIPTION
Refined UI around the Questionary prompts:

* Fixed bug where you couldn't delete something you'd entered
    * Empty answers were ignored, so if you typed something then went back and deleted it then the interface would revert to whatever you typed last - you couldn't reset it to nothing. Now fixed.
* Group select lists
    * Removed duplicated group heading
    * Stronger highlighting of group title
    * Default values of options formatted with dim text
    * Inputted values of options formatted with yellow text
    * Required options shown with hint if not yet set
    * Errors shown at top of list (as disabled options) if _Continue_ selected with required options not set
* Single parameters
    * Removed duplicated parameter title
    * Stronger highlighting of parameter title

Screenshots of cli interface before and after changes in this PR:

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

![image](https://user-images.githubusercontent.com/465550/104629104-53274680-5699-11eb-9c33-e0ed6acd6bc2.png)

</td><td>

![image](https://user-images.githubusercontent.com/465550/104629042-3f7be000-5699-11eb-861d-7ba3ae95bcdf.png)

</td></tr><tr><td>

![image](https://user-images.githubusercontent.com/465550/104629143-60443580-5699-11eb-8aef-6ce8989ef8fa.png)

</td><td>

![image](https://user-images.githubusercontent.com/465550/104628962-2b37e300-5699-11eb-9d4d-cadcf228ab8e.png)

</td></tr></table>

Implementation of https://github.com/nf-core/tools/issues/816 and with help from https://github.com/tmbo/questionary/issues/107

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
