### PR TITLE
Path fix triage 2

### DIFF
--- a/nf_core/modules/lint.py
+++ b/nf_core/modules/lint.py
@@ -236,7 +236,9 @@ class ModuleLint(object):
         if os.path.exists(nfcore_modules_dir):
             for m in sorted([m for m in os.listdir(nfcore_modules_dir) if not m == "lib"]):
                 if not os.path.isdir(os.path.join(nfcore_modules_dir, m)):
-                    raise ModuleLintException(f"File found in {nfcore_modules_dir} ({m})! This directly should only contain module directories.")
+                    raise ModuleLintException(
+                        f"File found in {nfcore_modules_dir} ({m})! This directly should only contain module directories."
+                    )
                 m_content = os.listdir(os.path.join(nfcore_modules_dir, m))
                 # Not a module, but contains sub-modules
                 if not "main.nf" in m_content:

--- a/nf_core/modules/lint.py
+++ b/nf_core/modules/lint.py
@@ -290,8 +290,8 @@ class ModuleLint(object):
                 last_modname = mod.module_name
                 table.add_row(
                     Markdown(f"{mod.module_name}"),
-                    Markdown(f"{result[1]}"),
                     os.path.relpath(result[2], self.dir),
+                    Markdown(f"{result[1]}"),
                     style=row_style,
                 )
             return table
@@ -308,8 +308,8 @@ class ModuleLint(object):
             )
             table = Table(style="green", box=rich.box.ROUNDED)
             table.add_column("Module name", width=max_mod_name_len)
-            table.add_column("Test message", no_wrap=True)
             table.add_column("File path", no_wrap=True)
+            table.add_column("Test message")
             table = format_result(self.passed, table)
             console.print(table)
 
@@ -322,8 +322,8 @@ class ModuleLint(object):
             )
             table = Table(style="yellow", box=rich.box.ROUNDED)
             table.add_column("Module name", width=max_mod_name_len)
-            table.add_column("Test message", no_wrap=True)
             table.add_column("File path", no_wrap=True)
+            table.add_column("Test message")
             table = format_result(self.warned, table)
             console.print(table)
 
@@ -334,8 +334,8 @@ class ModuleLint(object):
             )
             table = Table(style="red", box=rich.box.ROUNDED)
             table.add_column("Module name", width=max_mod_name_len)
-            table.add_column("Test message", no_wrap=True)
             table.add_column("File path", no_wrap=True)
+            table.add_column("Test message")
             table = format_result(self.failed, table)
             console.print(table)
 

--- a/nf_core/modules/lint.py
+++ b/nf_core/modules/lint.py
@@ -235,6 +235,8 @@ class ModuleLint(object):
         # Get nf-core modules
         if os.path.exists(nfcore_modules_dir):
             for m in sorted([m for m in os.listdir(nfcore_modules_dir) if not m == "lib"]):
+                if not os.path.isdir(os.path.join(nfcore_modules_dir, m)):
+                    raise ModuleLintException(f"File found in {nfcore_modules_dir} ({m})! This directly should only contain module directories.")
                 m_content = os.listdir(os.path.join(nfcore_modules_dir, m))
                 # Not a module, but contains sub-modules
                 if not "main.nf" in m_content:

--- a/nf_core/modules/lint.py
+++ b/nf_core/modules/lint.py
@@ -237,7 +237,7 @@ class ModuleLint(object):
             for m in sorted([m for m in os.listdir(nfcore_modules_dir) if not m == "lib"]):
                 if not os.path.isdir(os.path.join(nfcore_modules_dir, m)):
                     raise ModuleLintException(
-                        f"File found in {nfcore_modules_dir} ({m})! This directly should only contain module directories."
+                        f"File found in '{nfcore_modules_dir}': '{m}'! This directly should only contain module directories."
                     )
                 m_content = os.listdir(os.path.join(nfcore_modules_dir, m))
                 # Not a module, but contains sub-modules


### PR DESCRIPTION
This fixes the problems with wrapping and order of the output table. Also fixes any missing file paths in the table (they got wrapped earlier).

Checks whether all module dir's in `modules/software` are actually directories and raises an exception if not (to catch cases like `modules/software`.

Although to be honest we have to assume some kind of structure of the repo and there are lots of other places where files that shouldn't belong would break the code.