### PR TITLE
remove the "tool_subtool" tag from create-test-yml

### DIFF
--- a/nf_core/modules/test_yml_builder.py
+++ b/nf_core/modules/test_yml_builder.py
@@ -171,7 +171,6 @@ class ModulesTestYmlBuilder(object):
             tag_defaults = []
             for idx in range(0, len(mod_name_parts)):
                 tag_defaults.append("/".join(mod_name_parts[: idx + 1]))
-            tag_defaults.append(entry_point.replace("test_", ""))
             # Remove duplicates
             tag_defaults = list(set(tag_defaults))
             if self.no_prompts:


### PR DESCRIPTION
Removes the `tool_subtool` tag from the default list of tags, as we decided to only run with:

- tool
- tool/subtool

as tags.