### PR TITLE
Ignore any permission errors while creating/checking requests cache dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Update `modules` commands to use new test tag format `tool/subtool`
 * Rewrite how the tools documentation is deployed to the website, to allow multiple versions
 * Created new Docker image for the tools cli package - see installation docs for details [[#917](https://github.com/nf-core/tools/issues/917)]
+* Ignore permission errors for setting up requests cache directories to allow starting with an invalid or read-only HOME directory
 
 ### Template
 

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -283,13 +283,17 @@ def setup_requests_cachedir():
     """
     pyversion = ".".join(str(v) for v in sys.version_info[0:3])
     cachedir = os.path.join(os.getenv("HOME"), os.path.join(".nfcore", "cache_" + pyversion))
-    if not os.path.exists(cachedir):
-        os.makedirs(cachedir)
-    requests_cache.install_cache(
-        os.path.join(cachedir, "github_info"),
-        expire_after=datetime.timedelta(hours=1),
-        backend="sqlite",
-    )
+
+    try:
+        if not os.path.exists(cachedir):
+            os.makedirs(cachedir)
+        requests_cache.install_cache(
+            os.path.join(cachedir, "github_info"),
+            expire_after=datetime.timedelta(hours=1),
+            backend="sqlite",
+        )
+    except PermissionError:
+        pass
 
 
 def wait_cli_function(poll_func, poll_every=20):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -96,6 +96,14 @@ class TestUtils(unittest.TestCase):
         pipeline_obj._list_files()
         assert tmp_fn in pipeline_obj.files
 
+    @mock.patch("os.path.exists")
+    @mock.patch("os.makedirs")
+    def test_request_cant_create_cache(self, mock_mkd, mock_exists):
+        """Test that we don't get an error when we can't create cachedirs"""
+        mock_mkd.side_effect = PermissionError()
+        mock_exists.return_value = False
+        nf_core.utils.setup_requests_cachedir()
+
     def test_pip_package_pass(self):
         result = nf_core.utils.pip_package("multiqc=1.10")
         assert type(result) == dict


### PR DESCRIPTION
Catch permission errors while setting up cache directories for requests.

This allows at least starting `nf-core` and some operations (e.g. `download`) without a writable directory designated by `$HOME`.

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
