### PR TITLE
remove warning from output.md file

### DIFF
--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/output.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/output.md
@@ -1,7 +1,5 @@
 # {{ cookiecutter.name }}: Output
 
-> _Documentation of pipeline parameters is generated automatically from the pipeline schema and can no longer be found in markdown files._
-
 ## Introduction
 
 This document describes the output produced by the pipeline. Most of the plots are taken from the MultiQC report, which summarises results at the end of the pipeline.

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/output.md
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/docs/output.md
@@ -1,7 +1,5 @@
 # {{ cookiecutter.name }}: Output
 
-## :warning: Please read this documentation on the nf-core website: [https://nf-co.re/{{ cookiecutter.short_name }}/output](https://nf-co.re/{{ cookiecutter.short_name }}/output)
-
 > _Documentation of pipeline parameters is generated automatically from the pipeline schema and can no longer be found in markdown files._
 
 ## Introduction


### PR DESCRIPTION
Remove warning from `output.md` in the template as discussed here:
https://github.com/nf-core/tools/issues/810