### PR TITLE
Make --help output look nicer

### DIFF
--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/lib/NfcoreSchema.groovy
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/lib/NfcoreSchema.groovy
@@ -358,23 +358,37 @@ class NfcoreSchema {
      */
     private static String params_help(workflow, params, json_schema, command) {
         Map colors = log_colours(params.monochrome_logs)
+        Integer num_hidden = 0
         String output  = ''
         output        += 'Typical pipeline command:\n\n'
         output        += "    ${colors.cyan}${command}${colors.reset}\n\n"
         def params_map = params_load(json_schema)
         def max_chars  = params_max_chars(params_map) + 1
         for (group in params_map.keySet()) {
-            output += colors.underlined + colors.bold + group + colors.reset + '\n'
+            Integer num_params = 0
+            String group_output = colors.underlined + colors.bold + group + colors.reset + '\n'
             def group_params = params_map.get(group)  // This gets the parameters of that particular group
             for (param in group_params.keySet()) {
+                if (group_params.get(param).hidden && !params.show_hidden_params) {
+                    num_hidden += 1
+                    continue;
+                }
                 def type = '[' + group_params.get(param).type + ']'
                 def description = group_params.get(param).description
                 def defaultValue = group_params.get(param).default ? " [default: " + group_params.get(param).default.toString() + "]" : ''
-                output += "    --" +  param.padRight(max_chars) + colors.dim + type.padRight(10) + colors.reset + description + colors.dim + defaultValue + colors.reset + '\n'
+                group_output += "  --" +  param.padRight(max_chars) + colors.dim + type.padRight(10) + colors.reset + description + colors.dim + defaultValue + colors.reset + '\n'
+                num_params += 1
             }
-            output += '\n'
+            group_output += '\n'
+            if (num_params > 0){
+                output += group_output
+            }
         }
         output += dashed_line(params.monochrome_logs)
+        if (num_hidden > 0){
+            output += colors.dim + "\n Hiding $num_hidden params, use --show_hidden_params to show.\n" + colors.reset
+            output += dashed_line(params.monochrome_logs)
+        }
         return output
     }
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/lib/NfcoreSchema.groovy
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/lib/NfcoreSchema.groovy
@@ -224,17 +224,66 @@ class NfcoreSchema {
 
     private static Map log_colours(Boolean monochrome_logs) {
         Map colorcodes = [:]
+
+        // Reset / Meta
         colorcodes['reset']       = monochrome_logs ? '' : "\033[0m"
+        colorcodes['bold']        = monochrome_logs ? '' : "\033[1m"
         colorcodes['dim']         = monochrome_logs ? '' : "\033[2m"
+        colorcodes['underlined']  = monochrome_logs ? '' : "\033[4m"
+        colorcodes['blink']       = monochrome_logs ? '' : "\033[5m"
+        colorcodes['reverse']     = monochrome_logs ? '' : "\033[7m"
+        colorcodes['hidden']      = monochrome_logs ? '' : "\033[8m"
+
+        // Regular Colors
         colorcodes['black']       = monochrome_logs ? '' : "\033[0;30m"
+        colorcodes['red']         = monochrome_logs ? '' : "\033[0;31m"
         colorcodes['green']       = monochrome_logs ? '' : "\033[0;32m"
-        colorcodes['yellow']      = monochrome_logs ? '' :  "\033[0;33m"
-        colorcodes['yellow_bold'] = monochrome_logs ? '' : "\033[1;93m"
+        colorcodes['yellow']      = monochrome_logs ? '' : "\033[0;33m"
         colorcodes['blue']        = monochrome_logs ? '' : "\033[0;34m"
         colorcodes['purple']      = monochrome_logs ? '' : "\033[0;35m"
         colorcodes['cyan']        = monochrome_logs ? '' : "\033[0;36m"
         colorcodes['white']       = monochrome_logs ? '' : "\033[0;37m"
-        colorcodes['red']         = monochrome_logs ? '' : "\033[1;91m"
+
+        // Bold
+        colorcodes['bblack']      = monochrome_logs ? '' : "\033[1;30m"
+        colorcodes['bred']        = monochrome_logs ? '' : "\033[1;31m"
+        colorcodes['bgreen']      = monochrome_logs ? '' : "\033[1;32m"
+        colorcodes['byellow']     = monochrome_logs ? '' : "\033[1;33m"
+        colorcodes['bblue']       = monochrome_logs ? '' : "\033[1;34m"
+        colorcodes['bpurple']     = monochrome_logs ? '' : "\033[1;35m"
+        colorcodes['bcyan']       = monochrome_logs ? '' : "\033[1;36m"
+        colorcodes['bwhite']      = monochrome_logs ? '' : "\033[1;37m"
+
+        // Underline
+        colorcodes['ublack']      = monochrome_logs ? '' : "\033[4;30m"
+        colorcodes['ured']        = monochrome_logs ? '' : "\033[4;31m"
+        colorcodes['ugreen']      = monochrome_logs ? '' : "\033[4;32m"
+        colorcodes['uyellow']     = monochrome_logs ? '' : "\033[4;33m"
+        colorcodes['ublue']       = monochrome_logs ? '' : "\033[4;34m"
+        colorcodes['upurple']     = monochrome_logs ? '' : "\033[4;35m"
+        colorcodes['ucyan']       = monochrome_logs ? '' : "\033[4;36m"
+        colorcodes['uwhite']      = monochrome_logs ? '' : "\033[4;37m"
+
+        // High Intensity
+        colorcodes['iblack']      = monochrome_logs ? '' : "\033[0;90m"
+        colorcodes['ired']        = monochrome_logs ? '' : "\033[0;91m"
+        colorcodes['igreen']      = monochrome_logs ? '' : "\033[0;92m"
+        colorcodes['iyellow']     = monochrome_logs ? '' : "\033[0;93m"
+        colorcodes['iblue']       = monochrome_logs ? '' : "\033[0;94m"
+        colorcodes['ipurple']     = monochrome_logs ? '' : "\033[0;95m"
+        colorcodes['icyan']       = monochrome_logs ? '' : "\033[0;96m"
+        colorcodes['iwhite']      = monochrome_logs ? '' : "\033[0;97m"
+
+        // Bold High Intensity
+        colorcodes['biblack']     = monochrome_logs ? '' : "\033[1;90m"
+        colorcodes['bired']       = monochrome_logs ? '' : "\033[1;91m"
+        colorcodes['bigreen']     = monochrome_logs ? '' : "\033[1;92m"
+        colorcodes['biyellow']    = monochrome_logs ? '' : "\033[1;93m"
+        colorcodes['biblue']      = monochrome_logs ? '' : "\033[1;94m"
+        colorcodes['bipurple']    = monochrome_logs ? '' : "\033[1;95m"
+        colorcodes['bicyan']      = monochrome_logs ? '' : "\033[1;96m"
+        colorcodes['biwhite']     = monochrome_logs ? '' : "\033[1;97m"
+
         return colorcodes
     }
 
@@ -308,24 +357,24 @@ class NfcoreSchema {
      * Beautify parameters for --help
      */
     private static String params_help(workflow, params, json_schema, command) {
+        Map colors = log_colours(params.monochrome_logs)
         String output  = ''
         output        += 'Typical pipeline command:\n\n'
-        output        += "    ${command}\n\n"
+        output        += "    ${colors.cyan}${command}${colors.reset}\n\n"
         def params_map = params_load(json_schema)
         def max_chars  = params_max_chars(params_map) + 1
         for (group in params_map.keySet()) {
-            output += group + '\n'
+            output += colors.underlined + colors.bold + group + colors.reset + '\n'
             def group_params = params_map.get(group)  // This gets the parameters of that particular group
             for (param in group_params.keySet()) {
                 def type = '[' + group_params.get(param).type + ']'
                 def description = group_params.get(param).description
-                def defaultValue = group_params.get(param).default ? "  [default: " + group_params.get(param).default.toString() + "]" : ''
-                output += "    \u001B[1m--" +  param.padRight(max_chars) + "\u001B[1m" + type.padRight(10) + description + defaultValue + '\n'
+                def defaultValue = group_params.get(param).default ? " [default: " + group_params.get(param).default.toString() + "]" : ''
+                output += "    --" +  param.padRight(max_chars) + colors.dim + type.padRight(10) + colors.reset + description + colors.dim + defaultValue + colors.reset + '\n'
             }
             output += '\n'
         }
         output += dashed_line(params.monochrome_logs)
-        output += '\n\n' + dashed_line(params.monochrome_logs)
         return output
     }
 

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/main.nf
@@ -14,7 +14,7 @@ log.info Headers.nf_core(workflow, params.monochrome_logs)
 ////////////////////////////////////////////////////
 /* --               PRINT HELP                 -- */
 ////////////////////////////////////////////////////+
-def json_schema = "$baseDir/nextflow_schema.json"
+def json_schema = "$projectDir/nextflow_schema.json"
 if (params.help) {
     def command = "nextflow run {{ cookiecutter.name }} --input '*_R{1,2}.fastq.gz' -profile docker"
     log.info NfcoreSchema.params_help(workflow, params, json_schema, command)

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow.config
@@ -35,6 +35,7 @@ params {
   config_profile_contact = false
   config_profile_url = false
   validate_params = true
+  show_hidden_params = false
   schema_ignore_params = 'genomes,input_paths'
 
   // Defaults only, expecting to be overwritten

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow_schema.json
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow_schema.json
@@ -107,7 +107,8 @@
                 "validate_params": {
                     "type": "boolean",
                     "description": "Boolean whether to validate parameters against the schema at runtime",
-                    "default": true
+                    "default": true,
+                    "fa_icon": "fas fa-check-square"
                 },
                 "email_on_fail": {
                     "type": "string",
@@ -151,6 +152,13 @@
                     "default": "${params.outdir}/pipeline_info",
                     "fa_icon": "fas fa-cogs",
                     "hidden": true
+                },
+                "show_hidden_params": {
+                    "type": "boolean",
+                    "fa_icon": "far fa-eye-slash",
+                    "description": "Show all params when using `--help`",
+                    "hidden": true,
+                    "help_text": "By default, parameters set as _hidden_ in the schema are not shown on the command line when a user runs with `--help`. Specifying this option will tell the pipeline to show all parameters."
                 }
             }
         },

--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow_schema.json
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/nextflow_schema.json
@@ -108,7 +108,8 @@
                     "type": "boolean",
                     "description": "Boolean whether to validate parameters against the schema at runtime",
                     "default": true,
-                    "fa_icon": "fas fa-check-square"
+                    "fa_icon": "fas fa-check-square",
+                    "hidden": true
                 },
                 "email_on_fail": {
                     "type": "string",


### PR DESCRIPTION
* Improved the colours map to include all colour variants and styles
* Removed broken ascii colour codes in help output (it was missing a reset code)
* Added nicer colouring to the help output
* Removed duplicate dashed line at the end of the help block
* Replaced `baseDir` with `projectDir` for schema path

Before:

![image](https://user-images.githubusercontent.com/465550/110945838-7b9c8b80-833e-11eb-9603-4b96dda36fda.png)

After:

![image](https://user-images.githubusercontent.com/465550/110945867-848d5d00-833e-11eb-9334-8f7b81225f0f.png)
