### PR TITLE
Fix bug in lint with release mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.14dev
 
 * Fix sync error again where the Nextflow edge release needs to be used for some pipelines
+* Fix bug with `nf-core lint --release` (`NameError: name 'os' is not defined`)
 
 ## [v1.13.2 - Copper Crocodile CPR :crocodile: :face_with_head_bandage:](https://github.com/nf-core/tools/releases/tag/1.13.2) - [2021-03-23]
 

--- a/nf_core/lint/__init__.py
+++ b/nf_core/lint/__init__.py
@@ -438,7 +438,7 @@ class PipelineLint(nf_core.utils.Pipeline):
             f"{comment_body_text}\n\n"
             f"```diff{test_passed_count}{test_ignored_count}{test_fixed_count}{test_warning_count}{test_failure_count}\n"
             "```\n\n"
-            "<details>\n"
+            "<details>\n\n"
             f"{test_failures}{test_warnings}{test_ignored}{test_fixed}{test_passes}### Run details\n\n"
             f"* nf-core/tools version {nf_core.__version__}\n"
             f"* Run at `{timestamp}`\n\n"

--- a/nf_core/lint/version_consistency.py
+++ b/nf_core/lint/version_consistency.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import os
+
 
 def version_consistency(self):
     """Pipeline and container version number consistency.


### PR DESCRIPTION
Bug in the linting when in release mode, missing an import after the code restructure.

Also added an extra line break in the linting markdown outputs, as the header doesn't render on GitHub properly without it.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
