### PR TITLE
Download: Get DSL2 singularity containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Tools helper code
 
 * Fixed some bugs in the command line interface for `nf-core launch` and improved formatting [[#829](https://github.com/nf-core/tools/pull/829)]
-* New functionality for `nf-core download` to make it compatible with DSL2 pipelines
+* New functionality for `nf-core download` to make it compatible with DSL2 pipelines [[#832](https://github.com/nf-core/tools/pull/832)]
   * Singularity images in module files are now discovered and fetched
   * Direct downloads of Singularity images in python allowed (much faster than running `singularity pull`)
   * Downloads now work with `$NXF_SINGULARITY_CACHEDIR` so that pipelines sharing containers have efficient downloads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Tools helper code
 
 * Fixed some bugs in the command line interface for `nf-core launch` and improved formatting [[#829](https://github.com/nf-core/tools/pull/829)]
+* New functionality for `nf-core download` to make it compatible with DSL2 pipelines
+  * Singularity images in module files are now discovered and fetched
+  * Direct downloads of Singularity images in python allowed (much faster than running `singularity pull`)
+  * Downloads now work with `$NXF_SINGULARITY_CACHEDIR` so that pipelines sharing containers have efficient downloads
 
 ### Linting
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -212,14 +212,15 @@ def launch(pipeline, id, revision, command_only, params_in, params_out, save_all
     help="Compression type",
 )
 @click.option("-f", "--force", is_flag=True, default=False, help="Overwrite existing files")
-def download(pipeline, release, singularity, outdir, compress, force):
+@click.option("-p", "--parallel_downloads", type=int, default=4, help="Number of parallel container downloads")
+def download(pipeline, release, singularity, outdir, compress, force, parallel_downloads):
     """
     Download a pipeline, configs and singularity container.
 
     Collects all workflow files and shared configs from nf-core/configs.
     Configures the downloaded workflow to use the relative path to the configs.
     """
-    dl = nf_core.download.DownloadWorkflow(pipeline, release, singularity, outdir, compress, force)
+    dl = nf_core.download.DownloadWorkflow(pipeline, release, singularity, outdir, compress, force, parallel_downloads)
     dl.download_workflow()
 
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -211,14 +211,15 @@ def launch(pipeline, id, revision, command_only, params_in, params_out, save_all
     default="tar.gz",
     help="Compression type",
 )
-def download(pipeline, release, singularity, outdir, compress):
+@click.option("-f", "--force", is_flag=True, default=False, help="Overwrite existing files")
+def download(pipeline, release, singularity, outdir, compress, force):
     """
     Download a pipeline, configs and singularity container.
 
     Collects all workflow files and shared configs from nf-core/configs.
     Configures the downloaded workflow to use the relative path to the configs.
     """
-    dl = nf_core.download.DownloadWorkflow(pipeline, release, singularity, outdir, compress)
+    dl = nf_core.download.DownloadWorkflow(pipeline, release, singularity, outdir, compress, force)
     dl.download_workflow()
 
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -214,10 +214,10 @@ def launch(pipeline, id, revision, command_only, params_in, params_out, save_all
 @click.option("-f", "--force", is_flag=True, default=False, help="Overwrite existing files")
 @click.option(
     "-c",
-    "--use_singularity_cache",
+    "--use-singularity-cache",
     is_flag=True,
     default=False,
-    help="Don't copy images to the output directory and don't configure singularity.cacheDir",
+    help="Don't copy images to the output directory and don't configure 'singularity.cacheDir'",
 )
 @click.option("-p", "--parallel_downloads", type=int, default=4, help="Number of parallel image downloads")
 def download(pipeline, release, singularity, outdir, compress, force, use_singularity_cache, parallel_downloads):

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -202,23 +202,30 @@ def launch(pipeline, id, revision, command_only, params_in, params_out, save_all
 @nf_core_cli.command(help_priority=3)
 @click.argument("pipeline", required=True, metavar="<pipeline name>")
 @click.option("-r", "--release", type=str, help="Pipeline release")
-@click.option("-s", "--singularity", is_flag=True, default=False, help="Download singularity containers")
+@click.option("-s", "--singularity", is_flag=True, default=False, help="Download singularity images")
 @click.option("-o", "--outdir", type=str, help="Output directory")
 @click.option(
     "-c",
     "--compress",
     type=click.Choice(["tar.gz", "tar.bz2", "zip", "none"]),
     default="tar.gz",
-    help="Compression type",
+    help="Archive compression type",
 )
 @click.option("-f", "--force", is_flag=True, default=False, help="Overwrite existing files")
-@click.option("-p", "--parallel_downloads", type=int, default=4, help="Number of parallel container downloads")
-def download(pipeline, release, singularity, outdir, compress, force, parallel_downloads):
+@click.option(
+    "-c",
+    "--use_singularity_cache",
+    is_flag=True,
+    default=False,
+    help="Don't copy images to the output directory and don't configure singularity.cacheDir",
+)
+@click.option("-p", "--parallel_downloads", type=int, default=4, help="Number of parallel image downloads")
+def download(pipeline, release, singularity, outdir, compress, force, use_singularity_cache, parallel_downloads):
     """
-    Download a pipeline, configs and singularity container.
+    Download a pipeline, nf-core/configs and pipeline singularity images.
 
-    Collects all workflow files and shared configs from nf-core/configs.
-    Configures the downloaded workflow to use the relative path to the configs.
+    Collects all files in a single archive and configures the downloaded
+    workflow to use relative paths to the configs and singularity images.
     """
     dl = nf_core.download.DownloadWorkflow(pipeline, release, singularity, outdir, compress, force, parallel_downloads)
     dl.download_workflow()

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -227,7 +227,9 @@ def download(pipeline, release, singularity, outdir, compress, force, use_singul
     Collects all files in a single archive and configures the downloaded
     workflow to use relative paths to the configs and singularity images.
     """
-    dl = nf_core.download.DownloadWorkflow(pipeline, release, singularity, outdir, compress, force, parallel_downloads)
+    dl = nf_core.download.DownloadWorkflow(
+        pipeline, release, singularity, outdir, compress, force, use_singularity_cache, parallel_downloads
+    )
     dl.download_workflow()
 
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -202,7 +202,6 @@ def launch(pipeline, id, revision, command_only, params_in, params_out, save_all
 @nf_core_cli.command(help_priority=3)
 @click.argument("pipeline", required=True, metavar="<pipeline name>")
 @click.option("-r", "--release", type=str, help="Pipeline release")
-@click.option("-s", "--singularity", is_flag=True, default=False, help="Download singularity images")
 @click.option("-o", "--outdir", type=str, help="Output directory")
 @click.option(
     "-c",
@@ -212,15 +211,16 @@ def launch(pipeline, id, revision, command_only, params_in, params_out, save_all
     help="Archive compression type",
 )
 @click.option("-f", "--force", is_flag=True, default=False, help="Overwrite existing files")
+@click.option("-s", "--singularity", is_flag=True, default=False, help="Download singularity images")
 @click.option(
     "-c",
-    "--use-singularity-cache",
+    "--singularity-cache",
     is_flag=True,
     default=False,
-    help="Don't copy images to the output directory and don't configure 'singularity.cacheDir'",
+    help="Don't copy images to the output directory, don't set 'singularity.cacheDir' in workflow",
 )
-@click.option("-p", "--parallel_downloads", type=int, default=4, help="Number of parallel image downloads")
-def download(pipeline, release, singularity, outdir, compress, force, use_singularity_cache, parallel_downloads):
+@click.option("-p", "--parallel-downloads", type=int, default=4, help="Number of parallel image downloads")
+def download(pipeline, release, outdir, compress, force, singularity, singularity_cache, parallel_downloads):
     """
     Download a pipeline, nf-core/configs and pipeline singularity images.
 
@@ -228,7 +228,7 @@ def download(pipeline, release, singularity, outdir, compress, force, use_singul
     workflow to use relative paths to the configs and singularity images.
     """
     dl = nf_core.download.DownloadWorkflow(
-        pipeline, release, singularity, outdir, compress, force, use_singularity_cache, parallel_downloads
+        pipeline, release, outdir, compress, force, singularity, singularity_cache, parallel_downloads
     )
     dl.download_workflow()
 

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -438,7 +438,7 @@ class DownloadWorkflow(object):
                 for container in containers_pull:
                     progress.update(task, description="Pulling singularity images")
                     try:
-                        self.singularity_pull_image(*container, progress)
+                        self.singularity_pull_image(*container)
                     except RuntimeWarning as r:
                         # Raise exception if this is not possible
                         log.error("Not able to pull image. Service might be down or internet connection is dead.")

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -400,7 +400,7 @@ class DownloadWorkflow(object):
 
                     try:
                         # Iterate over each threaded download, waiting for them to finish
-                        for future in concurrent.futures.wait(future_downloads):
+                        for future in concurrent.futures.as_completed(future_downloads):
                             if future.exception():
                                 raise future.exception()
                             else:

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -515,12 +515,12 @@ class DownloadWorkflow(object):
         out_path_dir = os.path.dirname(out_path)
         if not os.path.isdir(out_path_dir):
             log.debug(f"Output directory not found, creating: {out_path_dir}")
-            os.mkdirs(out_path_dir)
+            os.makedirs(out_path_dir)
         if cache_path:
             cache_path_dir = os.path.dirname(cache_path)
             if not os.path.isdir(cache_path_dir):
                 log.debug(f"Cache directory not found, creating: {cache_path_dir}")
-                os.mkdirs(cache_path_dir)
+                os.makedirs(cache_path_dir)
 
         # Set output path to save file to
         output_path = cache_path or out_path

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -418,8 +418,9 @@ class DownloadWorkflow(object):
                         for future in concurrent.futures.as_completed(future_downloads):
                             try:
                                 future.result()
-                            except Exception:
-                                raise
+                            except Exception as e:
+                                log.error(f"Download failed: {e}")
+                                raise KeyboardInterrupt
                             else:
                                 try:
                                     progress.update(task, advance=1)

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -355,8 +355,6 @@ class DownloadWorkflow(object):
         if len(self.containers) == 0:
             log.info("No container names found in workflow")
         else:
-            if not self.use_singularity_cache:
-                os.mkdir(os.path.join(self.outdir, "singularity-images"))
             if not os.environ.get("NXF_SINGULARITY_CACHEDIR"):
                 log.info(
                     "[magenta]Tip: Set env var $NXF_SINGULARITY_CACHEDIR to use a central cache for container downloads"
@@ -514,10 +512,15 @@ class DownloadWorkflow(object):
         log.debug(f"Downloading Singularity image: '{container}'")
 
         # Check that download directories exist
-        if not os.path.isdir(os.path.dirname(out_path)):
-            raise FileNotFoundError("Output directory not found: '{}'".format(os.path.dirname(out_path)))
-        if cache_path and not os.path.isdir(os.path.dirname(cache_path)):
-            raise FileNotFoundError("Output directory not found: '{}'".format(os.path.dirname(cache_path)))
+        out_path_dir = os.path.dirname(out_path)
+        if not os.path.isdir(out_path_dir):
+            log.debug(f"Output directory not found, creating: {out_path_dir}")
+            os.mkdirs(out_path_dir)
+        if cache_path:
+            cache_path_dir = os.path.dirname(cache_path)
+            if not os.path.isdir(cache_path_dir):
+                log.debug(f"Cache directory not found, creating: {cache_path_dir}")
+                os.mkdirs(cache_path_dir)
 
         # Set output path to save file to
         output_path = cache_path or out_path

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -527,17 +527,16 @@ class DownloadWorkflow(object):
 
         # Set output path to save file to
         output_path = cache_path or out_path
-        output_path_tmp = None
+        output_path_tmp = f"{output_path}.partial"
+        log.debug(f"Downloading to: '{output_path_tmp}'")
 
         # Set up progress bar
         nice_name = container.split("/")[-1][:50]
         task = progress.add_task(nice_name, start=False, total=False, progress_type="download")
         try:
-            # Set a temporary filename to download to
-            output_path_tmp = f"{output_path}.partial"
+            # Delete temporary file if it already exists
             if os.path.exists(output_path_tmp):
                 os.remove(output_path_tmp)
-            log.debug(f"Downloading to: '{output_path_tmp}'")
 
             # Open file handle and download
             with open(output_path_tmp, "wb") as fh:

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -614,7 +614,11 @@ class DownloadWorkflow(object):
         try:
             # Run the singularity pull command
             proc = subprocess.Popen(
-                singularity_command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1
+                singularity_command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+                bufsize=1,
             )
             for line in proc.stdout:
                 log.debug(line.strip())

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -427,18 +427,14 @@ class DownloadWorkflow(object):
                     try:
                         # Iterate over each threaded download, waiting for them to finish
                         for future in concurrent.futures.as_completed(future_downloads):
+                            future.result()
                             try:
-                                future.result()
+                                progress.update(task, advance=1)
                             except Exception as e:
-                                log.error(f"Download failed: {e}")
-                                raise KeyboardInterrupt
-                            else:
-                                try:
-                                    progress.update(task, advance=1)
-                                except Exception as e:
-                                    log.error(f"Error updating progress bar: {e}")
+                                log.error(f"Error updating progress bar: {e}")
 
-                    except KeyboardInterrupt:
+                    except Exception as e:
+                        log.error(f"Error downloading container: {e}")
                         # Cancel the future threads that haven't started yet
                         for future in future_downloads:
                             future.cancel()

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -439,7 +439,7 @@ class DownloadWorkflow(object):
         """
         # Pull using singularity
         address = "docker://{}".format(container.replace("docker://", ""))
-        singularity_command = ["singularity", "pull", "--name", dl_path, address]
+        singularity_command = ["singularity", "pull", "--name", output_path, address]
         log.info("Building singularity image: {}".format(address))
         log.debug("Singularity command: {}".format(" ".join(singularity_command)))
 

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -281,7 +281,7 @@ class DownloadWorkflow(object):
         nfconfig_fn = os.path.join(self.outdir, "workflow", "nextflow.config")
         find_str = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
         repl_str = "../configs/"
-        log.debug("Editing params.custom_config_base in {}".format(nfconfig_fn))
+        log.debug("Editing 'params.custom_config_base' in '{}'".format(nfconfig_fn))
 
         # Load the nextflow.config file into memory
         with open(nfconfig_fn, "r") as nfconfig_fh:
@@ -537,6 +537,7 @@ class DownloadWorkflow(object):
             output_path_tmp = f"{output_path}.partial"
             if os.path.exists(output_path_tmp):
                 os.remove(output_path_tmp)
+            log.debug(f"Downloading to: '{output_path_tmp}'")
 
             # Open file handle and download
             with open(output_path_tmp, "wb") as fh:

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -370,8 +370,19 @@ class DownloadWorkflow(object):
                 containers_pull = []
                 for container in self.containers:
 
-                    # Copy from the cache if we can, generate download path if not
+                    # Fetch the output and cached filenames for this container
                     out_path, cache_path = self.singularity_image_filenames(container)
+
+                    # Check that the directories exist
+                    out_path_dir = os.path.dirname(out_path)
+                    if not os.path.isdir(out_path_dir):
+                        log.debug(f"Output directory not found, creating: {out_path_dir}")
+                        os.makedirs(out_path_dir)
+                    if cache_path:
+                        cache_path_dir = os.path.dirname(cache_path)
+                        if not os.path.isdir(cache_path_dir):
+                            log.debug(f"Cache directory not found, creating: {cache_path_dir}")
+                            os.makedirs(cache_path_dir)
 
                     # We already have the target file in place, return
                     if os.path.exists(out_path):
@@ -514,17 +525,6 @@ class DownloadWorkflow(object):
             progress (Progress): Rich progress bar instance to add tasks to.
         """
         log.debug(f"Downloading Singularity image: '{container}'")
-
-        # Check that download directories exist
-        out_path_dir = os.path.dirname(out_path)
-        if not os.path.isdir(out_path_dir):
-            log.debug(f"Output directory not found, creating: {out_path_dir}")
-            os.makedirs(out_path_dir)
-        if cache_path:
-            cache_path_dir = os.path.dirname(cache_path)
-            if not os.path.isdir(cache_path_dir):
-                log.debug(f"Cache directory not found, creating: {cache_path_dir}")
-                os.makedirs(cache_path_dir)
 
         # Set output path to save file to
         output_path = cache_path or out_path

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -427,14 +427,17 @@ class DownloadWorkflow(object):
                     try:
                         # Iterate over each threaded download, waiting for them to finish
                         for future in concurrent.futures.as_completed(future_downloads):
-                            future.result()
                             try:
-                                progress.update(task, advance=1)
-                            except Exception as e:
-                                log.error(f"Error updating progress bar: {e}")
+                                future.result()
+                            except Exception:
+                                raise
+                            else:
+                                try:
+                                    progress.update(task, advance=1)
+                                except Exception as e:
+                                    log.error(f"Error updating progress bar: {e}")
 
-                    except Exception as e:
-                        log.error(f"Error downloading container: {e}")
+                    except KeyboardInterrupt:
                         # Cancel the future threads that haven't started yet
                         for future in future_downloads:
                             future.cancel()

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -243,9 +243,6 @@ def setup_requests_cachedir():
     Caching directory will be set up in the user's home directory under
     a .nfcore_cache subdir.
     """
-    # Only import it if we need it
-    import requests_cache
-
     pyversion = ".".join(str(v) for v in sys.version_info[0:3])
     cachedir = os.path.join(os.getenv("HOME"), os.path.join(".nfcore", "cache_" + pyversion))
     if not os.path.exists(cachedir):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -172,15 +172,15 @@ class DownloadTest(unittest.TestCase):
         os.remove(tmpfile)
 
     #
-    # Tests for 'pull_singularity_image'
+    # Tests for 'singularity_pull_image'
     #
     # If Singularity is not installed, will log an error and exit
     # If Singularity is installed, should raise an OSError due to non-existant image
     @pytest.mark.xfail(raises=OSError)
-    def test_pull_singularity_image(self):
+    def test_singularity_pull_image(self):
         tmp_dir = tempfile.mkdtemp()
         download_obj = DownloadWorkflow(pipeline="dummy", outdir=tmp_dir)
-        download_obj.pull_singularity_image("a-container")
+        download_obj.singularity_pull_image("a-container", tmp_dir)
 
         # Clean up
         shutil.rmtree(tmp_dir)
@@ -188,7 +188,7 @@ class DownloadTest(unittest.TestCase):
     #
     # Tests for the main entry method 'download_workflow'
     #
-    @mock.patch("nf_core.download.DownloadWorkflow.pull_singularity_image")
+    @mock.patch("nf_core.download.DownloadWorkflow.singularity_pull_image")
     def test_download_workflow_with_success(self, mock_download_image):
 
         tmp_dir = tempfile.mkdtemp()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -180,7 +180,7 @@ class DownloadTest(unittest.TestCase):
     def test_singularity_pull_image(self):
         tmp_dir = tempfile.mkdtemp()
         download_obj = DownloadWorkflow(pipeline="dummy", outdir=tmp_dir)
-        download_obj.singularity_pull_image("a-container", tmp_dir)
+        download_obj.singularity_pull_image("a-container", tmp_dir, None)
 
         # Clean up
         shutil.rmtree(tmp_dir)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -177,10 +177,11 @@ class DownloadTest(unittest.TestCase):
     # If Singularity is not installed, will log an error and exit
     # If Singularity is installed, should raise an OSError due to non-existant image
     @pytest.mark.xfail(raises=OSError)
-    def test_singularity_pull_image(self):
+    @mock.patch("rich.progress.Progress.add_task")
+    def test_singularity_pull_image(self, mock_rich_progress):
         tmp_dir = tempfile.mkdtemp()
         download_obj = DownloadWorkflow(pipeline="dummy", outdir=tmp_dir)
-        download_obj.singularity_pull_image("a-container", tmp_dir, None)
+        download_obj.singularity_pull_image("a-container", tmp_dir, None, mock_rich_progress)
 
         # Clean up
         shutil.rmtree(tmp_dir)


### PR DESCRIPTION
With DSL2, we have multiple containers and they are specified within module files. These are no longer found by `nextflow config` and therefore `nf-core download` doesn't see them (#818).

This PR adds several new bits of functionality to `nf-core download` for singularity containers:

### Finding DSL2 containers

The tool now scrapes any `.nf` files in `modules/` recursively, and parses them to look for a lines that look like this:

```nextflow
container = "xxx"
```

If multiple matches are found in a file, any that start with `http` are prioritised and the first match after that is used.

> NB: Scraping code only handles simple strings and will fail with anything more complicated (e.g. [Sarek](https://github.com/nf-core/sarek/blob/bce378e09de25bb26c388b917f93f84806d3ba27/conf/base.config#L71)). This kind of thing needs to be resolved by Nextflow and so requires `nextflow config` or similar to work. I can't see any way around this in the scope of this PR.

### Direct image downloads

The code  can now directly download images if we have a URL. If the container name starts with `http` then we download this directly in Python. If not, then we pass to a `singularity pull` command as before. Python downloads are made pretty with a nice progress bar etc.

### Caching downloads

Finally, the code now checks for the `NXF_SINGULARITY_CACHEDIR` environment variable and saves singularity images there first if set, before copying to the archive. This speeds things up massively if running a few times and will be increasingly important with shared images across multiple DSL2 pipelines. If the env var is not set then the files are saved directly to the archive, but a log message with a tip about it is shown.

## Still to do:

- [x] Update the downloaded pipeline code so that it knows where to find the bundled singularity images (#464)
- [x] Check that auto-generated image names from https downloads are the same as those made by Nextflow
- [x] Figure out how to have nested Progress bars with different columns in Rich.
    - Have a global progress bar showing how far through all containers we are, then a transient progress bar for each download.
- [x] More testing (check DSL1 pipelines still work)

**Note 1:** This PR does not fix #513, but I suspect that this will be less of a problem as all pipelines transition to DSL2 so I think that we can probably ignore that issue now.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Documentation in `docs` is updated
