### PR TITLE
Launch: Strip unset params with no defaults.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixed an issue in the pipeline template regarding explicit disabling of unused container engines [[#972](https://github.com/nf-core/tools/pull/972)]
 * Fix overly strict `--max_time` formatting regex in template schema [[#973](https://github.com/nf-core/tools/issues/973)]
+* Strip values from `nf-core launch` web response which are False and have no default in the schema [[#976](https://github.com/nf-core/tools/issues/976)]
 
 ### Template
 

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -101,7 +101,7 @@ class PipelineSchema(object):
 
     def sanitise_param_default(self, param):
         """
-        Given a param, ensure that the default value it is the correct variable type
+        Given a param, ensure that the default value is the correct variable type
         """
         if "type" not in param or "default" not in param:
             return param

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -99,6 +99,37 @@ class PipelineSchema(object):
         self.schema_params = []
         log.debug("JSON file loaded: {}".format(self.schema_filename))
 
+    def sanitise_param_default(self, param):
+        """
+        Given a param, ensure that the default value it is the correct variable type
+        """
+        if "type" not in param or "default" not in param:
+            return param
+
+        # Bools
+        if param["type"] == "boolean":
+            if not isinstance(param["default"], bool):
+                param["default"] = param["default"] == "true"
+            return param
+
+        # For everything else, an empty string is an empty string
+        if isinstance(param["default"], str) and param["default"].strip() == "":
+            return ""
+
+        # Integers
+        if param["type"] == "integer":
+            param["default"] = int(param["default"])
+            return param
+
+        # Numbers
+        if param["type"] == "number":
+            param["default"] = float(param["default"])
+            return param
+
+        # Strings
+        param["default"] = str(param["default"])
+        return param
+
     def get_schema_defaults(self):
         """
         Generate set of default input parameters from schema.
@@ -110,6 +141,7 @@ class PipelineSchema(object):
         for p_key, param in self.schema.get("properties", {}).items():
             self.schema_params.append(p_key)
             if "default" in param:
+                param = self.sanitise_param_default(param)
                 self.schema_defaults[p_key] = param["default"]
 
         # Grouped schema properties in subschema definitions
@@ -117,6 +149,7 @@ class PipelineSchema(object):
             for p_key, param in definition.get("properties", {}).items():
                 self.schema_params.append(p_key)
                 if "default" in param:
+                    param = self.sanitise_param_default(param)
                     self.schema_defaults[p_key] = param["default"]
 
     def save_schema(self):


### PR DESCRIPTION
* If a param doesn't have a default in the schema and the input is False / None / , strip it
* Sanitise the default values in the schema so that they are the correct type
* Don't surround command-line params with quotes if numeric

Fixes nf-core/tools#976

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
