### PR TITLE
fix status typo for schema

### DIFF
--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -301,7 +301,7 @@ class Launch(object):
         try:
             assert "api_url" in web_response
             assert "web_url" in web_response
-            assert web_response["status"] == "recieved"
+            assert web_response["status"] == "received"
         except AssertionError:
             log.debug("Response content:\n{}".format(json.dumps(web_response, indent=4)))
             raise AssertionError(

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -555,7 +555,7 @@ class PipelineSchema(object):
         try:
             assert "api_url" in web_response
             assert "web_url" in web_response
-            assert web_response["status"] == "recieved"
+            assert web_response["status"] == "received"
         except (AssertionError) as e:
             log.debug("Response content:\n{}".format(json.dumps(web_response, indent=4)))
             raise AssertionError(

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -124,7 +124,7 @@ class TestLaunch(unittest.TestCase):
             assert e.args[0].startswith("Web launch response not recognised:")
 
     @mock.patch(
-        "nf_core.utils.poll_nfcore_web_api", side_effect=[{"api_url": "foo", "web_url": "bar", "status": "recieved"}]
+        "nf_core.utils.poll_nfcore_web_api", side_effect=[{"api_url": "foo", "web_url": "bar", "status": "received"}]
     )
     @mock.patch("webbrowser.open")
     @mock.patch("nf_core.utils.wait_cli_function")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -354,7 +354,7 @@ class TestSchema(unittest.TestCase):
             return MockResponse(response_data, 200)
 
         if kwargs["url"] == "valid_url_success":
-            response_data = {"status": "recieved", "api_url": "https://nf-co.re", "web_url": "https://nf-co.re"}
+            response_data = {"status": "received", "api_url": "https://nf-co.re", "web_url": "https://nf-co.re"}
             return MockResponse(response_data, 200)
 
     @mock.patch("requests.post", side_effect=mocked_requests_post)


### PR DESCRIPTION
the website counterpart was fixed in https://github.com/nf-core/nf-co.re/pull/760 and I forgot that the tools part also checks for it, sorry.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated