### PR TITLE
Minor tweaks

### DIFF
--- a/nf_core/pipeline-template/.github/PULL_REQUEST_TEMPLATE.md
+++ b/nf_core/pipeline-template/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,14 +10,15 @@ Remember that PRs should be made against the dev branch, unless you're preparing
 
 Learn more about contributing: [CONTRIBUTING.md](https://github.com/{{ name }}/tree/master/.github/CONTRIBUTING.md)
 -->
+<!-- markdownlint-disable ul-indent -->
 
 ## PR checklist
 
 - [ ] This comment contains a description of changes (with reason).
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
-  - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
-  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/{{ name }}/tree/master/.github/CONTRIBUTING.md)
-  - [ ] If necessary, also make a PR on the {{ name }} _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
+    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
+    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>{{ name }}/tree/master/.github/CONTRIBUTING.md)
+    - [ ] If necessary, also make a PR on the {{ name }} _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Usage Documentation in `docs/usage.md` is updated.

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -345,7 +345,7 @@ def poll_nfcore_web_api(api_url, post_data=None):
             try:
                 web_response = json.loads(response.content)
                 assert "status" in web_response
-            except (json.decoder.JSONDecodeError, AssertionError) as e:
+            except (json.decoder.JSONDecodeError, AssertionError, TypeError) as e:
                 log.debug("Response content:\n{}".format(response.content))
                 raise AssertionError(
                     "nf-core website API results response not recognised: {}\n See verbose log for full response".format(


### PR DESCRIPTION
Couple of minor fixes for things that I spotted whilst doing stuff this evening.

* Fix list indentation for correct GitHub rendering. GitHub needs 4 spaces, markdownlint likes 2. I have added a mdl comment to avoid the mdl linting from triggering a CI error.
* Schema build - add exception type to handle. This is one I ran into and I don't know why. I couldn't replicate it but figured that I could catch it properly next time.


## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
