### PR TITLE
remove containsKey() from validateParams()

### DIFF
--- a/nf_core/lint/nextflow_config.py
+++ b/nf_core/lint/nextflow_config.py
@@ -116,6 +116,7 @@ def nextflow_config(self):
         "params.container",
         "params.singleEnd",
         "params.igenomesIgnore",
+        "params.name",
     ]
 
     # Remove field that should be ignored according to the linting config

--- a/nf_core/pipeline-template/lib/NfcoreSchema.groovy
+++ b/nf_core/pipeline-template/lib/NfcoreSchema.groovy
@@ -219,7 +219,7 @@ class NfcoreSchema {
                     }
                 }
             }
-            if(rawSchema.keySet().contains('properties') && rawSchema.get('properties').containsKey(ignore_param)) {
+            if(rawSchema.keySet().contains('properties') && rawSchema.get('properties').keySet().contains(ignore_param)) {
                 rawSchema.get("properties").remove(ignore_param)
             }
             if(rawSchema.keySet().contains('required') && rawSchema.required.contains(ignore_param)) {


### PR DESCRIPTION
If we use `.keySet().contains()`  instead of `.containsKey()`, the problems at https://github.com/nf-core/diaproteomics/pull/103/checks?check_run_id=2167429157 are fixed.

