### PR TITLE
Split steps create lint wf

### DIFF
--- a/.github/workflows/create-lint-wf.yml
+++ b/.github/workflows/create-lint-wf.yml
@@ -4,6 +4,8 @@ on: [push, pull_request]
 jobs:
   MakeTestWorkflow:
     runs-on: ubuntu-latest
+    env:
+      NXF_VER: 21.03.0-edge
     steps:
       - uses: actions/checkout@v2
         name: Check out source-code repository
@@ -22,21 +24,32 @@ jobs:
         env:
           CAPSULE_LOG: none
         run: |
-          mkdir /tmp/nextflow
-          cd /tmp/nextflow
           wget -qO- get.nextflow.io | bash
-          sudo ln -s /tmp/nextflow/nextflow /usr/local/bin/nextflow
+          sudo mv nextflow /usr/local/bin/
 
-      - name: Run nf-core/tools
-        run: |
-          nf-core --log-file log.txt create -n testpipeline -d "This pipeline is for testing" -a "Testing McTestface"
-          nf-core --log-file log.txt lint nf-core-testpipeline --fail-ignored
-          nf-core --log-file log.txt list
-          nf-core --log-file log.txt licences nf-core-testpipeline
-          nf-core --log-file log.txt sync nf-core-testpipeline/
-          nf-core --log-file log.txt schema build nf-core-testpipeline/ --no-prompts
-          nf-core --log-file log.txt bump-version nf-core-testpipeline/ 1.1
-          nf-core --log-file log.txt modules install nf-core-testpipeline/ --tool fastqc
+      - name: nf-core create
+        run: nf-core --log-file log.txt create -n testpipeline -d "This pipeline is for testing" -a "Testing McTestface"
+
+      - name: nf-core lint
+        run: nf-core --log-file log.txt lint nf-core-testpipeline --fail-ignored
+
+      - name: nf-core list
+        run: nf-core --log-file log.txt list
+
+      - name: nf-core licences
+        run: nf-core --log-file log.txt licences nf-core-testpipeline
+
+      - name: nf-core sync
+        run: nf-core --log-file log.txt sync nf-core-testpipeline/
+
+      - name: nf-core schema
+        run: nf-core --log-file log.txt schema build nf-core-testpipeline/ --no-prompts
+
+      - name: nf-core bump-version
+        run: nf-core --log-file log.txt bump-version nf-core-testpipeline/ 1.1
+
+      - name: nf-core modules install
+        run: nf-core --log-file log.txt modules install nf-core-testpipeline/ --tool fastqc
 
       - name: Upload log file artifact
         if: ${{ always() }}

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -16,3 +16,28 @@ jobs:
 
       - name: Run Markdownlint
         run: markdownlint ${GITHUB_WORKSPACE} -c ${GITHUB_WORKSPACE}/.github/markdownlint.yml
+
+      # If the above check failed, post a comment on the PR explaining the failure
+      - name: Post PR comment
+        if: failure()
+        uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            ## Markdown linting is failing
+
+            To keep the code consistent with lots of contributors, we run automated code consistency checks.
+            To fix this CI test, please run:
+
+            * Install `markdownlint-cli`
+                * On Mac: `brew install markdownlint-cli`
+                * Everything else: [Install `npm`](https://www.npmjs.com/get-npm) then [install `markdownlint-cli`](https://www.npmjs.com/package/markdownlint-cli): `npm install -g markdownlint-cli`
+            * Try to automatically fix errors in your pipeline: `markdownlint . --config .github/markdownlint.yml --fix`
+            * Check that there are no remaining problems: `markdownlint . --config .github/markdownlint.yml`
+
+            Once you push these changes the test should pass, and you can hide this comment :+1:
+
+            We highly recommend setting up Black in your code editor so that this formatting is done automatically on save. Ask about it on Slack for help!
+
+            Thanks again for your contribution!
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-repeats: false

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -15,3 +15,25 @@ jobs:
 
       - name: Check code lints with Black
         uses: jpetrucciani/black-check@master
+
+      # If the above check failed, post a comment on the PR explaining the failure
+      - name: Post PR comment
+        if: failure()
+        uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            ## Python linting (`black`) is failing
+
+            To keep the code consistent with lots of contributors, we run automated code consistency checks.
+            To fix this CI test, please run:
+
+            * Install [`black`](https://black.readthedocs.io/en/stable/): `pip install black`
+            * Fix formatting errors in your pipeline: `black .`
+
+            Once you push these changes the test should pass, and you can hide this comment :+1:
+
+            We highly recommend setting up Black in your code editor so that this formatting is done automatically on save. Ask about it on Slack for help!
+
+            Thanks again for your contribution!
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-repeats: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # nf-core/tools: Changelog
 
-## v1.14dev
+## v1.13.2dev
 
-_..nothing yet.._
+### Tools code
+
+* Split the `create-lint-wf` tests up into separate steps in GitHub Actions to make the CI results easier to read
+* Added automated PR comments to the Markdownlint and Python Black lint CI tests to explain failures
 
 ## [v1.13.1 - Copper Crocodile Patch :crocodile: :pirate_flag:](https://github.com/nf-core/tools/releases/tag/1.13.1) - [2021-03-19]
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 import sys
 
-version = "1.14dev"
+version = "1.13.2dev"
 
 with open("README.md") as f:
     readme = f.read()


### PR DESCRIPTION
* Split up CI commands into separate steps for `create-lint-wf` to make it easier to read
* Added automated PR comments for markdown + Python code linting CI

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
