### PR TITLE
Add module test-yml generation tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Tools helper code
 
+* Added `nf-core modules md5` command to automatically generate md5 sums and a yaml file for module tests
 * Fixed some bugs in the command line interface for `nf-core launch` and improved formatting [[#829](https://github.com/nf-core/tools/pull/829)]
 
 ### Linting

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -417,16 +417,16 @@ def check(ctx):
     mods.check_modules()
 
 
-@modules.command("create-test-meta", help_priority=6)
+@modules.command("create-test-yml", help_priority=6)
 @click.pass_context
 @click.argument("module", type=str, required=True, metavar="<module name>")
 @click.option("-r", "--run-tests", is_flag=True, default=False, help="Run the test workflows")
 @click.option("-o", "--output", type=str, help="Path for output YAML file")
 @click.option("-f", "--force", is_flag=True, default=False, help="Overwrite output YAML file if it already exists")
 @click.option("-p", "--no-prompts", is_flag=True, default=False, help="Use defaults without prompting")
-def create_test_meta(ctx, module, run_tests, output, force, no_prompts):
+def create_test_yml(ctx, module, run_tests, output, force, no_prompts):
     """
-    Run test workflow and generate a module test.yml file for a new module.
+    Auto-generate a test.yml file for a new module.
 
     Given the name of a new module, run the Nextflow test command and automatically generate
     the required `test.yml` file based on the output files.
@@ -435,7 +435,7 @@ def create_test_meta(ctx, module, run_tests, output, force, no_prompts):
     sensible defaults.
     """
     try:
-        meta_builder = nf_core.modules.ModulesTestMetaBuilder(module, run_tests, output, force, no_prompts)
+        meta_builder = nf_core.modules.ModulesTestYmlBuilder(module, run_tests, output, force, no_prompts)
         meta_builder.run()
     except UserWarning as e:
         log.critical(e)

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -442,10 +442,7 @@ def create_test(ctx, module, name, command, tag, input, run_test, output, force,
         modules_test_helper = nf_core.modules.ModulesTestHelper(
             module, name, command, tag, input, run_test, output, force, no_prompts
         )
-        modules_test_helper.check_inputs()
-        modules_test_helper.get_md5_sums()
-        modules_test_helper.build_test_yaml()
-        modules_test_helper.print_test_yml()
+        modules_test_helper.run()
     except UserWarning as e:
         log.critical(e)
         sys.exit(1)

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """ nf-core: Helper tools for use with nf-core Nextflow pipelines. """
 
+from click.types import File
 from rich import print
 import click
 import logging
@@ -424,8 +425,11 @@ def md5(ctx, modules_dir):
     Generate md5 sums for all files in the "output" directory after running a command used for testing
     Helper utility to ease the generation of module tests
     """
-    modules_test_helper = nf_core.modules.ModulesTestHelper(modules_dir=modules_dir)
-    modules_test_helper.generate_test_yml()
+    try:
+        modules_test_helper = nf_core.modules.ModulesTestHelper(modules_dir=modules_dir)
+        modules_test_helper.generate_test_yml()
+    except FileNotFoundError as e:
+        log.error("Could not create test.yml file: {}".format(e))
 
 
 ## nf-core schema subcommands

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -275,7 +275,7 @@ def create(name, description, author, new_version, no_git, force, outdir):
     Create a new pipeline using the nf-core template.
 
     Uses the nf-core template to make a skeleton Nextflow pipeline with all required
-    files, boilerplate code and best-practices.
+    files, boilerplate code and bfest-practices.
     """
     create_obj = nf_core.create.PipelineCreate(name, description, author, new_version, no_git, force, outdir)
     create_obj.init_pipeline()
@@ -426,7 +426,8 @@ def check(ctx):
 @click.option("-i", "--input", type=click.Path(exists=True), help="Folder containing the test workflow results")
 @click.option("-r", "--run-test", is_flag=True, default=False, help="Run the test workflow")
 @click.option("-o", "--output", type=str, help="Path for output YAML file")
-def create_test(ctx, module, name, command, tag, input, run_test, output):
+@click.option("-f", "--force", is_flag=True, default=False, help="Overwrite output YAML file if it already exists")
+def create_test(ctx, module, name, command, tag, input, run_test, output, force):
     """
     Run test workflow and generate a module test.yml file for a new module.
 
@@ -437,7 +438,9 @@ def create_test(ctx, module, name, command, tag, input, run_test, output):
     sensible defaults.
     """
     try:
-        modules_test_helper = nf_core.modules.ModulesTestHelper(module, name, command, tag, input, run_test, output)
+        modules_test_helper = nf_core.modules.ModulesTestHelper(
+            module, name, command, tag, input, run_test, output, force
+        )
         modules_test_helper.check_inputs()
         modules_test_helper.get_md5_sums()
         modules_test_helper.build_test_yaml()

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -417,14 +417,14 @@ def check(ctx):
     mods.check_modules()
 
 
-@modules.command("create-test", help_priority=6)
+@modules.command("create-test-meta", help_priority=6)
 @click.pass_context
 @click.argument("module", type=str, required=True, metavar="<module name>")
 @click.option("-r", "--run-tests", is_flag=True, default=False, help="Run the test workflows")
 @click.option("-o", "--output", type=str, help="Path for output YAML file")
 @click.option("-f", "--force", is_flag=True, default=False, help="Overwrite output YAML file if it already exists")
 @click.option("-p", "--no-prompts", is_flag=True, default=False, help="Use defaults without prompting")
-def create_test(ctx, module, run_tests, output, force, no_prompts):
+def create_test_meta(ctx, module, run_tests, output, force, no_prompts):
     """
     Run test workflow and generate a module test.yml file for a new module.
 
@@ -435,8 +435,8 @@ def create_test(ctx, module, run_tests, output, force, no_prompts):
     sensible defaults.
     """
     try:
-        modules_test_helper = nf_core.modules.ModulesTestHelper(module, run_tests, output, force, no_prompts)
-        modules_test_helper.run()
+        meta_builder = nf_core.modules.ModulesTestMetaBuilder(module, run_tests, output, force, no_prompts)
+        meta_builder.run()
     except UserWarning as e:
         log.critical(e)
         sys.exit(1)

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -420,11 +420,11 @@ def check(ctx):
 @modules.command("create-test", help_priority=6)
 @click.pass_context
 @click.argument("module", type=str, required=True, metavar="<module name>")
-@click.option("-r", "--run-test", is_flag=True, default=False, help="Run the test workflow")
+@click.option("-r", "--run-tests", is_flag=True, default=False, help="Run the test workflows")
 @click.option("-o", "--output", type=str, help="Path for output YAML file")
 @click.option("-f", "--force", is_flag=True, default=False, help="Overwrite output YAML file if it already exists")
 @click.option("-p", "--no-prompts", is_flag=True, default=False, help="Use defaults without prompting")
-def create_test(ctx, module, run_test, output, force, no_prompts):
+def create_test(ctx, module, run_tests, output, force, no_prompts):
     """
     Run test workflow and generate a module test.yml file for a new module.
 
@@ -435,7 +435,7 @@ def create_test(ctx, module, run_test, output, force, no_prompts):
     sensible defaults.
     """
     try:
-        modules_test_helper = nf_core.modules.ModulesTestHelper(module, run_test, output, force, no_prompts)
+        modules_test_helper = nf_core.modules.ModulesTestHelper(module, run_tests, output, force, no_prompts)
         modules_test_helper.run()
     except UserWarning as e:
         log.critical(e)

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -420,15 +420,11 @@ def check(ctx):
 @modules.command("create-test", help_priority=6)
 @click.pass_context
 @click.argument("module", type=str, required=True, metavar="<module name>")
-@click.option("-n", "--name", type=str, help="Test name")
-@click.option("-c", "--command", type=str, help="Nextflow run command for test")
-@click.option("-t", "--tag", type=str, multiple=True, help="Test tag (can specify multiple times)")
-@click.option("-i", "--input", type=click.Path(exists=True), help="Folder containing the test workflow results")
 @click.option("-r", "--run-test", is_flag=True, default=False, help="Run the test workflow")
 @click.option("-o", "--output", type=str, help="Path for output YAML file")
 @click.option("-f", "--force", is_flag=True, default=False, help="Overwrite output YAML file if it already exists")
 @click.option("-p", "--no-prompts", is_flag=True, default=False, help="Use defaults without prompting")
-def create_test(ctx, module, name, command, tag, input, run_test, output, force, no_prompts):
+def create_test(ctx, module, run_test, output, force, no_prompts):
     """
     Run test workflow and generate a module test.yml file for a new module.
 
@@ -439,9 +435,7 @@ def create_test(ctx, module, name, command, tag, input, run_test, output, force,
     sensible defaults.
     """
     try:
-        modules_test_helper = nf_core.modules.ModulesTestHelper(
-            module, name, command, tag, input, run_test, output, force, no_prompts
-        )
+        modules_test_helper = nf_core.modules.ModulesTestHelper(module, run_test, output, force, no_prompts)
         modules_test_helper.run()
     except UserWarning as e:
         log.critical(e)

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -427,7 +427,8 @@ def check(ctx):
 @click.option("-r", "--run-test", is_flag=True, default=False, help="Run the test workflow")
 @click.option("-o", "--output", type=str, help="Path for output YAML file")
 @click.option("-f", "--force", is_flag=True, default=False, help="Overwrite output YAML file if it already exists")
-def create_test(ctx, module, name, command, tag, input, run_test, output, force):
+@click.option("-p", "--no-prompts", is_flag=True, default=False, help="Use defaults without prompting")
+def create_test(ctx, module, name, command, tag, input, run_test, output, force, no_prompts):
     """
     Run test workflow and generate a module test.yml file for a new module.
 
@@ -439,7 +440,7 @@ def create_test(ctx, module, name, command, tag, input, run_test, output, force)
     """
     try:
         modules_test_helper = nf_core.modules.ModulesTestHelper(
-            module, name, command, tag, input, run_test, output, force
+            module, name, command, tag, input, run_test, output, force, no_prompts
         )
         modules_test_helper.check_inputs()
         modules_test_helper.get_md5_sums()

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -416,6 +416,18 @@ def check(ctx):
     mods.check_modules()
 
 
+@modules.command(help_priority=6)
+@click.pass_context
+@click.argument("modules_dir", type=click.Path(exists=True), required=True, metavar="<modules directory>")
+def md5(ctx, modules_dir):
+    """
+    Generate md5 sums for all files in the "output" directory after running a command used for testing
+    Helper utility to ease the generation of module tests
+    """
+    modules_test_helper = nf_core.modules.ModulesTestHelper(modules_dir=modules_dir)
+    modules_test_helper.generate_test_yml()
+
+
 ## nf-core schema subcommands
 @nf_core_cli.group(cls=CustomHelpOrder, help_priority=8)
 def schema():

--- a/nf_core/modules.py
+++ b/nf_core/modules.py
@@ -242,7 +242,7 @@ class PipelineModules(object):
             return False
 
 
-class ModulesTestHelper(object):
+class ModulesTestMetaBuilder(object):
     def __init__(
         self,
         module_name,

--- a/nf_core/modules.py
+++ b/nf_core/modules.py
@@ -262,7 +262,7 @@ class ModulesTestHelper(object):
             assert os.path.exists(output_dir)
             assert len(glob.glob(os.path.join(output_dir, "*"))) > 0
         except:
-            print("output directory doesn't exist or is empty")
+            log.error("Output directory doesn't exist or is empty")
 
         # Get list of files and their md5sums
         md5_sums = self._get_md5_sums(output_dir)
@@ -283,5 +283,4 @@ class ModulesTestHelper(object):
         ]
 
         # print yaml to console
-
         print(yaml.dump(yml_dict, Dumper=self.CustomDumper))

--- a/nf_core/modules.py
+++ b/nf_core/modules.py
@@ -266,6 +266,7 @@ class ModulesTestHelper(object):
 
         # Get list of files and their md5sums
         md5_sums = self._get_md5_sums(output_dir)
+        md5_sums = list(set(md5_sums))
 
         # Create yaml output
         file_dicts = []

--- a/nf_core/modules.py
+++ b/nf_core/modules.py
@@ -242,7 +242,7 @@ class PipelineModules(object):
             return False
 
 
-class ModulesTestMetaBuilder(object):
+class ModulesTestYmlBuilder(object):
     def __init__(
         self,
         module_name,

--- a/nf_core/modules.py
+++ b/nf_core/modules.py
@@ -295,3 +295,4 @@ class ModulesTestHelper(object):
 
         # print yaml to console
         print(yaml.dump(yml_dict, Dumper=self.CustomDumper))
+        return yaml.dump(yml_dict, Dumper=self.CustomDumper)

--- a/nf_core/modules.py
+++ b/nf_core/modules.py
@@ -275,8 +275,6 @@ class ModulesTestHelper(object):
             # if directory, apply recursion
             if os.path.isdir(elem):
                 md5_sums = self._get_md5_sums(elem, md5_sums)
-            else:
-                continue
 
         return md5_sums
 
@@ -311,4 +309,3 @@ class ModulesTestHelper(object):
 
         # print yaml to console
         print(yaml.dump(yml_dict, Dumper=self.CustomDumper))
-        return True

--- a/nf_core/modules.py
+++ b/nf_core/modules.py
@@ -246,7 +246,7 @@ class ModulesTestHelper(object):
                 md5_sums.append((elem, elem_md5))
             # if directory, apply recursion
             if os.path.isdir(elem):
-                md5_sums += self._get_md5_sums(elem, md5_sums)
+                md5_sums = self._get_md5_sums(elem, md5_sums)
             else:
                 continue
 
@@ -266,7 +266,6 @@ class ModulesTestHelper(object):
 
         # Get list of files and their md5sums
         md5_sums = self._get_md5_sums(output_dir)
-        md5_sums = list(set(md5_sums))
 
         # Create yaml output
         file_dicts = []

--- a/nf_core/modules.py
+++ b/nf_core/modules.py
@@ -248,11 +248,13 @@ class ModulesTestHelper(object):
         test_input_results_dir=None,
         run_test=False,
         test_yml_output_path=None,
+        force_overwrite=False,
     ):
         self.module_name = module_name
         self.test_input_results_dir = test_input_results_dir
         self.run_test = run_test
         self.test_yml_output_path = test_yml_output_path
+        self.force_overwrite = force_overwrite
         self.modules_dir = os.path.join("software", *module_name.split("/"))
         self.test_yaml = {
             "name": test_name,
@@ -292,6 +294,16 @@ class ModulesTestHelper(object):
         if not self.run_test and self.test_input_results_dir is None:
             raise UserWarning(
                 f"Either supply a test output directory with '--input' or trigger a run with '--run-test'"
+            )
+
+        # Check that the output YAML file does not already exist
+        if (
+            self.test_yml_output_path is not None
+            and os.path.exists(self.test_yml_output_path)
+            and not self.force_overwrite
+        ):
+            raise UserWarning(
+                f"Test YAML file already exists! '{self.test_yml_output_path}'. Use '--force' to overwrite."
             )
 
     def build_test_yaml(self):
@@ -345,10 +357,13 @@ class ModulesTestHelper(object):
                 self.test_yml_output_path is not None
                 and self.test_yml_output_path != "-"
                 and os.path.exists(self.test_yml_output_path)
+                and not self.force_overwrite
             ):
-                if not rich.prompt.Confirm.ask(
+                if rich.prompt.Confirm.ask(
                     f"[red]File exists! [green]'{self.test_yml_output_path}' [violet]Overwrite?"
                 ):
+                    self.force_overwrite = True
+                else:
                     self.test_yml_output_path = None
 
         self.test_yaml["name"] = self.test_yaml["name"]

--- a/nf_core/modules.py
+++ b/nf_core/modules.py
@@ -239,6 +239,7 @@ class PipelineModules(object):
 class ModulesTestHelper(object):
     def __init__(self, modules_dir=""):
         self.modules_dir = modules_dir
+        self.file_dicts = []
 
     # Add custom dumper class to prevent overwriting the global state
     # This prevents yaml from changing the output order
@@ -271,12 +272,10 @@ class ModulesTestHelper(object):
             # if file, get md5 sum
             if os.path.isfile(elem):
                 elem_md5 = self._md5(elem)
-                md5_sums.append((elem, elem_md5))
+                self.file_dicts.append({"path": elem, "md5sum": elem_md5})
             # if directory, apply recursion
             if os.path.isdir(elem):
                 md5_sums = self._get_md5_sums(elem, md5_sums)
-
-        return md5_sums
 
     def generate_test_yml(self):
         """
@@ -291,19 +290,14 @@ class ModulesTestHelper(object):
             raise FileNotFoundError("Output directory doesn't exist or is empty")
 
         # Get list of files and their md5sums
-        md5_sums = self._get_md5_sums(output_dir)
-
-        # Create yaml output
-        file_dicts = []
-        for elem in md5_sums:
-            file_dicts.append({"path": elem[0], "md5sum": elem[1]})
+        self._get_md5_sums(output_dir)
 
         yml_dict = [
             {
                 "name": "<name of test>",
                 "command": "<command here>",
                 "tags": ["<tag>"],
-                "files": file_dicts,
+                "files": self.file_dicts,
             }
         ]
 

--- a/nf_core/modules.py
+++ b/nf_core/modules.py
@@ -259,23 +259,17 @@ class ModulesTestHelper(object):
         md5sum = hash_md5.hexdigest()
         return md5sum
 
-    def _get_md5_sums(self, dir, md5_sums=None):
+    def _get_md5_sums(self, dir):
         """
         Recursively go through directories and subdirectories
         and generate tuples of (<file_path>, <md5sum>)
         returns: list of tuples
         """
-        if not md5_sums:
-            md5_sums = []
-        elements = glob.glob(dir + "/*")
-        for elem in elements:
-            # if file, get md5 sum
-            if os.path.isfile(elem):
+        for root, dir, file in os.walk(dir):
+            for elem in file:
+                elem = os.path.join(root, elem)
                 elem_md5 = self._md5(elem)
                 self.file_dicts.append({"path": elem, "md5sum": elem_md5})
-            # if directory, apply recursion
-            if os.path.isdir(elem):
-                md5_sums = self._get_md5_sums(elem, md5_sums)
 
     def generate_test_yml(self):
         """
@@ -283,14 +277,12 @@ class ModulesTestHelper(object):
         """
         # Look for output directory
         output_dir = os.path.join(self.modules_dir, "output")
-        try:
-            assert os.path.exists(output_dir)
-            assert len(glob.glob(os.path.join(output_dir, "*"))) > 0
-        except:
-            raise FileNotFoundError("Output directory doesn't exist or is empty")
 
         # Get list of files and their md5sums
         self._get_md5_sums(output_dir)
+
+        if len(self.file_dicts) == 0:
+            log.warn("Could not find any output files. Does the 'output' directory exist?")
 
         yml_dict = [
             {

--- a/nf_core/modules.py
+++ b/nf_core/modules.py
@@ -278,7 +278,7 @@ class ModulesTestYmlBuilder(object):
         if not os.path.isdir(self.module_dir):
             raise UserWarning(f"Cannot find directory '{self.module_dir}'. Should be TOOL/SUBTOOL or TOOL")
         if not os.path.exists(self.module_test_main):
-            raise UserWarning(f"Cannot find module test workflow '{self.module_dir}/main.nf'")
+            raise UserWarning(f"Cannot find module test workflow '{self.module_test_main}'")
 
         # Check that we're running tests if no prompts
         if not self.run_tests and self.no_prompts:
@@ -448,12 +448,14 @@ class ModulesTestYmlBuilder(object):
         try:
             nfconfig_raw = subprocess.check_output(shlex.split(command))
         except OSError as e:
-            if e.errno == errno.ENOENT:
+            if e.errno == errno.ENOENT and command.strip().startswith("nextflow "):
                 raise AssertionError(
                     "It looks like Nextflow is not installed. It is required for most nf-core functions."
                 )
         except subprocess.CalledProcessError as e:
             raise UserWarning(f"Error running test workflow (exit code {e.returncode})\n[red]{e.output.decode()}")
+        except Exception as e:
+            raise UserWarning(f"Error running test workflow: {e}")
         else:
             log.info("Test workflow finished!")
             log.debug(nfconfig_raw)

--- a/nf_core/modules.py
+++ b/nf_core/modules.py
@@ -271,7 +271,7 @@ class ModulesTestHelper(object):
         # Create yaml output
         file_dicts = []
         for elem in md5_sums:
-            file_dicts.append({"path": elem[0], "md5sum": elem[1]})
+            file_dicts.append({"path": elem[0], "md5sum": elem[1], "should_exist": True})
 
         yml_dict = [
             {

--- a/nf_core/modules.py
+++ b/nf_core/modules.py
@@ -271,7 +271,7 @@ class ModulesTestHelper(object):
         # Create yaml output
         file_dicts = []
         for elem in md5_sums:
-            file_dicts.append({"path": elem[0], "md5sum": elem[1], "should_exist": True})
+            file_dicts.append({"path": elem[0], "md5sum": elem[1]})
 
         yml_dict = [
             {

--- a/nf_core/modules.py
+++ b/nf_core/modules.py
@@ -294,11 +294,6 @@ class ModulesTestHelper(object):
                 f"Either supply a test output directory with '--input' or trigger a run with '--run-test'"
             )
 
-        # Check that the output YAML file does not already exist
-        # TODO: Instead of clobbering can parse + append to list if already there
-        if self.test_yml_output_path is not None and os.path.exists(self.test_yml_output_path):
-            raise UserWarning(f"Test YAML file already exists! '{self.test_yml_output_path}'")
-
     def build_test_yaml(self):
         """Given the supplied cli flags, prompt for any that are missing.
 

--- a/nf_core/modules.py
+++ b/nf_core/modules.py
@@ -224,6 +224,17 @@ class PipelineModules(object):
         with open(dl_filename, "wb") as fh:
             fh.write(file_contents)
 
+    def has_valid_pipeline(self):
+        """Check that we were given a pipeline"""
+        if self.pipeline_dir is None or not os.path.exists(self.pipeline_dir):
+            log.error("Could not find pipeline: {}".format(self.pipeline_dir))
+            return False
+        main_nf = os.path.join(self.pipeline_dir, "main.nf")
+        nf_config = os.path.join(self.pipeline_dir, "nextflow.config")
+        if not os.path.exists(main_nf) and not os.path.exists(nf_config):
+            log.error("Could not find a main.nf or nextfow.config file in: {}".format(self.pipeline_dir))
+            return False
+
 
 class ModulesTestHelper(object):
     def __init__(self, modules_dir=""):
@@ -279,7 +290,7 @@ class ModulesTestHelper(object):
             assert os.path.exists(output_dir)
             assert len(glob.glob(os.path.join(output_dir, "*"))) > 0
         except:
-            log.error("Output directory doesn't exist or is empty")
+            raise FileNotFoundError("Output directory doesn't exist or is empty")
 
         # Get list of files and their md5sums
         md5_sums = self._get_md5_sums(output_dir)
@@ -300,14 +311,4 @@ class ModulesTestHelper(object):
 
         # print yaml to console
         print(yaml.dump(yml_dict, Dumper=self.CustomDumper))
-
-        def has_valid_pipeline(self):
-        """Check that we were given a pipeline"""
-        if self.pipeline_dir is None or not os.path.exists(self.pipeline_dir):
-            log.error("Could not find pipeline: {}".format(self.pipeline_dir))
-            return False
-        main_nf = os.path.join(self.pipeline_dir, "main.nf")
-        nf_config = os.path.join(self.pipeline_dir, "nextflow.config")
-        if not os.path.exists(main_nf) and not os.path.exists(nf_config):
-            log.error("Could not find a main.nf or nextfow.config file in: {}".format(self.pipeline_dir))
-            return False
+        return True

--- a/nf_core/modules.py
+++ b/nf_core/modules.py
@@ -212,9 +212,10 @@ class ModulesTestHelper(object):
     def __init__(self, modules_dir=""):
         self.modules_dir = modules_dir
 
-    # Using a custom Dumper class to prevent changing the global state
+    # Add custom dumper class to prevent overwriting the global state
+    # This prevents yaml from changing the output order
+    # See https://stackoverflow.com/a/52621703/1497385
     class CustomDumper(yaml.Dumper):
-        # Super neat hack to preserve the mapping key order. See https://stackoverflow.com/a/52621703/1497385
         def represent_dict_preserve_order(self, data):
             return self.represent_dict(data.items())
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -72,12 +72,3 @@ class TestModules(unittest.TestCase):
     def test_modules_remove_fastqc_uninstalled(self):
         """ Test removing FastQC module without installing it """
         assert self.mods.remove("fastqc") is False
-
-    def test_modules_md5_sum_helper(self):
-        """ Test the modules md5 sum helper command """
-        os.mkdir("output")
-        open("output/test.txt", "w").close()
-        modules_test_helper = nf_core.modules.ModulesTestYmlBuilder(modules_dir="./")
-        res = yaml.safe_load(modules_test_helper.generate_test_yml())
-        shutil.rmtree("output")
-        assert res[0]["files"][0]["md5sum"] == "d41d8cd98f00b204e9800998ecf8427e"

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -77,7 +77,7 @@ class TestModules(unittest.TestCase):
         """ Test the modules md5 sum helper command """
         os.mkdir("output")
         open("output/test.txt", "w").close()
-        modules_test_helper = nf_core.modules.ModulesTestHelper(modules_dir="./")
+        modules_test_helper = nf_core.modules.ModulesTestMetaBuilder(modules_dir="./")
         res = yaml.safe_load(modules_test_helper.generate_test_yml())
         shutil.rmtree("output")
         assert res[0]["files"][0]["md5sum"] == "d41d8cd98f00b204e9800998ecf8427e"

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -77,7 +77,7 @@ class TestModules(unittest.TestCase):
         """ Test the modules md5 sum helper command """
         os.mkdir("output")
         open("output/test.txt", "w").close()
-        modules_test_helper = nf_core.modules.ModulesTestMetaBuilder(modules_dir="./")
+        modules_test_helper = nf_core.modules.ModulesTestYmlBuilder(modules_dir="./")
         res = yaml.safe_load(modules_test_helper.generate_test_yml())
         shutil.rmtree("output")
         assert res[0]["files"][0]["md5sum"] == "d41d8cd98f00b204e9800998ecf8427e"

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -80,4 +80,4 @@ class TestModules(unittest.TestCase):
         modules_test_helper = nf_core.modules.ModulesTestHelper(modules_dir="./")
         res = yaml.safe_load(modules_test_helper.generate_test_yml())
         shutil.rmtree("output")
-        assert res[3][1] == "d41d8cd98f00b204e9800998ecf8427e"
+        assert res[0]["files"][0]["md5sum"] == "d41d8cd98f00b204e9800998ecf8427e"

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -9,6 +9,7 @@ import os
 import shutil
 import tempfile
 import unittest
+import yaml
 
 
 class TestModules(unittest.TestCase):
@@ -71,3 +72,12 @@ class TestModules(unittest.TestCase):
     def test_modules_remove_fastqc_uninstalled(self):
         """ Test removing FastQC module without installing it """
         assert self.mods.remove("fastqc") is False
+
+    def test_modules_md5_sum_helper(self):
+        """ Test the modules md5 sum helper command """
+        os.mkdir("output")
+        open("output/test.txt", "w").close()
+        modules_test_helper = nf_core.modules.ModulesTestHelper(modules_dir="./")
+        res = yaml.safe_load(modules_test_helper.generate_test_yml())
+        shutil.rmtree("output")
+        assert res[3][1] == "d41d8cd98f00b204e9800998ecf8427e"


### PR DESCRIPTION
## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated

This PR adds the command
`nf-core modules md5`
which automatically generates a yaml file containing the md5sums and paths of all files in the `output` directory.

So for writing module tests, you would run your test inside the module directory, which should generate the `output` directory. Then, you can run `nf-code modules md5 <path_to_modules_dir>`

Which generates output such as:

```yaml
- name: <name of test>
  command: <command here>
  tags:
  - <tag>
  files:
  - path: modules/output/star/star/chrStart.txt
    md5sum: faf5c55020c99eceeef3e34188ac0d2f
  - path: modules/output/star/star/chrNameLength.txt
    md5sum: c7ceb0a8827b2ea91c386933bee48742
  - path: modules/output/star/star/chrLength.txt
    md5sum: f2bea3725fe1c01420c57fb73bdeb31a
  - path: modules/output/star/star/sjdbList.fromGTF.out.tab
    md5sum: d41d8cd98f00b204e9800998ecf8427e
  - path: modules/output/star/star/exonInfo.tab
    md5sum: 42eca6ebc2dc72d9d6e6b3acd3714343
  - path: modules/output/star/star/sjdbList.out.tab
    md5sum: d41d8cd98f00b204e9800998ecf8427e
  - path: modules/output/star/star/SAindex
    md5sum: a94198b95a245d4f64af2a7133b6ec7b
  - path: modules/output/star/star/chrName.txt
    md5sum: e5025ccdd12db2953b69007d3ef11c98
  - path: modules/output/star/star/geneInfo.tab
    md5sum: 62659cefd88615960384d3b30dbcb22f
  - path: modules/output/star/star/SA
    md5sum: 3e70e4fc6d031e1915bb510727f2c559
  - path: modules/output/star/star/sjdbInfo.txt
    md5sum: 1082ab459363b3f2f7aabcef0979c1ed
  - path: modules/output/star/star/exonGeTrInfo.tab
    md5sum: aec6e7a1ae3fc8c638ce5a9ce9c886b6
  - path: modules/output/star/star/transcriptInfo.tab
    md5sum: 8fbe69abbbef4f89da3854873984dbac
  - path: modules/output/star/star/Genome
    md5sum: 323c992bac354f93073ce0fc43f222f8
  - path: modules/output/star/star/genomeParameters.txt
    md5sum: ed47b8b034cae2fefcdb39321aea47cd
```

Currently the files paths still need to be adapted if run outside of the modules directory (like above).
Might still add some code to adapt this though.
And I will add a test if we decide to include this.