### PR TITLE
Add implicit workflow declaration to main.nf template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Template
 
+* Add the implicit workflow declaration to `main.nf` template as discussed [here](https://github.com/nf-core/rnaseq/issues/619)
 * Fixed an issue regarding explicit disabling of unused container engines [[#972](https://github.com/nf-core/tools/pull/972)]
 * Removed trailing slash from `params.igenomes_base` to yield valid s3 paths (previous paths work with Nextflow but not aws cli)
 * Added a timestamp to the trace + timetime + report + dag filenames to fix overwrite issue on AWS

--- a/nf_core/pipeline-template/main.nf
+++ b/nf_core/pipeline-template/main.nf
@@ -52,9 +52,13 @@ Workflow.validateMainParams(workflow, params, json_schema, log)
 /* --            RUN WORKFLOW(S)               -- */
 ////////////////////////////////////////////////////
 
-workflow {
+workflow NFCORE_{{ short_name|upper }} {
     include { {{ short_name|upper }} } from './workflows/pipeline' addParams( summary_params: summary_params )
     {{ short_name|upper }} ()
+}
+
+workflow {
+  NFCORE_{{ short_name|upper }} ()
 }
 
 ////////////////////////////////////////////////////


### PR DESCRIPTION
As discussed [here](https://github.com/nf-core/rnaseq/issues/619), it was agreed to include in the `main.nf` of DSL2 pipelines the implicit declaration of the workflow. This change is added to the DSL2 template on this PR.

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
