### PR TITLE
Download - use relative path for configs import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fixed a bug in the Docker image build for tools that failed due to an extra hyphen. [[#1069](https://github.com/nf-core/tools/pull/1069)]
 * Regular release sync fix - this time it was to do with JSON serialisation [[#1072](https://github.com/nf-core/tools/pull/1072)]
 * Fixed bug in schema validation that ignores upper/lower-case typos in parameters [[#1087](https://github.com/nf-core/tools/issues/1087)]
+* Bugfix: Download should use path relative to workflow for configs
 
 ### Modules
 

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -388,7 +388,7 @@ class DownloadWorkflow(object):
         """Edit the downloaded nextflow.config file to use the local config files"""
         nfconfig_fn = os.path.join(self.outdir, "workflow", "nextflow.config")
         find_str = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
-        repl_str = "../configs/"
+        repl_str = "${projectDir}/../configs/"
         log.debug("Editing 'params.custom_config_base' in '{}'".format(nfconfig_fn))
 
         # Load the nextflow.config file into memory

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -113,7 +113,7 @@ class DownloadTest(unittest.TestCase):
         # Test the function
         download_obj.wf_use_local_configs()
         wf_config = nf_core.utils.fetch_wf_config(os.path.join(test_outdir, "workflow"))
-        assert wf_config["params.custom_config_base"] == "'../configs/'"
+        assert wf_config["params.custom_config_base"] == f"'{test_outdir}/workflow/../configs/'"
 
     #
     # Tests for 'find_container_images'


### PR DESCRIPTION
Small bugfix - when running `nf-core download` it edits the `nextflow.config` file to make it work with the downloaded files with relative links.

The singularity cacheDir stuff correctly uses `$projectDir` to make these paths relative to the workflow, irrespective of where it was run from. However, the config base did not.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
