### PR TITLE
Do not show None on test.yml name when subtool is missing

### DIFF
--- a/nf_core/module-template/tests/test.yml
+++ b/nf_core/module-template/tests/test.yml
@@ -1,6 +1,6 @@
 ## TODO nf-core: Please run the following command to build this file:
 #                nf-core modules create-test-yml {{ tool }}/{{ subtool }}
-- name: {{ tool }} {{ subtool }}
+- name: {{ tool_test_name }}
   command: nextflow run ./tests/software/{{ tool_dir }} -entry test_{{ tool_name }} -c tests/config/nextflow.config
   tags:
     - {{ tool }}

--- a/nf_core/module-template/tests/test.yml
+++ b/nf_core/module-template/tests/test.yml
@@ -1,6 +1,6 @@
 ## TODO nf-core: Please run the following command to build this file:
 #                nf-core modules create-test-yml {{ tool }}/{{ subtool }}
-- name: {{ tool }} {{ subtool if subtool != None else '' }}
+- name: {{ tool }}{{ ' '+subtool if subtool else '' }}
   command: nextflow run ./tests/software/{{ tool_dir }} -entry test_{{ tool_name }} -c tests/config/nextflow.config
   tags:
     - {{ tool }}

--- a/nf_core/module-template/tests/test.yml
+++ b/nf_core/module-template/tests/test.yml
@@ -1,6 +1,6 @@
 ## TODO nf-core: Please run the following command to build this file:
 #                nf-core modules create-test-yml {{ tool }}/{{ subtool }}
-- name: {{ tool_test_name }}
+- name: {{ tool }} {{ subtool if subtool != None else '' }}
   command: nextflow run ./tests/software/{{ tool_dir }} -entry test_{{ tool_name }} -c tests/config/nextflow.config
   tags:
     - {{ tool }}

--- a/nf_core/modules/create.py
+++ b/nf_core/modules/create.py
@@ -107,7 +107,6 @@ class ModuleCreate(object):
         # Determine the tool name
         self.tool_name = self.tool
         self.tool_dir = self.tool
-        self.tool_test_name = self.tool
 
         if self.subtool:
             self.tool_name = f"{self.tool}_{self.subtool}"

--- a/nf_core/modules/create.py
+++ b/nf_core/modules/create.py
@@ -108,7 +108,7 @@ class ModuleCreate(object):
         self.tool_name = self.tool
         self.tool_dir = self.tool
         self.tool_test_name = self.tool
-        
+
         if self.subtool:
             self.tool_name = f"{self.tool}_{self.subtool}"
             self.tool_dir = os.path.join(self.tool, self.subtool)

--- a/nf_core/modules/create.py
+++ b/nf_core/modules/create.py
@@ -107,9 +107,12 @@ class ModuleCreate(object):
         # Determine the tool name
         self.tool_name = self.tool
         self.tool_dir = self.tool
+        self.tool_test_name = self.tool
+        
         if self.subtool:
             self.tool_name = f"{self.tool}_{self.subtool}"
             self.tool_dir = os.path.join(self.tool, self.subtool)
+            self.tool_test_name = f"{self.tool} {self.subtool}"
 
         # Check existance of directories early for fast-fail
         self.file_paths = self.get_module_dirs()

--- a/nf_core/modules/create.py
+++ b/nf_core/modules/create.py
@@ -111,7 +111,6 @@ class ModuleCreate(object):
         if self.subtool:
             self.tool_name = f"{self.tool}_{self.subtool}"
             self.tool_dir = os.path.join(self.tool, self.subtool)
-            self.tool_test_name = f"{self.tool} {self.subtool}"
 
         # Check existance of directories early for fast-fail
         self.file_paths = self.get_module_dirs()


### PR DESCRIPTION
When no `subtool` was provided to `modules create`, the  created `test.yml` was rendering the `tag` content: 

`- name: tool_name None`

Changed to render:

`- name: tool_name`


<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 