### PR TITLE
Fix bug in unexpected param log with false values.

### DIFF
--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/lib/NfcoreSchema.groovy
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/lib/NfcoreSchema.groovy
@@ -18,13 +18,12 @@ class NfcoreSchema {
     * whether the given paremeters adhere to the specificiations
     */
     /* groovylint-disable-next-line UnusedPrivateMethodParameter */
-    private static ArrayList validateParameters(params, jsonSchema, log) {
+    private static void validateParameters(params, jsonSchema, log) {
         def has_error = false
         //=====================================================================//
         // Check for nextflow core params and unexpected params
         def json = new File(jsonSchema).text
         def Map schemaParams = (Map) new JsonSlurper().parseText(json).get('definitions')
-        def specifiedParamKeys = params.keySet()
         def nf_params = [
             // Options for base `nextflow` command
             'bg',
@@ -105,7 +104,7 @@ class NfcoreSchema {
             }
         }
 
-        for (specifiedParam in specifiedParamKeys) {
+        for (specifiedParam in params.keySet()) {
             // nextflow params
             if (nf_params.contains(specifiedParam)) {
                 log.error "ERROR: You used a core Nextflow option with two hyphens: '--${specifiedParam}'. Please resubmit with '-${specifiedParam}'"
@@ -144,26 +143,21 @@ class NfcoreSchema {
         }
 
         // Check for unexpected parameters
-        // Getting this message a lot for parameters that you *do* expect?
-        // You can make a csv list of expected params not in the schema with 'params.schema_ignore_params'
-        // for example, in your institutional config
         if (unexpectedParams.size() > 0) {
             Map colors = log_colours(params.monochrome_logs)
             println ''
             def warn_msg = 'Found unexpected parameters:'
             for (unexpectedParam in unexpectedParams) {
-                warn_msg = warn_msg + "\n* --${unexpectedParam}: ${paramsJSON[unexpectedParam].toString()}"
+                warn_msg = warn_msg + "\n* --${unexpectedParam}: ${params[unexpectedParam].toString()}"
             }
             log.warn warn_msg
-            log.info "- ${colors.dim}(Hide this message with 'params.schema_ignore_params')${colors.reset} -"
+            log.info "- ${colors.dim}Ignore this warning: params.schema_ignore_params = \"${unexpectedParams.join(',')}\" ${colors.reset}"
             println ''
         }
 
         if (has_error) {
             System.exit(1)
         }
-
-        return unexpectedParams
     }
 
     // Loop over nested exceptions and print the causingException

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
@@ -24,9 +24,8 @@ if (params.help) {
 ////////////////////////////////////////////////////
 /* --         VALIDATE PARAMETERS              -- */
 ////////////////////////////////////////////////////+
-def unexpectedParams = []
 if (params.validate_params) {
-    unexpectedParams = NfcoreSchema.validateParameters(params, json_schema, log)
+    NfcoreSchema.validateParameters(params, json_schema, log)
 }
 
 ////////////////////////////////////////////////////
@@ -365,10 +364,8 @@ workflow.onComplete {
 }
 
 workflow.onError {
-    // Print unexpected parameters
-    for (p in unexpectedParams) {
-        log.warn "Unexpected parameter: ${p}"
-    }
+    // Print unexpected parameters - easiest is to just rerun validation
+    NfcoreSchema.validateParameters(params, json_schema, log)
 }
 
 def checkHostname() {

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
@@ -12,6 +12,7 @@ params {
   // TODO nf-core: Specify your pipeline's command line flags
   genome = false
   input = null
+  input_paths = null
   single_end = false
   outdir = './results'
   publish_dir_mode = 'copy'
@@ -34,7 +35,7 @@ params {
   config_profile_contact = false
   config_profile_url = false
   validate_params = true
-  schema_ignore_params = 'genomes'
+  schema_ignore_params = 'genomes,input_paths'
 
   // Defaults only, expecting to be overwritten
   max_memory = 128.GB
@@ -58,13 +59,13 @@ try {
 }
 
 profiles {
-  conda { 
+  conda {
     docker.enabled = false
     singularity.enabled = false
     podman.enabled = false
     shifter.enabled = false
     charliecloud = false
-    process.conda = "$projectDir/environment.yml" 
+    process.conda = "$projectDir/environment.yml"
   }
   debug { process.beforeScript = 'echo $HOSTNAME' }
   docker {
@@ -101,7 +102,7 @@ profiles {
     shifter.enabled = true
     charliecloud.enabled = false
   }
-  charliecloud { 
+  charliecloud {
     singularity.enabled = false
     docker.enabled = false
     podman.enabled = false


### PR DESCRIPTION
Follow-on to https://github.com/nf-core/tools/pull/857

Tried to add `params.input_paths = null` to `nextflow.config` to avoid the warning that Nextflow threw about undefined params and hit a bug in the new unexpected params code:

```
JSONObject["input_paths"] not found.
 -- Check script 'nf-core-test/main.nf' at line: 28 or see '.nextflow.log' file for more details
```

After a bit of digging I figured out that it was because this code was removing anything evaluating to `false` from the parameters map:

https://github.com/nf-core/tools/blob/729f03ae5bd13ce588e367d333d594fb2185f482/nf_core/pipeline-template/%7B%7Bcookiecutter.name_noslash%7D%7D/lib/NfcoreSchema.groovy#L197-L200

So just switching to use `params` instead of `cleanedParams` when printing the value of the unexpected parameter solved the issue.

Also included a couple of other minor tweaks, notably just repeating the validation at the end of the pipeline. This is so that we don't have to repeat the code that prints the warnings so a bit less code maintenance in the main pipeline.