### PR TITLE
Put the TODO comment in a YAML array.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # nf-core/tools: Changelog
 
+## v1.14.1dev
+
+### Template
+
+* Move TODO item of `contains:` map in a YAML string [[#1082](https://github.com/nf-core/tools/issues/1082)]
+
 ## [v1.14 - Brass Chicken :chicken:](https://github.com/nf-core/tools/releases/tag/1.14) - [2021-05-11]
 
 ### Template

--- a/nf_core/modules/test_yml_builder.py
+++ b/nf_core/modules/test_yml_builder.py
@@ -241,7 +241,7 @@ class ModulesTestYmlBuilder(object):
                 test_files[i].pop("md5sum")
                 test_files[i][
                     "contains"
-                ] = "# TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead"
+                ] = "[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]"
 
         if len(test_files) == 0:
             raise UserWarning(f"Could not find any test result files in '{results_dir}'")


### PR DESCRIPTION
The `contains:` map needs an array of strings.  By placing the TODO comment between brackets I hope that the user will be more likely to produce a valid file. 

Closes: #1082

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
