### PR TITLE
Only one tag on test.yml when no subtool set

### DIFF
--- a/nf_core/module-template/tests/test.yml
+++ b/nf_core/module-template/tests/test.yml
@@ -4,7 +4,9 @@
   command: nextflow run ./tests/software/{{ tool_dir }} -entry test_{{ tool_name }} -c tests/config/nextflow.config
   tags:
     - {{ tool }}
+    {%- if subtool %}
     - {{ tool_name }}
+    {%- endif %}
   files:
     - path: output/{{ tool }}/test.bam
       md5sum: e667c7caad0bc4b7ac383fd023c654fc


### PR DESCRIPTION
When no subtool present, there appear two equal tags on the `test.yml`:

```yaml
tags:
   - tool
   - tool
```
Put a conditional in the template to avoid this behavior.
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 
