### PR TITLE
Ignore --input schema in test.config

### DIFF
--- a/nf_core/pipeline-template/conf/test.config
+++ b/nf_core/pipeline-template/conf/test.config
@@ -23,4 +23,6 @@ params {
     ['Testdata', ['https://github.com/nf-core/test-datasets/raw/exoseq/testdata/Testdata_R1.tiny.fastq.gz', 'https://github.com/nf-core/test-datasets/raw/exoseq/testdata/Testdata_R2.tiny.fastq.gz']],
     ['SRR389222', ['https://github.com/nf-core/test-datasets/raw/methylseq/testdata/SRR389222_sub1.fastq.gz', 'https://github.com/nf-core/test-datasets/raw/methylseq/testdata/SRR389222_sub2.fastq.gz']]
   ]
+  // Ignore `--input` as otherwise the parameter validation will throw an error
+  schema_ignore_params = 'genomes,input_paths,input'
 }

--- a/nf_core/pipeline-template/conf/test_full.config
+++ b/nf_core/pipeline-template/conf/test_full.config
@@ -19,4 +19,6 @@ params {
     ['Testdata', ['https://github.com/nf-core/test-datasets/raw/exoseq/testdata/Testdata_R1.tiny.fastq.gz', 'https://github.com/nf-core/test-datasets/raw/exoseq/testdata/Testdata_R2.tiny.fastq.gz']],
     ['SRR389222', ['https://github.com/nf-core/test-datasets/raw/methylseq/testdata/SRR389222_sub1.fastq.gz', 'https://github.com/nf-core/test-datasets/raw/methylseq/testdata/SRR389222_sub2.fastq.gz']]
   ]
+  // Ignore `--input` as otherwise the parameter validation will throw an error
+  schema_ignore_params = 'genomes,input_paths,input'
 }


### PR DESCRIPTION
Fix the test CI workflow by ignoring `--input` from the schema, which is not used in this config.