### PR TITLE
fixed template for "modules create"

### DIFF
--- a/nf_core/module-template/tests/test.yml
+++ b/nf_core/module-template/tests/test.yml
@@ -1,5 +1,5 @@
 ## TODO nf-core: Please run the following command to build this file:
-#                nf-core modules create-test-yml {{ tool }}/{{ subtool }}
+#                nf-core modules create-test-yml {{ tool }}{%- if subtool %}/{{ subtool }}{%- endif %}
 - name: {{ tool }}{{ ' '+subtool if subtool else '' }}
   command: nextflow run ./tests/software/{{ tool_dir }} -entry test_{{ tool_name }} -c tests/config/nextflow.config
   tags:


### PR DESCRIPTION
Tiny fix of the module template (unconditional use of "subtool" in the template)

Closes https://github.com/nf-core/tools/issues/993