### PR TITLE
Make all modules commands use --tool and fuzzy module name input

### DIFF
--- a/.github/workflows/create-lint-wf.yml
+++ b/.github/workflows/create-lint-wf.yml
@@ -36,7 +36,7 @@ jobs:
           nf-core --log-file log.txt sync nf-core-testpipeline/
           nf-core --log-file log.txt schema build nf-core-testpipeline/ --no-prompts
           nf-core --log-file log.txt bump-version nf-core-testpipeline/ 1.1
-          nf-core --log-file log.txt modules install nf-core-testpipeline/ fastqc
+          nf-core --log-file log.txt modules install nf-core-testpipeline/ --tool fastqc
 
       - name: Upload log file artifact
         uses: actions/upload-artifact@v2

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -367,22 +367,20 @@ def list(ctx, pipeline_dir, json):
     """
     mods = nf_core.modules.PipelineModules()
     mods.modules_repo = ctx.obj["modules_repo_obj"]
-    print(mods.list_modules(pipeline_dir, json))
+    mods.pipeline_dir = pipeline_dir
+    print(mods.list_modules(json))
 
 
 @modules.command(help_priority=2)
 @click.pass_context
 @click.argument("pipeline_dir", type=click.Path(exists=True), required=True, metavar="<pipeline directory>")
-@click.argument("tool", type=str, required=False, metavar="(<tool name>)")
+@click.option("-t", "--tool", type=str, metavar="<tool> or <tool/subtool>")
 def install(ctx, pipeline_dir, tool):
     """
     Add a DSL2 software wrapper module to a pipeline.
 
-    Given a software name, finds the relevant files in nf-core/modules
-    and copies to the pipeline along with associated metadata.
-
-    If <tool name> is not supplied on the command line, an interactive fuzzy-finder
-    tool is given with available nf-core module names.
+    Finds the relevant files in nf-core/modules and copies to the pipeline,
+    along with associated metadata.
     """
     try:
         mods = nf_core.modules.PipelineModules()
@@ -418,7 +416,7 @@ def install(ctx, pipeline_dir, tool):
 @modules.command(help_priority=4)
 @click.pass_context
 @click.argument("pipeline_dir", type=click.Path(exists=True), required=True, metavar="<pipeline directory>")
-@click.argument("tool", type=str, required=True, metavar="<tool name>")
+@click.option("-t", "--tool", type=str, metavar="<tool> or <tool/subtool>")
 def remove(ctx, pipeline_dir, tool):
     """
     Remove a software wrapper from a pipeline.
@@ -436,7 +434,7 @@ def remove(ctx, pipeline_dir, tool):
 @modules.command("create", help_priority=5)
 @click.pass_context
 @click.argument("directory", type=click.Path(exists=True), required=True, metavar="<directory>")
-@click.argument("tool", type=str, required=True, metavar="<tool/subtool>")
+@click.option("-t", "--tool", type=str, metavar="<tool> or <tool/subtool>")
 @click.option("-a", "--author", type=str, metavar="<author>", help="Module author's GitHub username")
 @click.option("-l", "--label", type=str, metavar="<process label>", help="Standard resource label for process")
 @click.option("-m", "--meta", is_flag=True, default=False, help="Use Groovy meta map for sample information")
@@ -445,10 +443,6 @@ def remove(ctx, pipeline_dir, tool):
 def create_module(ctx, directory, tool, author, label, meta, no_meta, force):
     """
     Create a new DSL2 module from the nf-core template.
-
-    \b
-    Tool should be named just <tool> or <tool/subtool>
-    e.g fastqc or samtools/sort, respectively.
 
     If <directory> is a pipeline, this function creates a file called
     'modules/local/tool_subtool.nf'
@@ -476,23 +470,20 @@ def create_module(ctx, directory, tool, author, label, meta, no_meta, force):
 
 @modules.command("create-test-yml", help_priority=6)
 @click.pass_context
-@click.argument("module", type=str, required=True, metavar="<module name>")
+@click.option("-t", "--tool", type=str, metavar="<tool> or <tool/subtool>")
 @click.option("-r", "--run-tests", is_flag=True, default=False, help="Run the test workflows")
 @click.option("-o", "--output", type=str, help="Path for output YAML file")
 @click.option("-f", "--force", is_flag=True, default=False, help="Overwrite output YAML file if it already exists")
 @click.option("-p", "--no-prompts", is_flag=True, default=False, help="Use defaults without prompting")
-def create_test_yml(ctx, module, run_tests, output, force, no_prompts):
+def create_test_yml(ctx, tool, run_tests, output, force, no_prompts):
     """
     Auto-generate a test.yml file for a new module.
 
-    Given the name of a new module, run the Nextflow test command and automatically generate
+    Given the name of a module, runs the Nextflow test command and automatically generate
     the required `test.yml` file based on the output files.
-
-    If not supplied on the command line, tool will prompt for name, command, tags etc with
-    sensible defaults.
     """
     try:
-        meta_builder = nf_core.modules.ModulesTestYmlBuilder(module, run_tests, output, force, no_prompts)
+        meta_builder = nf_core.modules.ModulesTestYmlBuilder(tool, run_tests, output, force, no_prompts)
         meta_builder.run()
     except UserWarning as e:
         log.critical(e)

--- a/nf_core/modules/create.py
+++ b/nf_core/modules/create.py
@@ -78,6 +78,8 @@ class ModuleCreate(object):
         )
 
         # Collect module info via prompt if empty or invalid
+        if self.tool is None:
+            self.tool = ""
         while self.tool == "" or re.search(r"[^a-z\d/]", self.tool) or self.tool.count("/") > 0:
 
             # Check + auto-fix for invalid chacters

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -31,10 +31,10 @@ nfcore_question_style = prompt_toolkit.styles.Style(
     [
         ("qmark", "fg:ansiblue bold"),  # token in front of the question
         ("question", "bold"),  # question text
-        ("answer", "fg:ansigreen nobold"),  # submitted answer text behind the question
+        ("answer", "fg:ansigreen nobold bg:"),  # submitted answer text behind the question
         ("pointer", "fg:ansiyellow bold"),  # pointer used in select and checkbox prompts
         ("highlighted", "fg:ansiblue bold"),  # pointed-at choice in select and checkbox prompts
-        ("selected", "fg:ansigreen noreverse"),  # style for a selected item of a checkbox
+        ("selected", "fg:ansiyellow noreverse bold"),  # style for a selected item of a checkbox
         ("separator", "fg:ansiblack"),  # separator in lists
         ("instruction", ""),  # user instructions for select, rawselect, checkbox
         ("text", ""),  # plain text
@@ -44,6 +44,7 @@ nfcore_question_style = prompt_toolkit.styles.Style(
         ("choice-required", "fg:ansired"),
     ]
 )
+
 
 def check_if_outdated(current_version=None, remote_version=None, source_url="https://nf-co.re/tools_version"):
     """


### PR DESCRIPTION
All `nf-core modules` commands now take the module name as an option instead of argument (`--tool` instead of positional) and are able to run if it is not given. If not supplied, all tools use the cool fuzzy-finder interface thing to collect module name.