### PR TITLE
Extra lint test with --release

### DIFF
--- a/.github/workflows/create-lint-wf.yml
+++ b/.github/workflows/create-lint-wf.yml
@@ -48,6 +48,9 @@ jobs:
       - name: nf-core bump-version
         run: nf-core --log-file log.txt bump-version nf-core-testpipeline/ 1.1
 
+      - name: nf-core lint in release mode
+        run: nf-core --log-file log.txt lint nf-core-testpipeline --fail-ignored --release
+
       - name: nf-core modules install
         run: nf-core --log-file log.txt modules install nf-core-testpipeline/ --tool fastqc
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -32,7 +32,7 @@ log = logging.getLogger()
 
 def run_nf_core():
     # Set up the rich traceback
-    rich.traceback.install(width=200, word_wrap=True)
+    rich.traceback.install(width=200, word_wrap=True, extra_lines=1)
 
     # Print nf-core header to STDERR
     stderr = rich.console.Console(file=sys.stderr, force_terminal=nf_core.utils.rich_force_colors())


### PR DESCRIPTION
* Run an extra job in the CI to do linting with `--release` to try to pick up any other nasty hidden errors like the one that sneaked into the recent releases.
* Tweak the traceback setup so that they are not so long and people can paste them into Slack 😉 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
