### PR TITLE
Remove trailing slash from `params.igenomes_base`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Fixed an issue in the pipeline template regarding explicit disabling of unused container engines [[#972](https://github.com/nf-core/tools/pull/972)]
 * Fix overly strict `--max_time` formatting regex in template schema [[#973](https://github.com/nf-core/tools/issues/973)]
 
+### Template
+
+* Removed trailing slash from `params.igenomes_base` to yield valid s3 paths (previous paths work with Nextflow but not aws cli)
+
 ## [v1.13.3 - Copper Crocodile Resurrection :crocodile:](https://github.com/nf-core/tools/releases/tag/1.13.2) - [2021-03-24]
 
 * Running tests twice with `nf-core modules create-test-yml` to catch unreproducible md5 sums [[#890](https://github.com/nf-core/tools/issues/890)]

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -25,7 +25,7 @@ params {
   plaintext_email = false
   monochrome_logs = false
   help = false
-  igenomes_base = 's3://ngi-igenomes/igenomes/'
+  igenomes_base = 's3://ngi-igenomes/igenomes'
   tracedir = "${params.outdir}/pipeline_info"
   igenomes_ignore = false
   custom_config_version = 'master'

--- a/nf_core/pipeline-template/nextflow_schema.json
+++ b/nf_core/pipeline-template/nextflow_schema.json
@@ -62,7 +62,7 @@
                 "igenomes_base": {
                     "type": "string",
                     "description": "Directory / URL base for iGenomes references.",
-                    "default": "s3://ngi-igenomes/igenomes/",
+                    "default": "s3://ngi-igenomes/igenomes",
                     "fa_icon": "fas fa-cloud-download-alt",
                     "hidden": true
                 },


### PR DESCRIPTION
Turns out that Nextflow has been tolerating broken AWS s3 paths for us for years. Let's fix it before anyone notices 🤫 

Discussion on Slack in `#aws` channel: https://nfcore.slack.com/archives/CE7FBAMRP/p1616747167005700

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
