### PR TITLE
fix conda and podman profile strictness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.14dev
 
-_..nothing yet.._
+* Fixed an issue in the pipeline template regarding explicit disabling of unused container engines [[#972](https://github.com/nf-core/tools/pull/972)]
 
 ## [v1.13.3 - Copper Crocodile Resurrection :crocodile:](https://github.com/nf-core/tools/releases/tag/1.13.2) - [2021-03-24]
 

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -65,7 +65,7 @@ profiles {
     singularity.enabled = false
     podman.enabled = false
     shifter.enabled = false
-    charliecloud = false
+    charliecloud.enabled = false
     process.conda = "$projectDir/environment.yml"
   }
   debug { process.beforeScript = 'echo $HOSTNAME' }
@@ -94,7 +94,7 @@ profiles {
     docker.enabled = false
     podman.enabled = true
     shifter.enabled = false
-    charliecloud = false
+    charliecloud.enabled = false
   }
   shifter {
     singularity.enabled = false


### PR DESCRIPTION
In https://github.com/nf-core/tools/pull/866, we increased the strictness for container profiles by explicitly disabling other container engines if a profile is selected.

Right now nothing is broken per se, but for the `conda` and `podman` profiles, we currently do not disable `charliecloud` properly. This fixes it.

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

 - [ ] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
