### PR TITLE
make cleanParameters more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Added a timestamp to the trace + timetime + report + dag filenames to fix overwrite issue on AWS
 * Rewrite the `params_summary_log()` function to properly ignore unset params and have nicer formatting [[#971](https://github.com/nf-core/tools/issues/971)]
 * Fix overly strict `--max_time` formatting regex in template schema [[#973](https://github.com/nf-core/tools/issues/973)]
+* Convert `d` to `day` in the `cleanParameters` function to make Duration objects like `2d` pass the validation [[#858](https://github.com/nf-core/tools/issues/858)]
 
 ## [v1.13.3 - Copper Crocodile Resurrection :crocodile:](https://github.com/nf-core/tools/releases/tag/1.13.2) - [2021-03-24]
 

--- a/nf_core/pipeline-template/lib/NfcoreSchema.groovy
+++ b/nf_core/pipeline-template/lib/NfcoreSchema.groovy
@@ -243,7 +243,7 @@ class NfcoreSchema {
             }
             // Cast Duration to String
             if (p['value'].getClass() == nextflow.util.Duration) {
-                new_params.replace(p.key, p['value'].toString())
+                new_params.replace(p.key, p['value'].toString().replaceFirst(/d\s?$/, "day"))
             }
             // Cast LinkedHashMap to String
             if (p['value'].getClass() == LinkedHashMap) {

--- a/nf_core/pipeline-template/lib/NfcoreSchema.groovy
+++ b/nf_core/pipeline-template/lib/NfcoreSchema.groovy
@@ -243,7 +243,7 @@ class NfcoreSchema {
             }
             // Cast Duration to String
             if (p['value'].getClass() == nextflow.util.Duration) {
-                new_params.replace(p.key, p['value'].toString().replaceFirst(/d\s?$/, "day"))
+                new_params.replace(p.key, p['value'].toString().replaceFirst(/d(?!.)/, "day"))
             }
             // Cast LinkedHashMap to String
             if (p['value'].getClass() == LinkedHashMap) {

--- a/nf_core/pipeline-template/lib/NfcoreSchema.groovy
+++ b/nf_core/pipeline-template/lib/NfcoreSchema.groovy
@@ -243,7 +243,7 @@ class NfcoreSchema {
             }
             // Cast Duration to String
             if (p['value'].getClass() == nextflow.util.Duration) {
-                new_params.replace(p.key, p['value'].toString().replaceFirst(/d(?!.)/, "day"))
+                new_params.replace(p.key, p['value'].toString().replaceFirst(/d(?!\S)/, "day"))
             }
             // Cast LinkedHashMap to String
             if (p['value'].getClass() == LinkedHashMap) {


### PR DESCRIPTION
As discussed on slack, replace `d` with `day` for Nextflow Duration objects within `cleanParameters()`