### PR TITLE
Add `params_used` lint ignore list

### DIFF
--- a/nf_core/lint/params_used.py
+++ b/nf_core/lint/params_used.py
@@ -15,6 +15,8 @@ def params_used(self):
         "params.config_profile_name",
         "params.show_hidden_params",
         "params.schema_ignore_params",
+        "params.igenomes_base",
+        "params.igenomes_ignore",
     ]
     ignore_params = self.lint_config.get("params_used", [])
 


### PR DESCRIPTION
Add `igenomes_base` and `igenomes_ignore` to the params to ignore in `params_used` lint test.

