### PR TITLE
Sync: Try to fix the GitHub abuse mechanism coping code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixed an issue in the pipeline template regarding explicit disabling of unused container engines [[#972](https://github.com/nf-core/tools/pull/972)]
 * Fix overly strict `--max_time` formatting regex in template schema [[#973](https://github.com/nf-core/tools/issues/973)]
+* Try to fix the fix for the automated sync when we submit too many PRs at once [[#970](https://github.com/nf-core/tools/issues/970)]
 
 ### Template
 


### PR DESCRIPTION
* Fixes main bug that the default value for the Retry-After header was an int and not a str
* Make the default wait random, between 10 - 60 seconds
* Some tweaks, print the headers in more log messages, make them prettier.

Fixes nf-core/tools#970

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
