### PR TITLE
Update comments on functions.nf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Template
 
+* Update comment style of modules `function.nf` template file [[#1076](https://github.com/nf-core/tools/issues/1076)]
 * Fixed an issue regarding explicit disabling of unused container engines [[#972](https://github.com/nf-core/tools/pull/972)]
 * Removed trailing slash from `params.igenomes_base` to yield valid s3 paths (previous paths work with Nextflow but not aws cli)
 * Added a timestamp to the trace + timetime + report + dag filenames to fix overwrite issue on AWS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Fixed a bug in the Docker image build for tools that failed due to an extra hyphen. [[#1069](https://github.com/nf-core/tools/pull/1069)]
 * Regular release sync fix - this time it was to do with JSON serialisation [[#1072](https://github.com/nf-core/tools/pull/1072)]
 
+### Modules
+
+* Update comment style of modules `function.nf` template file [[#1076](https://github.com/nf-core/tools/issues/1076)]
+
 ## [v1.14 - Brass Chicken :chicken:](https://github.com/nf-core/tools/releases/tag/1.14) - [2021-05-11]
 
 ### Template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,12 @@
 
 ### Modules
 
-* Update comment style of modules `function.nf` template file [[#1076](https://github.com/nf-core/tools/issues/1076)]
+* Update comment style of modules `functions.nf` template file [[#1076](https://github.com/nf-core/tools/issues/1076)]
 
 ## [v1.14 - Brass Chicken :chicken:](https://github.com/nf-core/tools/releases/tag/1.14) - [2021-05-11]
 
 ### Template
 
-* Update comment style of modules `functions.nf` template file [[#1076](https://github.com/nf-core/tools/issues/1076)]
 * Fixed an issue regarding explicit disabling of unused container engines [[#972](https://github.com/nf-core/tools/pull/972)]
 * Removed trailing slash from `params.igenomes_base` to yield valid s3 paths (previous paths work with Nextflow but not aws cli)
 * Added a timestamp to the trace + timetime + report + dag filenames to fix overwrite issue on AWS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@
 
 * Don't set the default value to `"null"` when a parameter is initialised as `null` in the config [[#1074](https://github.com/nf-core/tools/pull/1074)]
 
-
 ## [v1.14 - Brass Chicken :chicken:](https://github.com/nf-core/tools/releases/tag/1.14) - [2021-05-11]
 
 ### Template

--- a/nf_core/module-template/software/functions.nf
+++ b/nf_core/module-template/software/functions.nf
@@ -1,19 +1,17 @@
-/*
- * -----------------------------------------------------
- *  Utility functions used in nf-core DSL2 module files
- * -----------------------------------------------------
- */
+// 
+//  Utility functions used in nf-core DSL2 module files
+//
 
-/*
- * Extract name of software tool from process name using $task.process
- */
+//
+// Extract name of software tool from process name using $task.process
+//
 def getSoftwareName(task_process) {
     return task_process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()
 }
 
-/*
- * Function to initialise default values and to generate a Groovy Map of available options for nf-core modules
- */
+//
+// Function to initialise default values and to generate a Groovy Map of available options for nf-core modules
+//
 def initOptions(Map args) {
     def Map options = [:]
     options.args            = args.args ?: ''
@@ -26,18 +24,18 @@ def initOptions(Map args) {
     return options
 }
 
-/*
- * Tidy up and join elements of a list to return a path string
- */
+//
+// Tidy up and join elements of a list to return a path string
+//
 def getPathFromList(path_list) {
     def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
     paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
-/*
- * Function to save/publish module results
- */
+//
+// Function to save/publish module results
+//
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
         def ioptions  = initOptions(args.options)


### PR DESCRIPTION
As discussed on #1076, the comments on `functions.nf` template have been updated to follow the new commenting style.

Closes #1076

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated

