### PR TITLE
Bump to v1.15dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # nf-core/tools: Changelog
 
-## v1.14.1dev
+## v1.15dev
 
 ### Template
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-version = "1.14"
+version = "1.15dev"
 
 with open("README.md") as f:
     readme = f.read()


### PR DESCRIPTION
Looks like the version number was never bumped after the release - probably my fault, sorry (this is what you get for doing a live release during a talk!).

Bumping to v1.15dev now.