### PR TITLE
Use gh cli auth details for GH API if we can

### DIFF
--- a/nf_core/modules/pipeline_modules.py
+++ b/nf_core/modules/pipeline_modules.py
@@ -176,7 +176,7 @@ class PipelineModules(object):
         api_url = "https://api.github.com/repos/{}/git/trees/{}?recursive=1".format(
             self.modules_repo.name, self.modules_repo.branch
         )
-        r = requests.get(api_url)
+        r = requests.get(api_url, auth=nf_core.utils.github_api_auto_auth())
         if r.status_code == 404:
             log.error(
                 "Repository / branch not found: {} ({})\n{}".format(
@@ -250,7 +250,7 @@ class PipelineModules(object):
             os.makedirs(dl_directory)
 
         # Call the GitHub API
-        r = requests.get(api_url)
+        r = requests.get(api_url, auth=nf_core.utils.github_api_auto_auth())
         if r.status_code != 200:
             raise SystemError("Could not fetch {} file: {}\n {}".format(self.modules_repo.name, r.status_code, api_url))
         result = r.json()

--- a/nf_core/sync.py
+++ b/nf_core/sync.py
@@ -2,16 +2,13 @@
 """Synchronise a pipeline TEMPLATE branch with the template.
 """
 
-import click
 import git
 import json
 import logging
 import os
-import re
 import requests
 import requests_cache
 import shutil
-import tempfile
 
 import nf_core
 import nf_core.create

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -45,6 +45,7 @@ nfcore_question_style = prompt_toolkit.styles.Style(
     ]
 )
 
+
 def check_if_outdated(current_version=None, remote_version=None, source_url="https://nf-co.re/tools_version"):
     """
     Check if the current version of nf-core is outdated
@@ -74,6 +75,17 @@ def rich_force_colors():
     """
     if os.getenv("GITHUB_ACTIONS") or os.getenv("FORCE_COLOR") or os.getenv("PY_COLORS"):
         return True
+    return None
+
+
+def github_api_auto_auth():
+    try:
+        with open(os.path.join(os.path.expanduser("~/.config/gh/hosts.yml")), "r") as fh:
+            auth = yaml.safe_load(fh)
+            log.debug("Auto-authenticating GitHub API as '@{}'".format(auth["github.com"]["user"]))
+            return requests.auth.HTTPBasicAuth(auth["github.com"]["user"], auth["github.com"]["oauth_token"])
+    except Exception as e:
+        log.debug(f"Couldn't auto-auth for GitHub: [red]{e}")
     return None
 
 


### PR DESCRIPTION
If you use the GitHub `gh` command line tools (https://cli.github.com) then you will have a local config file set up at `~/.config/gh/hosts.yml` with your oauth token. You can see this with the command `gh auth status`.

This PR checks if that file exists and tries to parse your username and token. If successful, it passes these as authentication in the GitHub API calls used by `nf-core modules install` to increase the rate-limit cap on the API.