### PR TITLE
Interactive prompts for 'download' and 'launch'

### DIFF
--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -224,8 +224,7 @@ def confirm_singularity_cache(ctx, opts, value):
 @click.option(
     "-c",
     "--compress",
-    type=click.Choice(["tar.gz", "tar.bz2", "zip", "none"]),
-    default="tar.gz",
+    is_flag=True,
     help="Archive compression type",
 )
 @click.option("-f", "--force", is_flag=True, default=False, help="Overwrite existing files")

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -201,8 +201,8 @@ def launch(pipeline, id, revision, command_only, params_in, params_out, save_all
 
 # nf-core download
 @nf_core_cli.command(help_priority=3)
-@click.argument("pipeline", metavar="<pipeline name>")
-@click.option("-r", "--release", type=str, help="Pipeline release")
+@click.argument("pipeline", required=False, metavar="<pipeline name>")
+@click.option("-r", "--release", is_flag=True, help="Pipeline release")
 @click.option("-o", "--outdir", type=str, help="Output directory")
 @click.option(
     "-c",

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -211,11 +211,13 @@ def confirm_container_download(ctx, opts, value):
             value = "none"
     return value
 
+
 def confirm_singularity_cache(ctx, opts, value):
     """Confirm that singularity image should be cached"""
     if not value:
         return Confirm.ask(f"Should singularity image be cached?")
     return value
+
 
 @nf_core_cli.command(help_priority=3)
 @click.argument("pipeline", required=False, metavar="<pipeline name>")
@@ -231,7 +233,7 @@ def confirm_singularity_cache(ctx, opts, value):
 @click.option(
     "-C",
     "--container",
-    type=click.Choice(['none', 'singularity']),
+    type=click.Choice(["none", "singularity"]),
     default=None,
     callback=confirm_container_download,
     help="Download images",

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -203,12 +203,19 @@ def launch(pipeline, id, revision, command_only, params_in, params_out, save_all
 # nf-core download
 def confirm_container_download(ctx, opts, value):
     """Confirm choice of container"""
-    if value != "none":
-        is_satisfied = Confirm.ask(f"Should {value} image be downloaded?")
-        if not is_satisfied:
-            value = 'none'
+    if value == None:
+        should_download = Confirm.ask(f"Should singularity image be downloaded?")
+        if should_download:
+            value = "singularity"
+        else:
+            value = "none"
     return value
 
+def confirm_singularity_cache(ctx, opts, value):
+    """Confirm that singularity image should be cached"""
+    if not value:
+        return Confirm.ask(f"Should singularity image be cached?")
+    return value
 
 @nf_core_cli.command(help_priority=3)
 @click.argument("pipeline", required=False, metavar="<pipeline name>")
@@ -226,7 +233,7 @@ def confirm_container_download(ctx, opts, value):
     "-C",
     "--container",
     type=click.Choice(['none', 'singularity']),
-    default="none",
+    default=None,
     callback=confirm_container_download,
     help="Download images",
 )
@@ -234,6 +241,7 @@ def confirm_container_download(ctx, opts, value):
     "-s",
     "--singularity-cache",
     is_flag=True,
+    callback=confirm_singularity_cache,
     default=False,
     help="Don't copy images to the output directory, don't set 'singularity.cacheDir' in workflow",
 )

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -78,7 +78,7 @@ class DownloadWorkflow(object):
         pipeline=None,
         release_flag=False,
         outdir=None,
-        compress_type="tar.gz",
+        compress=False,
         force=False,
         container='none',
         singularity_cache_only=False,
@@ -89,9 +89,8 @@ class DownloadWorkflow(object):
         self.release = None
         self.outdir = outdir
         self.output_filename = None
-        self.compress_type = compress_type
-        if self.compress_type == "none":
-            self.compress_type = None
+        self.compress = compress
+        self.compress_type = None
         self.force = force
         self.singularity = container == "singularity"
         self.singularity_cache_only = singularity_cache_only
@@ -182,6 +181,15 @@ class DownloadWorkflow(object):
         if self.singularity:
             self.find_container_images()
             self.get_singularity_images()
+
+        # If '--compress' flag was set, ask user what compression type to be used
+        if self.compress:
+            self.compress_type = questionary.select(
+                "Choose compression type:",
+                choices=["none", "tar.gz", "tar.bz2", "zip",]
+            ).ask()
+            if self.compress_type == "none":
+                self.compress_type = None
 
         # Compress into an archive
         if self.compress_type is not None:

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -141,9 +141,7 @@ class DownloadWorkflow(object):
             "Pull singularity containers: '{}'".format("Yes" if self.singularity else "No"),
         ]
         if self.singularity:
-            export_in_file = (
-                os.popen('grep -c "export NXF_SINGULARITY_CACHEDIR" ~/.bashrc').read().strip("\n") != "0"
-            )
+            export_in_file = os.popen('grep -c "export NXF_SINGULARITY_CACHEDIR" ~/.bashrc').read().strip("\n") != "0"
             if not export_in_file:
                 append_to_file = Confirm.ask("Add 'export NXF_SINGULARITY_CACHEDIR' to .bashrc?")
                 if append_to_file:

--- a/nf_core/list.py
+++ b/nf_core/list.py
@@ -71,7 +71,7 @@ def get_local_wf(workflow, revision=None):
     log.info("Downloading workflow: {} ({})".format(workflow, revision))
     pull_cmd = f"nextflow pull {workflow}"
     if revision is not None:
-        pull_cmd += f"-r {revision}"
+        pull_cmd += f" -r {revision}"
     nf_pull_output = nf_core.utils.nextflow_cmd(pull_cmd)
     local_wf = LocalWorkflow(workflow)
     local_wf.get_local_nf_workflow_details()


### PR DESCRIPTION
Added more interactive prompts to `download` and `launch` commands in accordance to https://github.com/nf-core/tools/issues/1009: 

Download:
- Version selection list if `-r`flag is set.
- Confirmation when `--container` (previously `--singularity`) and `--singularity-cache` flags are not set.
- Selection list of compression types when `--compression` flag is set.
- Option to append `export NXF_SINGULARITY_CACHEDIR` to `.bashrc` if not already present. 

Launch:
- Selection list to specify version of pipeline.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
