### PR TITLE
Dockstore pipeline config - add publish:True

### DIFF
--- a/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/.dockstore.yml
+++ b/nf_core/pipeline-template/{{cookiecutter.name_noslash}}/.github/.dockstore.yml
@@ -3,3 +3,4 @@ version: 1.2
 workflows:
   - subclass: nfl
     primaryDescriptorPath: /nextflow.config
+    publish: True


### PR DESCRIPTION
Add new parameter to Dockstore config YAML file that tells Dockstore to automatically publish newly discovered workflows. This means that we don't need to go in to Dockstore and manually publish any new workflows, as soon as the new repo is added to nf-core it should show up publicly on Dockstore 🥳 

See dockstore/dockstore#3876 for details.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
