### PR TITLE
Schema validate max resources

### DIFF
--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow_schema.json
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow_schema.json
@@ -174,6 +174,7 @@
                     "description": "Maximum amount of memory that can be requested for any single job.",
                     "default": "128.GB",
                     "fa_icon": "fas fa-memory",
+                    "pattern": "^[\\d\\.]+\\.(K|M|G|T)?B$",
                     "hidden": true,
                     "help_text": "Use to set an upper-limit for the memory requirement for each process. Should be a string in the format integer-unit e.g. `--max_memory '8.GB'`"
                 },
@@ -182,6 +183,7 @@
                     "description": "Maximum amount of time that can be requested for any single job.",
                     "default": "240.h",
                     "fa_icon": "far fa-clock",
+                    "pattern": "^[\\d\\.]+\\.(s|m|h|d)$",
                     "hidden": true,
                     "help_text": "Use to set an upper-limit for the time requirement for each process. Should be a string in the format integer-unit e.g. `--max_time '2.h'`"
                 }

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow_schema.json
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow_schema.json
@@ -109,13 +109,6 @@
                     "description": "Boolean whether to validate parameters against the schema at runtime",
                     "default": true
                 },
-                "name": {
-                    "type": "string",
-                    "description": "Workflow name.",
-                    "fa_icon": "fas fa-fingerprint",
-                    "hidden": true,
-                    "help_text": "A custom name for the pipeline run. Unlike the core nextflow `-name` option with one hyphen this parameter can be reused multiple times, for example if using `-resume`. Passed through to steps such as MultiQC and used for things like report filenames and titles."
-                },
                 "email_on_fail": {
                     "type": "string",
                     "description": "Email address for completion summary, only when pipeline fails.",


### PR DESCRIPTION
* Remove `--name` from the schema since we removed this core nextflow option from `nextflow.config` in #852 (throws a linting warning instead of fail, so wasn't caught by the CI)
* Added `pattern` regexes for validation of `--max_memory` and `--max_time`
  * Patterns are fairly strict - must now be in the format `123.GB` or `456.h`
  * Used the prefixes listed on the nextflow docs, neither now allowed without any prefix (e.g.`789`)
  * `--max_cpus` is already set as an `int` so fully validated already

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
