### PR TITLE
Fix GitHub Actions typo that broke PR lint comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v1.13dev
 
+### Template
+
+* Fixed typo in nf-core-lint CI that prevented the markdown summary from being automatically posted on PRs as a comment.
+
 ### Modules
 
 * added `nf-core modules remove` command to uninstall modules

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/linting.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/workflows/linting.yml
@@ -69,7 +69,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
-          name: linting-log-file
+          name: linting-logs
           path: |
             lint_log.txt
             lint_results.md


### PR DESCRIPTION
Back in https://github.com/nf-core/tools/pull/769 I added functionality to get the output of `nf-core lint` as a markdown file and automatically post it on a PR, even if the PR comes from a fork of the repo (see https://github.com/nf-core/tools/issues/765 for discussion). This went out in release v1.12, however I realised that I haven't really seen any of these popping up.

Looking specifically at `nf-core/ampliseq`, I realised that the step to find the PR number couldn't find the file:

```
Run echo "::set-output name=pr_number::$(cat linting-logs/PR_number.txt)"
cat: linting-logs/PR_number.txt: No such file or directory
```

The step above showed the files being fetched from the artefact, so the file was there:

```
Run dawidd6/action-download-artifact@v2
==> Repo: nf-core/ampliseq
==> RunID: 537608188
==> Artifact: 39106759
==> Downloading: linting-log-file.zip (161.34 kB)
  inflating: linting-log-file/lint_log.txt
  inflating: linting-log-file/lint_results.md
  inflating: linting-log-file/PR_number.txt
```

Then I spotted the `linting-logs` / `linting-log-file` match up. This PR changes the latter (a missed remnant of an older version which I renamed) and hopefully gets this lovely feature up and running again.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
