### PR TITLE
Pipeline create - apply file permissions to new files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Added better logging message if a user doesn't specificy the directory correctly with `nf-core modules` commands [[#942](https://github.com/nf-core/tools/pull/942)]
 * Fixed parameter validation bug caused by JSONObject [[#937](https://github.com/nf-core/tools/issues/937)]
-* Fixed template creation error regarding file permissions [[#923](https://github.com/nf-core/tools/issues/923)]
+* Fixed template creation error regarding file permissions [[#932](https://github.com/nf-core/tools/issues/932)]
 * Split the `create-lint-wf` tests up into separate steps in GitHub Actions to make the CI results easier to read
 * Added automated PR comments to the Markdownlint and Python Black lint CI tests to explain failures
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added better logging message if a user doesn't specificy the directory correctly with `nf-core modules` commands [[#942](https://github.com/nf-core/tools/pull/942)]
 * Fixed parameter validation bug caused by JSONObject [[#937](https://github.com/nf-core/tools/issues/937)]
+* Fixed template creation error regarding file permissions [[#923](https://github.com/nf-core/tools/issues/923)]
 * Split the `create-lint-wf` tests up into separate steps in GitHub Actions to make the CI results easier to read
 * Added automated PR comments to the Markdownlint and Python Black lint CI tests to explain failures
 

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -134,6 +134,10 @@ class PipelineCreate(object):
                 shutil.copy(template_fn_path, output_path)
                 continue
 
+            # Mirror file permissions
+            template_stat = os.stat(template_fn_path)
+            os.chmod(output_path, template_stat.st_mode)
+
         # Make a logo and save it
         self.make_pipeline_logo()
 

--- a/nf_core/modules/create.py
+++ b/nf_core/modules/create.py
@@ -237,7 +237,7 @@ class ModuleCreate(object):
                 fh.write(rendered_output)
 
             # Mirror file permissions
-            template_stat = os.stat(template_fn)
+            template_stat = os.stat(os.path.join("nf_core", "module-template", template_fn))
             os.chmod(dest_fn, template_stat.st_mode)
 
     def get_repo_type(self, directory):

--- a/nf_core/modules/create.py
+++ b/nf_core/modules/create.py
@@ -236,6 +236,10 @@ class ModuleCreate(object):
                 log.debug(f"Writing output to: '{dest_fn}'")
                 fh.write(rendered_output)
 
+            # Mirror file permissions
+            template_stat = os.stat(template_fn)
+            os.chmod(dest_fn, template_stat.st_mode)
+
     def get_repo_type(self, directory):
         """
         Determine whether this is a pipeline repository or a clone of


### PR DESCRIPTION
Get the file mode from the template file and apply it to the new file in `nf-core create`

Fixes nf-core/tools#932


## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
