### PR TITLE
update module commands with new format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 1.14dev
 
-
 ### Tools
 
 * Strip values from `nf-core launch` web response which are False and have no default in the schema [[#976](https://github.com/nf-core/tools/issues/976)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixed an issue in the pipeline template regarding explicit disabling of unused container engines [[#972](https://github.com/nf-core/tools/pull/972)]
 * Fix overly strict `--max_time` formatting regex in template schema [[#973](https://github.com/nf-core/tools/issues/973)]
+* Update `modules` commands to use new test tag format `tool/subtool`
 
 ### Template
 

--- a/nf_core/module-template/tests/test.yml
+++ b/nf_core/module-template/tests/test.yml
@@ -5,7 +5,7 @@
   tags:
     - {{ tool }}
     {%- if subtool %}
-    - {{ tool_name }}
+    - {{ tool }}/{{ subtool }}
     {%- endif %}
   files:
     - path: output/{{ tool }}/test.bam

--- a/nf_core/modules/create.py
+++ b/nf_core/modules/create.py
@@ -113,7 +113,7 @@ class ModuleCreate(object):
         self.tool_dir = self.tool
 
         if self.subtool:
-            self.tool_name = f"{self.tool}_{self.subtool}"
+            self.tool_name = f"{self.tool}/{self.subtool}"
             self.tool_dir = os.path.join(self.tool, self.subtool)
 
         # Check existance of directories early for fast-fail

--- a/nf_core/modules/lint.py
+++ b/nf_core/modules/lint.py
@@ -519,6 +519,7 @@ class NFCoreModule(object):
         # Lint the test.yml file
         try:
             with open(self.test_yml, "r") as fh:
+                # TODO: verify that the tags are correct
                 test_yml = yaml.safe_load(fh)
             self.passed.append(("test_yml_exists", "Test `test.yml` exists", self.test_yml))
         except FileNotFoundError:

--- a/nf_core/modules/test_yml_builder.py
+++ b/nf_core/modules/test_yml_builder.py
@@ -170,7 +170,7 @@ class ModulesTestYmlBuilder(object):
             mod_name_parts = self.module_name.split("/")
             tag_defaults = []
             for idx in range(0, len(mod_name_parts)):
-                tag_defaults.append("_".join(mod_name_parts[: idx + 1]))
+                tag_defaults.append("/".join(mod_name_parts[: idx + 1]))
             tag_defaults.append(entry_point.replace("test_", ""))
             # Remove duplicates
             tag_defaults = list(set(tag_defaults))


### PR DESCRIPTION
This updates the module commands `create` and `create-test-yml` with the new module format for the `test.yml` 

Instead of `tool_subtool` the tag will now be `tool/subtool`  (see here: https://github.com/nf-core/modules/pull/389) 

Still need to update the lint command to look for the correct tags if we decided to go only for these tags instead of having things like "my_tool_single_end" etc.

