### PR TITLE
added validation check for default params to nf-core lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Linting
 
-* Added validation of default params to `nf-core lint` [[#823](https://github.com/nf-core/tools/issues/823)]
+* Added validation of default params to `nf-core schema lint` [[#823](https://github.com/nf-core/tools/issues/823)]
 * Added schema validation of GitHub action workflows to lint function [[#795](https://github.com/nf-core/tools/issues/795)]
 * Fixed bug in schema title and description validation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Linting
 
+* Added validation of default params to `nf-core lint` [[#823](https://github.com/nf-core/tools/issues/823)]
 * Added schema validation of GitHub action workflows to lint function [[#795](https://github.com/nf-core/tools/issues/795)]
 * Fixed bug in schema title and description validation
 

--- a/nf_core/lint/schema_lint.py
+++ b/nf_core/lint/schema_lint.py
@@ -74,7 +74,6 @@ def schema_lint(self):
 
     try:
         self.schema_obj.load_lint_schema()
-        self.schema_obj.validate_default_params()
         passed.append("Schema lint passed")
     except AssertionError as e:
         failed.append("Schema lint failed: {}".format(e))

--- a/nf_core/lint/schema_lint.py
+++ b/nf_core/lint/schema_lint.py
@@ -2,6 +2,7 @@
 
 import logging
 import nf_core.schema
+import jsonschema
 
 
 def schema_lint(self):
@@ -69,10 +70,15 @@ def schema_lint(self):
     # Lint the schema
     self.schema_obj = nf_core.schema.PipelineSchema()
     self.schema_obj.get_schema_path(self.wf_path)
+
     try:
-        self.schema_obj.load_lint_schema()
+        self.schema_obj.load_schema()
+        self.schema_obj.get_schema_defaults()
+        self.schema_obj.validate_schema()
+        # Check default params
+        jsonschema.validate(self.schema_obj.schema_defaults, self.schema_obj.schema)
         passed.append("Schema lint passed")
-    except AssertionError as e:
+    except Exception as e:
         failed.append("Schema lint failed: {}".format(e))
 
     # Check the title and description - gives warnings instead of fail

--- a/nf_core/lint/schema_lint.py
+++ b/nf_core/lint/schema_lint.py
@@ -7,8 +7,7 @@ import jsonschema
 
 def remove_required_fields(schema):
     """ Remove all required fields from a schema """
-    for group_key in schema["definitions"].keys():
-        group = schema["definitions"][group_key]
+    for group_key, group in schema["definitions"].items():
         group_keys = list(group.keys())
         if "required" in group_keys:
             required_params = group["required"]

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -185,10 +185,10 @@ class PipelineSchema(object):
                     schema_no_required["definitions"][group_key].pop("required")
             jsonschema.validate(self.schema_defaults, schema_no_required)
         except AssertionError:
-            log.error("[red]\[✗] Pipeline schema not found")
+            log.error("[red][✗] Pipeline schema not found")
         except jsonschema.exceptions.ValidationError as e:
             raise AssertionError("Default parameters are invalid: {}".format(e.message))
-        log.info("[green]\[✓] Default parameters look valid")
+        log.info("[green][✓] Default parameters look valid")
 
     def validate_schema(self, schema=None):
         """

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -80,6 +80,7 @@ class PipelineSchema(object):
             self.load_schema()
             num_params = self.validate_schema()
             self.get_schema_defaults()
+            self.validate_default_params()
             log.info("[green]\[✓] Pipeline schema looks valid[/] [dim](found {} params)".format(num_params))
         except json.decoder.JSONDecodeError as e:
             error_msg = "[bold red]Could not parse schema JSON:[/] {}".format(e)
@@ -173,7 +174,6 @@ class PipelineSchema(object):
         Check that all default parameters in the schema are valid
         Ignores 'required' flag, as required parameters might have no defaults
         """
-        self.get_schema_defaults()
         try:
             assert self.schema is not None
             # Make copy of schema and remove required flags


### PR DESCRIPTION
Simply added a jsonschema validation check to the `schema_lint.py` function check.

So the steps are now to:
* load the schema
* get schema defaults
* check for correct format as before
* then validate the default params against the schema itself

The `AssertionError` was exchanged with an `Exception` because we capture two different errors now.
Will probably make this more finegrained.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
