### PR TITLE
Fix lint md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # nf-core/tools: Changelog
 
-## v1.14dev
+## v1.13.1dev
 
-_..nothing yet.._
+### Bugs fixed
+
+* Fixed bug in pipeline linting markdown output that gets posted to PR comments [[#914]](https://github.com/nf-core/tools/issues/914)
 
 ## [v1.13 - Copper Crocodile](https://github.com/nf-core/tools/releases/tag/1.13) - [2021-03-18]
 

--- a/nf_core/lint/__init__.py
+++ b/nf_core/lint/__init__.py
@@ -347,6 +347,8 @@ class PipelineLint(nf_core.utils.Pipeline):
         """
         # Overall header
         overall_result = "Passed :white_check_mark:"
+        if len(self.warned) > 0:
+            overall_result += " :warning:"
         if len(self.failed) > 0:
             overall_result = "Failed :x:"
 

--- a/nf_core/lint/__init__.py
+++ b/nf_core/lint/__init__.py
@@ -16,7 +16,6 @@ import os
 import re
 import rich
 import rich.progress
-import textwrap
 import yaml
 
 import nf_core.utils
@@ -431,24 +430,16 @@ class PipelineLint(nf_core.utils.Pipeline):
 
         comment_body_text = "Posted for pipeline commit {}".format(self.git_sha[:7]) if self.git_sha is not None else ""
         timestamp = now.strftime("%Y-%m-%d %H:%M:%S")
-        markdown = textwrap.dedent(
-            f"""
-        #### `nf-core lint` overall result: {overall_result}
-
-        {comment_body_text}
-
-        ```diff{test_passed_count}{test_ignored_count}{test_fixed_count}{test_warning_count}{test_failure_count}
-        ```
-
-        <details>
-
-        {test_failures}{test_warnings}{test_ignored}{test_fixed}{test_passes}### Run details:
-
-        * nf-core/tools version {nf_core.__version__}
-        * Run at `{timestamp}`
-
-        </details>
-        """
+        markdown = (
+            f"#### `nf-core lint` overall result: {overall_result}\n\n"
+            f"{comment_body_text}\n\n"
+            f"```diff{test_passed_count}{test_ignored_count}{test_fixed_count}{test_warning_count}{test_failure_count}\n"
+            "```\n\n"
+            "<details>\n"
+            f"{test_failures}{test_warnings}{test_ignored}{test_fixed}{test_passes}### Run details\n\n"
+            f"* nf-core/tools version {nf_core.__version__}\n"
+            f"* Run at `{timestamp}`\n\n"
+            "</details>\n"
         )
 
         return markdown

--- a/nf_core/lint/__init__.py
+++ b/nf_core/lint/__init__.py
@@ -431,7 +431,7 @@ class PipelineLint(nf_core.utils.Pipeline):
         comment_body_text = "Posted for pipeline commit {}".format(self.git_sha[:7]) if self.git_sha is not None else ""
         timestamp = now.strftime("%Y-%m-%d %H:%M:%S")
         markdown = (
-            f"#### `nf-core lint` overall result: {overall_result}\n\n"
+            f"## `nf-core lint` overall result: {overall_result}\n\n"
             f"{comment_body_text}\n\n"
             f"```diff{test_passed_count}{test_ignored_count}{test_fixed_count}{test_warning_count}{test_failure_count}\n"
             "```\n\n"

--- a/nf_core/pipeline-template/.github/workflows/branch.yml
+++ b/nf_core/pipeline-template/.github/workflows/branch.yml
@@ -23,11 +23,19 @@ jobs:
         uses: mshick/add-pr-comment@v1
         with:
           message: |
+            ## This PR is against the `master` branch :x:
+
+            * Do not close this PR
+            * Click _Edit_ and change the `base` to `dev`
+            * This CI test will remain failed until you push a new commit
+
+            ---
+
             Hi @${{ github.event.pull_request.user.login }},
 
-            It looks like this pull-request is has been made against the ${{github.event.pull_request.base.repo.full_name }} `master` branch.
+            It looks like this pull-request is has been made against the [${{github.event.pull_request.head.repo.full_name }}](https://github.com/${{github.event.pull_request.head.repo.full_name }}) `master` branch.
             The `master` branch on nf-core repositories should always contain code from the latest release.
-            Because of this, PRs to `master` are only allowed if they come from the ${{github.event.pull_request.base.repo.full_name }} `dev` branch.
+            Because of this, PRs to `master` are only allowed if they come from the [${{github.event.pull_request.head.repo.full_name }}](https://github.com/${{github.event.pull_request.head.repo.full_name }}) `dev` branch.
 
             You do not need to close this PR, you can change the target branch to `dev` by clicking the _"Edit"_ button at the top of this page.
             Note that even after this, the test will continue to show as failing until you push a new commit.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 import sys
 
-version = "1.14dev"
+version = "1.13.1dev"
 
 with open("README.md") as f:
     readme = f.read()


### PR DESCRIPTION
Fixes bug in linting markdown output: https://github.com/nf-core/tools/issues/914

Also tweaks the markdown comment added for the PR branch test checking for PRs to `master`,  now with a _TLDR_ section at the top to make it more attention grabbing:

https://github.com/nf-core/ampliseq/pull/228#issuecomment-801977264
![image](https://user-images.githubusercontent.com/465550/111680027-122aea00-8822-11eb-9b42-884596beb68a.png)
