### PR TITLE
Write docs for running nf-core tools docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Extended `nf-core modules lint` functionality to check tags in `test.yml` and to look for a entry in the `pytest_software.yml` file
 * Update `modules` commands to use new test tag format `tool/subtool`
 * Rewrite how the tools documentation is deployed to the website, to allow multiple versions
+* Created new Docker image for the tools cli package - see installation docs for details [[#917](https://github.com/nf-core/tools/issues/917)]
 
 ### Template
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,46 @@ conda activate nf-core
 pip install nf-core
 ```
 
+### Docker image
+
+There is a docker image that you can use to run `nf-core/tools` that has all of the requirements packaged (including Nextflow) and so should work out of the box. It is called [`nfcore/tools`](https://hub.docker.com/r/nfcore/tools) _**(NB: no hyphen!)**_
+
+You can use this container on the command line as follows:
+
+```bash
+docker run -itv `pwd`:`pwd` -w `pwd` nfcore/tools
+```
+
+* `-i` and `-t` are needed for the interactive cli prompts to work (this tells Docker to use a pseudo-tty with stdin attached)
+* The `-v` argument tells Docker to bind your current working directory (`pwd`) to the same path inside the container, so that files created there will be saved to your local file system outside of the container.
+* `-w` sets the working directory in the container to this path, so that it's the same as your working directory outside of the container.
+
+After the above base command, you can use the regular command line flags that you would use with other types of installation.
+For example, to launch the `viralrecon` pipeline:
+
+```bash
+docker run -itv `pwd`:`pwd` -w `pwd` nfcore/tools launch viralrecon -r 1.1.0
+```
+
+#### Docker bash alias
+
+The above base command is a little verbose, so if you are using this a lot it may be worth adding the following bash alias to your `~/.bashrc` file:
+
+```bash
+alias nf-core="docker run -itv `pwd`:`pwd` -w `pwd` nfcore/tools"
+```
+
+Once applied (you may need to reload your shell if added to your `.bashrc`) you can just use `nf-core` instead:
+
+```bash
+nf-core list
+```
+
+#### Docker versions
+
+You can use docker image tags to specify the version you would like to use. For example, `nfcore/tools:dev` for the latest development version of the code, or `nfcore/tools:1.14` for version `1.14` of tools.
+If you omit this, it will default to `:latest`, which should be the latest stable release.
+
 ### Development version
 
 If you would like the latest development version of tools, the command is:


### PR DESCRIPTION
@ErikDanielsson has done an awesome job and we now have a functioning `nfcore/tools` docker container that seems to be working nicely! (x-ref https://github.com/nf-core/tools/issues/917)

I have done a bit of testing and figured out the required `docker run` flags needed to use it. Here is some documentation.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
