### PR TITLE
Move commands into base image instead of Dockerfile in template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,12 @@ FROM continuumio/miniconda3:4.8.2
 LABEL authors="phil.ewels@scilifelab.se,alexander.peltzer@qbic.uni-tuebingen.de" \
       description="Docker image containing base requirements for the nfcore pipelines"
 
-# Install procps so that Nextflow can poll CPU usage and 
+# Install procps so that Nextflow can poll CPU usage and
 # deep clean the apt cache to reduce image/layer size
 RUN apt-get update \
- && apt-get install -y procps \
- && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+      && apt-get install -y procps \
+      && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# Instruct R processes to use these empty files instead of clashing with a local version
+RUN touch .Rprofile
+RUN touch .Renviron

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3:4.8.2
+FROM continuumio/miniconda3:4.9.2
 LABEL authors="phil.ewels@scilifelab.se,alexander.peltzer@boehringer-ingelheim.com" \
       description="Docker image containing base requirements for the nfcore pipelines"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM continuumio/miniconda3:4.8.2
-LABEL authors="phil.ewels@scilifelab.se,alexander.peltzer@qbic.uni-tuebingen.de" \
+LABEL authors="phil.ewels@scilifelab.se,alexander.peltzer@boehringer-ingelheim.com" \
       description="Docker image containing base requirements for the nfcore pipelines"
 
 # Install procps so that Nextflow can poll CPU usage and

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/Dockerfile
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/Dockerfile
@@ -11,7 +11,3 @@ ENV PATH /opt/conda/envs/{{ cookiecutter.name_noslash }}-{{ cookiecutter.version
 
 # Dump the details of the installed packages to a file for posterity
 RUN conda env export --name {{ cookiecutter.name_noslash }}-{{ cookiecutter.version }} > {{ cookiecutter.name_noslash }}-{{ cookiecutter.version }}.yml
-
-# Instruct R processes to use these empty files instead of clashing with a local version
-RUN touch .Rprofile
-RUN touch .Renviron


### PR DESCRIPTION
I don't think that these commands need to go out into all pipelines. Simpler and less error prone if they are instead added to the base image that all other DSL1 containers are built from.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
