### PR TITLE
Conda name flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Strip values from `nf-core launch` web response which are False and have no default in the schema [[#976](https://github.com/nf-core/tools/issues/976)]
 * Try to fix the fix for the automated sync when we submit too many PRs at once [[#970](https://github.com/nf-core/tools/issues/970)]
+* Added `--conda-name` flag to `nf-core modules create` command to allow sidestepping questionary [[#988](https://github.com/nf-core/tools/issues/988)]
 
 ### Template
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -466,9 +466,7 @@ def create_module(ctx, directory, tool, author, label, meta, no_meta, force, con
 
     # Run function
     try:
-        module_create = nf_core.modules.ModuleCreate(
-            directory, tool, author, label, has_meta, force, conda_name
-        )
+        module_create = nf_core.modules.ModuleCreate(directory, tool, author, label, has_meta, force, conda_name)
         module_create.create()
     except UserWarning as e:
         log.critical(e)

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -444,7 +444,8 @@ def remove(ctx, pipeline_dir, tool):
 @click.option("-m", "--meta", is_flag=True, default=False, help="Use Groovy meta map for sample information")
 @click.option("-n", "--no-meta", is_flag=True, default=False, help="Don't use meta map for sample information")
 @click.option("-f", "--force", is_flag=True, default=False, help="Overwrite any files if they already exist")
-def create_module(ctx, directory, tool, author, label, meta, no_meta, force):
+@click.option("-c", "--conda-name", type=str, default=None, help="Name of the conda package to use")
+def create_module(ctx, directory, tool, author, label, meta, no_meta, force, conda_name):
     """
     Create a new DSL2 module from the nf-core template.
 
@@ -465,7 +466,9 @@ def create_module(ctx, directory, tool, author, label, meta, no_meta, force):
 
     # Run function
     try:
-        module_create = nf_core.modules.ModuleCreate(directory, tool, author, label, has_meta, force)
+        module_create = nf_core.modules.ModuleCreate(
+            directory, tool, author, label, has_meta, force, conda_name=conda_name
+        )
         module_create.create()
     except UserWarning as e:
         log.critical(e)

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -467,7 +467,7 @@ def create_module(ctx, directory, tool, author, label, meta, no_meta, force, con
     # Run function
     try:
         module_create = nf_core.modules.ModuleCreate(
-            directory, tool, author, label, has_meta, force, conda_name=conda_name
+            directory, tool, author, label, has_meta, force, conda_name
         )
         module_create.create()
     except UserWarning as e:

--- a/nf_core/modules/create.py
+++ b/nf_core/modules/create.py
@@ -24,7 +24,9 @@ log = logging.getLogger(__name__)
 
 
 class ModuleCreate(object):
-    def __init__(self, directory=".", tool="", author=None, process_label=None, has_meta=None, force=False):
+    def __init__(
+        self, directory=".", tool="", author=None, process_label=None, has_meta=None, force=False, conda_name=None
+    ):
         self.directory = directory
         self.tool = tool
         self.author = author
@@ -32,7 +34,7 @@ class ModuleCreate(object):
         self.has_meta = has_meta
         self.force_overwrite = force
 
-        self.tool_conda_name = None
+        self.tool_conda_name = conda_name
         self.subtool = None
         self.tool_licence = None
         self.repo_type = None

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -101,14 +101,6 @@ class TestModules(unittest.TestCase):
         module_create.create()
         assert os.path.exists(os.path.join(self.pipeline_dir, "modules", "local", "fastqc.nf"))
 
-    def test_modules_create_different_conda_name(self):
-        """ Test creating a new module using a different conda package name """
-        module_create = nf_core.modules.ModuleCreate(
-            self.pipeline_dir, "trimgalore", "@author", "process_low", True, True, conda_name="trim-galore"
-        )
-        module_create.create()
-        assert os.path.exists(os.path.join(self.pipeline_dir, "modules", "local", "trimgalore.nf"))
-
     def test_modules_create_fail_exists(self):
         """ Fail at creating the same module twice"""
         module_create = nf_core.modules.ModuleCreate(

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -101,6 +101,14 @@ class TestModules(unittest.TestCase):
         module_create.create()
         assert os.path.exists(os.path.join(self.pipeline_dir, "modules", "local", "fastqc.nf"))
 
+    def test_modules_create_different_conda_name(self):
+        """ Test creating a new module using a different conda package name """
+        module_create = nf_core.modules.ModuleCreate(
+            self.pipeline_dir, "trimgalore", "@author", "process_low", True, True, conda_name="trim-galore"
+        )
+        module_create.create()
+        assert os.path.exists(os.path.join(self.pipeline_dir, "modules", "local", "trimgalore.nf"))
+
     def test_modules_create_fail_exists(self):
         """ Fail at creating the same module twice"""
         module_create = nf_core.modules.ModuleCreate(


### PR DESCRIPTION
This PR adds a `--conda-name`, `-c` flag to `nf-core modules create` to allow sidestepping of questionary, e.g. during pytest. 

Fixes https://github.com/nf-core/tools/issues/988  


## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
