### PR TITLE
Template profile docs fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Template
 
 * Fixed typo in nf-core-lint CI that prevented the markdown summary from being automatically posted on PRs as a comment.
+* Fixed a mistake in template documentation regarding how profiles are loaded, and added how to identify process name for resource customisation
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Template
 
 * Fixed typo in nf-core-lint CI that prevented the markdown summary from being automatically posted on PRs as a comment.
-* Fixed a mistake in template documentation regarding how profiles are loaded, and added how to identify process name for resource customisation
+* Added to template docs about how to identify process name for resource customisation
 
 ### Modules
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
@@ -58,7 +58,7 @@ Several generic profiles are bundled with the pipeline which instruct the pipeli
 The pipeline also dynamically loads configurations from [https://github.com/nf-core/configs](https://github.com/nf-core/configs) when it runs, making multiple config profiles for various institutional clusters available at run time. For more information and to see if your system is available in these configs please see the [nf-core/configs documentation](https://github.com/nf-core/configs#documentation).
 
 Note that multiple profiles can be loaded, for example: `-profile test,docker` - the order of arguments is important!
-They are loaded in sequence, so parameters or settings in earlier profiles can overwrite later profiles.
+They are loaded in sequence, so later profiles can overwrite earlier profiles.
 
 If `-profile` is not specified, the pipeline will run locally and expect all software to be installed and available on the `PATH`. This is _not_ recommended.
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/usage.md
@@ -58,7 +58,7 @@ Several generic profiles are bundled with the pipeline which instruct the pipeli
 The pipeline also dynamically loads configurations from [https://github.com/nf-core/configs](https://github.com/nf-core/configs) when it runs, making multiple config profiles for various institutional clusters available at run time. For more information and to see if your system is available in these configs please see the [nf-core/configs documentation](https://github.com/nf-core/configs#documentation).
 
 Note that multiple profiles can be loaded, for example: `-profile test,docker` - the order of arguments is important!
-They are loaded in sequence, so later profiles can overwrite earlier profiles.
+They are loaded in sequence, so parameters or settings in earlier profiles can overwrite later profiles.
 
 If `-profile` is not specified, the pipeline will run locally and expect all software to be installed and available on the `PATH`. This is _not_ recommended.
 
@@ -102,6 +102,8 @@ process {
   }
 }
 ```
+
+To find the exact name of a process you wish to modify the compute resources, check the live-status of a nextflow run displayed on your terminal or check the nextflow error for a line like so: `Error executing process > 'bwa'`. In this case the name to specify in the custom config file is `bwa`.
 
 See the main [Nextflow documentation](https://www.nextflow.io/docs/latest/config.html) for more information.
 


### PR DESCRIPTION
This fixes a mistake in the template usage documentation how profiles are loaded.

It also adds a line describing where to find the exact names of processes you may wish to customise resources for,

Both at suggestion of an eager user who is trying to create a profile.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Documentation in `docs` is updated
