### PR TITLE
better logging if directory not correctly specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # nf-core/tools: Changelog
 
-## v1.14dev
+## v1.13.2
 
-_..nothing yet.._
+* Added better logging message if a user doesn't specificy the directory correctly with `nf-core modules` commands [[#942](https://github.com/nf-core/tools/pull/942)]
+* Fixed parameter validation bug caused by JSONObject [[#937](https://github.com/nf-core/tools/issues/937)]
 
 ## [v1.13.1 - Copper Crocodile Patch :crocodile: :pirate_flag:](https://github.com/nf-core/tools/releases/tag/1.13.1) - [2021-03-19]
 

--- a/nf_core/modules/create.py
+++ b/nf_core/modules/create.py
@@ -251,7 +251,10 @@ class ModuleCreate(object):
         elif os.path.exists(os.path.join(directory, "software")):
             return "modules"
         else:
-            raise UserWarning(f"Could not determine repository type: '{directory}'")
+            raise UserWarning(
+                f"This directory does not look like a clone of nf-core/modules or an nf-core pipeline: '{directory}'"
+                " Please point to a valid directory."
+            )
 
     def get_module_dirs(self):
         """Given a directory and a tool/subtool, set the file paths and check if they already exist


### PR DESCRIPTION
Add a better logging message if a directory  has not specified correctly.

closes https://github.com/nf-core/tools/issues/940