### PR TITLE
ignored maps in params_used check

### DIFF
--- a/nf_core/lint/params_used.py
+++ b/nf_core/lint/params_used.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
 import os
+import logging
+
+log = logging.getLogger(__name__)
 
 
 def params_used(self):
@@ -29,6 +32,7 @@ def params_used(self):
             ignored.append("Config variable ignored: {}".format(self._wrap_quotes(cf)))
             continue
         if cf.count(".") > 1:
+            log.debug(f"Ignoring nested param: {cf}")
             continue
         if cf in main_nf:
             passed.append("Config variable found in `main.nf`: {}".format(self._wrap_quotes(cf)))


### PR DESCRIPTION
This fixes the issue in #1055 

Very simple solution by just checking whether the `param` contains more than one `.` 

In my logic, there can never be more than one dot unless it is a list or something like that. Am I missing something, or can we go with this?

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
