### PR TITLE
Remove special nxf 21.03.0-edge versions

### DIFF
--- a/.github/workflows/create-lint-wf.yml
+++ b/.github/workflows/create-lint-wf.yml
@@ -4,8 +4,6 @@ on: [push, pull_request]
 jobs:
   MakeTestWorkflow:
     runs-on: ubuntu-latest
-    env:
-      NXF_VER: 21.03.0-edge
     steps:
       - uses: actions/checkout@v2
         name: Check out source-code repository

--- a/.github/workflows/create-lint-wf.yml
+++ b/.github/workflows/create-lint-wf.yml
@@ -1,6 +1,9 @@
 name: Create a pipeline and lint it
 on: [push, pull_request]
 
+# Uncomment if we need an edge release of Nextflow again
+# env: NXF_EDGE: 1
+
 jobs:
   MakeTestWorkflow:
     runs-on: ubuntu-latest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,8 +12,6 @@ on:
 jobs:
   pytest:
     runs-on: ubuntu-latest
-    env:
-      NXF_VER: 21.03.0-edge
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - "**.py"
 
+# Uncomment if we need an edge release of Nextflow again
+# env: NXF_EDGE: 1
+
 jobs:
   pytest:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -4,6 +4,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+# Uncomment if we need an edge release of Nextflow again
+# env: NXF_EDGE: 1
+
 jobs:
   get-pipelines:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -4,9 +4,6 @@ on:
     types: [published]
   workflow_dispatch:
 
-env:
-  NXF_VER: 21.03.0-edge
-
 jobs:
   get-pipelines:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Merge markers lint test - ignore binary files, allow config to ignore specific files [[#1040](https://github.com/nf-core/tools/pull/1040)]
 * New lint test to check if params in `nextflow config` are mentioned in `main.nf` [[#1038](https://github.com/nf-core/tools/issues/1038)]
 * New modules lint test comparing the `functions.nf` file to the template version
+* Use latest stable Nextflow version `21.04.0` for CI tests instead of the `-edge` release
 
 ### Template
 

--- a/nf_core/bump_version.py
+++ b/nf_core/bump_version.py
@@ -145,8 +145,8 @@ def bump_nextflow_version(pipeline_obj, new_version):
         pipeline_obj,
         [
             (
-                r"nxf_ver: \[[\'\"]?{}[\'\"]?, '21.03.0-edge'\]".format(current_version.replace(".", r"\.")),
-                "nxf_ver: ['{}', '21.03.0-edge']".format(new_version),
+                r"nxf_ver: \[[\'\"]?{}[\'\"]?, ''\]".format(current_version.replace(".", r"\.")),
+                "nxf_ver: ['{}', '']".format(new_version),
             )
         ],
     )

--- a/nf_core/pipeline-template/.github/workflows/ci.yml
+++ b/nf_core/pipeline-template/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
-        nxf_ver: ['20.04.0', '21.03.0-edge']
+        nxf_ver: ['20.04.0', '']
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2

--- a/nf_core/pipeline-template/.github/workflows/ci.yml
+++ b/nf_core/pipeline-template/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   release:
     types: [published]
 
+# Uncomment if we need an edge release of Nextflow again
+# env: NXF_EDGE: 1
+
 jobs:
   test:
     name: Run workflow tests


### PR DESCRIPTION
Now that the stable 21.04.0 Nextflow release is out, we can revert to using the latest stable version of Nextflow for CI tests etc.

Hopefully I got them all...

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
