### PR TITLE
Bump to v1.14dev, move NXF_VER up in scope in sync wf

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -4,11 +4,12 @@ on:
     types: [published]
   workflow_dispatch:
 
+env:
+  NXF_VER: 21.03.0-edge
+
 jobs:
   get-pipelines:
     runs-on: ubuntu-latest
-    env:
-      NXF_VER: 21.03.0-edge
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # nf-core/tools: Changelog
 
+## v1.14dev
+
+* Fix sync error again where the Nextflow edge release needs to be used for some pipelines
+
 ## [v1.13.2 - Copper Crocodile CPR :crocodile: :face_with_head_bandage:](https://github.com/nf-core/tools/releases/tag/1.13.2) - [2021-03-23]
 
 * Make module template pass the EC linter [[#953](https://github.com/nf-core/tools/pull/953)]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-version = "1.13.2"
+version = "1.14dev"
 
 with open("README.md") as f:
     readme = f.read()


### PR DESCRIPTION
* Bump to v1.14dev
* Move `NXF_VER` up to the workflow scope for the sync job so that we use the latest edge release of Nextflow in the sync

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
