### PR TITLE
Add missing iGenome - Rnor_5.0

### DIFF
--- a/nf_core/pipeline-template/conf/igenomes.config
+++ b/nf_core/pipeline-template/conf/igenomes.config
@@ -196,6 +196,16 @@ params {
       readme      = "${params.igenomes_base}/Pan_troglodytes/Ensembl/CHIMP2.1.4/Annotation/README.txt"
       mito_name   = "MT"
     }
+    'Rnor_5.0' {
+      fasta       = "${params.igenomes_base}/Rattus_norvegicus/Ensembl/Rnor_5.0/Sequence/WholeGenomeFasta/genome.fa"
+      bwa         = "${params.igenomes_base}/Rattus_norvegicus/Ensembl/Rnor_5.0/Sequence/BWAIndex/genome.fa"
+      bowtie2     = "${params.igenomes_base}/Rattus_norvegicus/Ensembl/Rnor_5.0/Sequence/Bowtie2Index/"
+      star        = "${params.igenomes_base}/Rattus_norvegicus/Ensembl/Rnor_5.0/Sequence/STARIndex/"
+      bismark     = "${params.igenomes_base}/Rattus_norvegicus/Ensembl/Rnor_5.0/Sequence/BismarkIndex/"
+      gtf         = "${params.igenomes_base}/Rattus_norvegicus/Ensembl/Rnor_5.0/Annotation/Genes/genes.gtf"
+      bed12       = "${params.igenomes_base}/Rattus_norvegicus/Ensembl/Rnor_5.0/Annotation/Genes/genes.bed"
+      mito_name   = "MT"
+    }
     'Rnor_6.0' {
       fasta       = "${params.igenomes_base}/Rattus_norvegicus/Ensembl/Rnor_6.0/Sequence/WholeGenomeFasta/genome.fa"
       bwa         = "${params.igenomes_base}/Rattus_norvegicus/Ensembl/Rnor_6.0/Sequence/BWAIndex/genome.fa"


### PR DESCRIPTION
Rnor_5.0 is available in AWS iGenomes, but missing in the config file leading to pipeline errors. This commit should fix it and propagate the fix to all pipelines.

See also https://github.com/nf-core/rnaseq/issues/639

## PR checklist

 - [X] This comment contains a description of changes (with reason)
 - [X] `CHANGELOG.md` is updated
I don't think such a small change warrants this, but let me know if it does.
 - [X] If you've fixed a bug or added code that should be tested, add tests!
 I hope existing tests cover this small change.
