### PR TITLE
Fix nextflow permissions for non-root users in docker

### DIFF
--- a/tools.Dockerfile
+++ b/tools.Dockerfile
@@ -23,7 +23,8 @@ RUN mkdir -p /usr/share/man/man1 \
 
 # Install Nextflow
 RUN curl -s https://get.nextflow.io | bash \
-      && mv nextflow /usr/local/bin
+      && mv nextflow /usr/local/bin \
+      && chmod a+rx /usr/local/bin/nextflow
 # Add the nf-core source files to the image
 COPY . /usr/src/nf_core
 WORKDIR /usr/src/nf_core


### PR DESCRIPTION
Make sure users other than root can run `nextflow` within the container.
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
