### PR TITLE
Linting: Check that aws.config is deleted

### DIFF
--- a/nf_core/lint/files_exist.py
+++ b/nf_core/lint/files_exist.py
@@ -43,6 +43,7 @@ def files_exist(self):
         'Singularity',
         'parameters.settings.json',
         'bin/markdown_to_html.r',
+        'conf/aws.config',
         '.github/workflows/push_dockerhub.yml'
 
     Files that *should not* be present::
@@ -84,6 +85,7 @@ def files_exist(self):
         "Singularity",
         "parameters.settings.json",
         os.path.join("bin", "markdown_to_html.r"),
+        os.path.join("conf", "aws.config"),
         os.path.join(".github", "workflows", "push_dockerhub.yml"),
     ]
     files_warn_ifexists = [".travis.yml"]


### PR DESCRIPTION
Mini PR to add a check for an additional file that should no longer be present.

This config has been moved to nf-core/configs and is no longer referenced in `nextflow.config`, but the template sync doesn't seem to pick up that the config file should be deleted.

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
