### PR TITLE
Module lint uses repository and branch specified on command line

### DIFF
--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -510,6 +510,7 @@ def lint(ctx, pipeline_dir, tool, all, local, passed):
     """
     try:
         module_lint = nf_core.modules.ModuleLint(dir=pipeline_dir)
+        module_lint.modules_repo = ctx.obj["modules_repo_obj"]
         module_lint.lint(module=tool, all_modules=all, print_results=True, local=local, show_passed=passed)
     except nf_core.modules.lint.ModuleLintException as e:
         log.error(e)

--- a/nf_core/modules/lint.py
+++ b/nf_core/modules/lint.py
@@ -25,6 +25,7 @@ from nf_core.lint.pipeline_todos import pipeline_todos
 import sys
 
 import nf_core.utils
+from .pipeline_modules import ModulesRepo
 
 log = logging.getLogger(__name__)
 
@@ -45,7 +46,6 @@ class LintResult(object):
         self.file_path = file_path
         self.module_name = mod.module_name
 
-
 class ModuleLint(object):
     """
     An object for linting modules either in a clone of the 'nf-core/modules'
@@ -58,6 +58,7 @@ class ModuleLint(object):
         self.passed = []
         self.warned = []
         self.failed = []
+        self.modules_repo = ModulesRepo()
 
     def lint(self, module=None, all_modules=False, print_results=True, show_passed=False, local=False):
         """
@@ -391,7 +392,7 @@ class ModuleLint(object):
             for mod in nfcore_modules:
                 progress_bar.update(comparison_progress, advance=1, test_name=mod.module_name)
                 module_base_url = (
-                    f"https://raw.githubusercontent.com/nf-core/modules/master/software/{mod.module_name}/"
+                    f"https://raw.githubusercontent.com/{self.modules_repo.name}/{self.modules_repo.branch}/software/{mod.module_name}/"
                 )
 
                 for f in files_to_check:

--- a/nf_core/modules/lint.py
+++ b/nf_core/modules/lint.py
@@ -46,6 +46,7 @@ class LintResult(object):
         self.file_path = file_path
         self.module_name = mod.module_name
 
+
 class ModuleLint(object):
     """
     An object for linting modules either in a clone of the 'nf-core/modules'
@@ -391,9 +392,7 @@ class ModuleLint(object):
             # Loop over nf-core modules
             for mod in nfcore_modules:
                 progress_bar.update(comparison_progress, advance=1, test_name=mod.module_name)
-                module_base_url = (
-                    f"https://raw.githubusercontent.com/{self.modules_repo.name}/{self.modules_repo.branch}/software/{mod.module_name}/"
-                )
+                module_base_url = f"https://raw.githubusercontent.com/{self.modules_repo.name}/{self.modules_repo.branch}/software/{mod.module_name}/"
 
                 for f in files_to_check:
                     # open local copy, continue if file not found (a failed message has already been issued in this case)


### PR DESCRIPTION
Previously, the `-r` and `-b` arguments, specifying the GitHub repository and branch from which to download modules, wasn't used in the module specific lint command. This meant that if you installed a module from a repository other than `nf-core/modules`, and then used `nf-core modules lint` to check if the module was out of date, then it would always be compared to the `nf-core/modules` repository. I've made it so that the `ModuleLint` class uses the `-r` and `-b` command line parameters when it checks for a remote copy.

## PR checklist

 - [X] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
