### PR TITLE
Singularity download - don't add hyphen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * New modules lint test comparing the `functions.nf` file to the template version
 * Use latest stable Nextflow version `21.04.0` for CI tests instead of the `-edge` release
 * Added temporary fix to remove warnings about params that get converted from camelCase to camel-case [[#1035](https://github.com/nf-core/tools/issues/1035)]
+* Fix bug in `nf-core download` where image names were getting a hyphen in `nf-core` which was breaking things.
 
 ### Template
 

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -503,8 +503,6 @@ class DownloadWorkflow(object):
             out_name = out_name[:-4]
         # Strip : and / characters
         out_name = out_name.replace("/", "-").replace(":", "-")
-        # Stupid Docker Hub not allowing hyphens
-        out_name = out_name.replace("nfcore", "nf-core")
         # Add file extension
         out_name = out_name + extension
 


### PR DESCRIPTION
So apparently I added this code back for the `v1.13` release, but I think it breaks stuff. As much as that hyphen brings back a certain aesthetic to the image filenames, it also means that they do not match the filename that Nextflow is looking for when it runs the pipeline. This means that Nextflow then tries to fetch the image.

Discovered in diaproteomics pipeline [in Slack](https://nfcore.slack.com/archives/C017PDRCQQG/p1620252286147100). Kind of surprised that we haven't had more bug reports about this one 🤔 

Sorry all.. 🙏🏻 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
