### PR TITLE
Suppress messages from request-cache

### DIFF
--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -26,6 +26,9 @@ from rich.spinner import Spinner
 
 log = logging.getLogger(__name__)
 
+# Only show error messages from pipeline creation
+logging.getLogger("requests_cache").setLevel(logging.WARNING)
+
 # Custom style for questionary
 nfcore_question_style = prompt_toolkit.styles.Style(
     [


### PR DESCRIPTION
Disable request-cache from logging status messages to console during linting. 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
