### PR TITLE
Fail if functions.nf doesnt match template

### DIFF
--- a/nf_core/module-template/software/functions.nf
+++ b/nf_core/module-template/software/functions.nf
@@ -1,4 +1,4 @@
-// 
+//
 //  Utility functions used in nf-core DSL2 module files
 //
 

--- a/nf_core/modules/lint.py
+++ b/nf_core/modules/lint.py
@@ -848,7 +848,7 @@ class NFCoreModule(object):
 
         # Compare the files
         if local_copy != template_copy:
-            self.warned.append(("function_nf_comparison", "New version of functions.nf available", self.function_nf))
+            self.failed.append(("function_nf_comparison", "New version of functions.nf available", self.function_nf))
         else:
             self.passed.append(("function_nf_comparison", "functions.nf is up to date", self.function_nf))
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -117,7 +117,7 @@ class TestModules(unittest.TestCase):
         """Test linting the fastqc module"""
         self.mods.install("fastqc")
         module_lint = nf_core.modules.ModuleLint(dir=self.pipeline_dir)
-        module_lint.lint(print_results=False, all_modules=True)
+        module_lint.lint(print_results=False, module="fastqc")
         assert len(module_lint.passed) > 0
         assert len(module_lint.warned) >= 0
         assert len(module_lint.failed) == 0


### PR DESCRIPTION
`nf-core modules lint` currently generates a warning if the `functions.nf` doesn't match that present in the modules template. This PR downgrades it to a failure so it is more visible to developers who submit to nf-core/modules. Much easier than checking manually and commenting.