### PR TITLE
Initialize `custom_profile_name`in nextflow config

### DIFF
--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -31,6 +31,7 @@ params {
   custom_config_version = 'master'
   custom_config_base = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
   hostnames = false
+  config_profile_name = null
   config_profile_description = false
   config_profile_contact = false
   config_profile_url = false


### PR DESCRIPTION
The parameter `custom_profile_name` is in the schema but was missing in the nextflow config, causing the linting to warn. This should fix it. 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
