### PR TITLE
Modules lint - exit code 1 if we have failures

### DIFF
--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -515,6 +515,8 @@ def lint(ctx, pipeline_dir, tool, all, local, passed):
     try:
         module_lint = nf_core.modules.ModuleLint(dir=pipeline_dir)
         module_lint.lint(module=tool, all_modules=all, print_results=True, local=local, show_passed=passed)
+        if len(module_lint.failed) > 0:
+            sys.exit(1)
     except nf_core.modules.lint.ModuleLintException as e:
         log.error(e)
         sys.exit(1)


### PR DESCRIPTION
Currently the `nf-core module lint` command exits with code `0` even if there are failures, meaning that the CI always passes. This PR addresses that, mimics how `nf-core lint` works.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
