### PR TITLE
Lint fail on ignore

### DIFF
--- a/.github/workflows/create-lint-wf.yml
+++ b/.github/workflows/create-lint-wf.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run nf-core/tools
         run: |
           nf-core --log-file log.txt create -n testpipeline -d "This pipeline is for testing" -a "Testing McTestface"
-          nf-core --log-file log.txt lint nf-core-testpipeline
+          nf-core --log-file log.txt lint nf-core-testpipeline --fail-ignored
           nf-core --log-file log.txt list
           nf-core --log-file log.txt licences nf-core-testpipeline
           nf-core --log-file log.txt sync nf-core-testpipeline/

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -306,9 +306,10 @@ def create(name, description, author, version, no_git, force, outdir):
     "-f", "--fix", type=str, metavar="<test>", multiple=True, help="Attempt to automatically fix specified lint test"
 )
 @click.option("-p", "--show-passed", is_flag=True, help="Show passing tests on the command line")
+@click.option("-i", "--fail-ignored", is_flag=True, help="Convert ignored tests to failures")
 @click.option("--markdown", type=str, metavar="<filename>", help="File to write linting results to (Markdown)")
 @click.option("--json", type=str, metavar="<filename>", help="File to write linting results to (JSON)")
-def lint(pipeline_dir, release, fix, show_passed, markdown, json):
+def lint(pipeline_dir, release, fix, show_passed, fail_ignored, markdown, json):
     """
     Check pipeline code against nf-core guidelines.
 
@@ -319,7 +320,7 @@ def lint(pipeline_dir, release, fix, show_passed, markdown, json):
 
     # Run the lint tests!
     try:
-        lint_obj = nf_core.lint.run_linting(pipeline_dir, release, fix, show_passed, markdown, json)
+        lint_obj = nf_core.lint.run_linting(pipeline_dir, release, fix, show_passed, fail_ignored, markdown, json)
         if len(lint_obj.failed) > 0:
             sys.exit(1)
     except AssertionError as e:

--- a/nf_core/lint/__init__.py
+++ b/nf_core/lint/__init__.py
@@ -24,7 +24,9 @@ import nf_core.utils
 log = logging.getLogger(__name__)
 
 
-def run_linting(pipeline_dir, release_mode=False, fix=(), show_passed=False, fail_ignored=False, md_fn=None, json_fn=None):
+def run_linting(
+    pipeline_dir, release_mode=False, fix=(), show_passed=False, fail_ignored=False, md_fn=None, json_fn=None
+):
     """Runs all nf-core linting checks on a given Nextflow pipeline project
     in either `release` mode or `normal` mode (default). Returns an object
     of type :class:`PipelineLint` after finished.


### PR DESCRIPTION
New feature for main pipeline linting - flag `--fail-on-ignore`.

Not useful for much except the CI tests for tools itself. No tests should be ignored on a vanilla template so this lets us check that there isn't any funky stuff going on.