### PR TITLE
Lint - merge markers - ignore binary files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fix bug in nf-core lint config skipping for the `nextflow_config` test [[#1019](https://github.com/nf-core/tools/issues/1019)]
 * New `-k`/`--key` cli option for `nf-core lint` to allow you to run only named lint tests, for faster local debugging
 * Ignore permission errors for setting up requests cache directories to allow starting with an invalid or read-only HOME directory
+* Merge markers lint test - ignore binary files, allow config to ignore specific files [[#1040](https://github.com/nf-core/tools/pull/1040)]
 
 ### Template
 

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -6,7 +6,6 @@ from genericpath import exists
 import git
 import jinja2
 import logging
-import mimetypes
 import os
 import pathlib
 import requests
@@ -83,8 +82,6 @@ class PipelineCreate(object):
             loader=jinja2.PackageLoader("nf_core", "pipeline-template"), keep_trailing_newline=True
         )
         template_dir = os.path.join(os.path.dirname(__file__), "pipeline-template")
-        binary_ftypes = ["image", "application/java-archive", "application/x-java-archive"]
-        binary_extensions = [".jpeg", ".jpg", ".png", ".zip", ".gz", ".jar", ".tar"]
         object_attrs = vars(self)
         object_attrs["nf_core_version"] = nf_core.__version__
 
@@ -108,15 +105,9 @@ class PipelineCreate(object):
             os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
             try:
-                # Just copy certain file extensions
-                filename, file_extension = os.path.splitext(template_fn_path)
-                if file_extension in binary_extensions:
-                    raise AttributeError(f"File extension: {file_extension}")
-
-                # Try to detect binary files
-                (ftype, encoding) = mimetypes.guess_type(template_fn_path, strict=False)
-                if encoding is not None or (ftype is not None and any([ftype.startswith(ft) for ft in binary_ftypes])):
-                    raise AttributeError(f"Encoding: {encoding}")
+                # Just copy binary files
+                if nf_core.utils.is_file_binary(template_fn_path):
+                    raise AttributeError(f"Binary file: {template_fn_path}")
 
                 # Got this far - render the template
                 log.debug(f"Rendering template file: '{template_fn}'")

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -11,6 +11,7 @@ import git
 import hashlib
 import json
 import logging
+import mimetypes
 import os
 import prompt_toolkit
 import re
@@ -550,3 +551,19 @@ def custom_yaml_dumper():
 
     CustomDumper.add_representer(dict, CustomDumper.represent_dict_preserve_order)
     return CustomDumper
+
+
+def is_file_binary(path):
+    """ Check file path to see if it is a binary file """
+    binary_ftypes = ["image", "application/java-archive", "application/x-java-archive"]
+    binary_extensions = [".jpeg", ".jpg", ".png", ".zip", ".gz", ".jar", ".tar"]
+
+    # Check common file extensions
+    filename, file_extension = os.path.splitext(path)
+    if file_extension in binary_extensions:
+        return True
+
+    # Try to detect binary files
+    (ftype, encoding) = mimetypes.guess_type(path, strict=False)
+    if encoding is not None or (ftype is not None and any([ftype.startswith(ft) for ft in binary_ftypes])):
+        return True


### PR DESCRIPTION
Merge markers lint test:

* Ignore binary files
* Added ability to ignore specific files in the lint config.

Moved binary detection function into utils.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
