### PR TITLE
Biocontainer api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Modules
 
 * Update comment style of modules `functions.nf` template file [[#1076](https://github.com/nf-core/tools/issues/1076)]
+* Use Biocontainers API instead of quayi.io API for `nf-core modules create` [[#875](https://github.com/nf-core/tools/issues/875)]
 
 #### Sync
 

--- a/nf_core/module-template/software/main.nf
+++ b/nf_core/module-template/software/main.nf
@@ -33,9 +33,9 @@ process {{ tool_name_underscore|upper }} {
     // TODO nf-core: See section in main README for further information regarding finding and adding container addresses to the section below.
     conda (params.enable_conda ? "{{ bioconda if bioconda else 'YOUR-TOOL-HERE' }}" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/{{ container_tag if container_tag else 'YOUR-TOOL-HERE' }}"
+        container "https://depot.galaxyproject.org/singularity/{{ singularity_container if singularity_container else 'YOUR-TOOL-HERE' }}"
     } else {
-        container "quay.io/biocontainers/{{ container_tag if container_tag else 'YOUR-TOOL-HERE' }}"
+        container "quay.io/biocontainers/{{ docker_container if docker_container else 'YOUR-TOOL-HERE' }}"
     }
 
     input:

--- a/nf_core/modules/create.py
+++ b/nf_core/modules/create.py
@@ -156,9 +156,13 @@ class ModuleCreate(object):
         if self.bioconda:
             try:
                 if self.tool_conda_name:
-                    self.docker_container, self.singularity_container = nf_core.utils.get_biocontainer_tag(self.tool_conda_name, version)
+                    self.docker_container, self.singularity_container = nf_core.utils.get_biocontainer_tag(
+                        self.tool_conda_name, version
+                    )
                 else:
-                    self.docker_container, self.singularity_container =  nf_core.utils.get_biocontainer_tag(self.tool, version)
+                    self.docker_container, self.singularity_container = nf_core.utils.get_biocontainer_tag(
+                        self.tool, version
+                    )
                 log.info(f"Using Docker container: '{self.docker_container}'")
                 log.info(f"Using Singularity container: '{self.singularity_container}'")
             except (ValueError, LookupError) as e:

--- a/nf_core/modules/create.py
+++ b/nf_core/modules/create.py
@@ -42,7 +42,8 @@ class ModuleCreate(object):
         self.tool_doc_url = ""
         self.tool_dev_url = ""
         self.bioconda = None
-        self.container_tag = None
+        self.singularity_container = None
+        self.docker_container = None
         self.file_paths = {}
 
     def create(self):
@@ -155,12 +156,13 @@ class ModuleCreate(object):
         if self.bioconda:
             try:
                 if self.tool_conda_name:
-                    self.container_tag = nf_core.utils.get_biocontainer_tag(self.tool_conda_name, version)
+                    self.docker_container, self.singularity_container = nf_core.utils.get_biocontainer_tag(self.tool_conda_name, version)
                 else:
-                    self.container_tag = nf_core.utils.get_biocontainer_tag(self.tool, version)
-                log.info(f"Using Docker / Singularity container with tag: '{self.container_tag}'")
+                    self.docker_container, self.singularity_container =  nf_core.utils.get_biocontainer_tag(self.tool, version)
+                log.info(f"Using Docker container: '{self.docker_container}'")
+                log.info(f"Using Singularity container: '{self.singularity_container}'")
             except (ValueError, LookupError) as e:
-                log.info(f"Could not find a container tag ({e})")
+                log.info(f"Could not find a Docker/Singularity container ({e})")
 
         # Prompt for GitHub username
         # Try to guess the current user if `gh` is installed

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -6,6 +6,7 @@ import nf_core
 
 from distutils import version
 import datetime
+import dateutil.parser
 import errno
 import git
 import hashlib
@@ -496,8 +497,7 @@ def get_biocontainer_tag(package, version):
         Format a date given by the biocontainers API
         Given format: '2021-03-25T08:53:00Z'
         """
-        tag_date = tag_date.split("T")[0].split("-")
-        return datetime.date(year=int(tag_date[0]), month=int(tag_date[1]), day=int(tag_date[2]))
+        return dateutil.parser.parse(tag_date)
 
     try:
         response = requests.get(biocontainers_api_url)

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -526,7 +526,7 @@ def get_biocontainer_tag(package, version):
         elif response.status_code != 404:
             raise LookupError(f"Unexpected response code `{response.status_code}` for {biocontainers_api_url}")
         elif response.status_code == 404:
-            raise ValueError(f"Could not fine `{package}` on api.biocontainers.pro")
+            raise ValueError(f"Could not find `{package}` on api.biocontainers.pro")
 
 
 def custom_yaml_dumper():

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -474,13 +474,12 @@ def pip_package(dep):
         else:
             raise ValueError("Could not find pip dependency using the PyPI API: `{}`".format(dep))
 
-
 def get_biocontainer_tag(package, version):
     """
-    Given a bioconda package and version, look for a container
-    at quay.io and returns the tag of the most recent image
-    that matches the package version
-    Sends a HTTP GET request to the quay.io API.
+    Given a bioconda package and verion, looks for Docker and Singularity containers
+    using the biocontaineres API, e.g.:
+    https://api.biocontainers.pro/ga4gh/trs/v2/tools/{tool}/versions/{tool}-{version}
+    Returns the most recent container versions by default.  
     Args:
         package (str): A bioconda package name.
         version (str): Version of the bioconda package
@@ -489,38 +488,44 @@ def get_biocontainer_tag(package, version):
         A ValueError, if the package name can not be found (404)
     """
 
+    biocontainers_api_url = f"https://api.biocontainers.pro/ga4gh/trs/v2/tools/{package}/versions/{package}-{version}"
+
     def get_tag_date(tag_date):
-        # Reformat a date given by quay.io to  datetime
-        return datetime.datetime.strptime(tag_date.replace("-0000", "").strip(), "%a, %d %b %Y %H:%M:%S")
-
-    quay_api_url = f"https://quay.io/api/v1/repository/biocontainers/{package}/tag/"
-
+        """
+        Format a date given by the biocontainers API
+        Given format: '2021-03-25T08:53:00Z'
+        """
+        tag_date = tag_date.split("T")[0].split("-")
+        return datetime.date(year=int(tag_date[0]), month=int(tag_date[1]), day=int(tag_date[2]))
+        
     try:
-        response = requests.get(quay_api_url)
+        response = requests.get(biocontainers_api_url)
     except requests.exceptions.ConnectionError:
-        raise LookupError("Could not connect to quay.io API")
+        raise LookupError("Could not connect to biocontainers.pro API")
     else:
         if response.status_code == 200:
-            # Get the container tag
-            tags = response.json()["tags"]
-            matching_tags = [t for t in tags if t["name"].startswith(version)]
-            # If version matches several images, get the most recent one, else return tag
-            if len(matching_tags) > 0:
-                tag = matching_tags[0]
-                tag_date = get_tag_date(tag["last_modified"])
-                for t in matching_tags:
-                    if get_tag_date(t["last_modified"]) > tag_date:
-                        tag = t
-                return package + ":" + tag["name"]
-            else:
-                return matching_tags[0]["name"]
+            print(response.json())
+            images = response.json()["images"]
+            singularity_image = None
+            docker_image = None
+            for img in images:
+                if img["image_type"] == "Docker":
+                    modification_date = get_tag_date(img["updated"])
+                    if docker_image and modification_date < get_tag_date(docker_image["updated"]):
+                        continue
+                    else:
+                        docker_image = img
+                if img["image_type"] == "Singularity":
+                    modification_date = get_tag_date(img["updated"])
+                    if singularity_image and modification_date < get_tag_date(singularity_image["updated"]):
+                        continue
+                    else:
+                        singularity_image = img
+            return docker_image["image_name"], singularity_image["image_name"]
         elif response.status_code != 404:
-            raise LookupError(
-                f"quay.io API returned unexpected response code `{response.status_code}` for {quay_api_url}"
-            )
+            raise LookupError(f"Unexpected response code `{response.status_code}` for {biocontainers_api_url}")
         elif response.status_code == 404:
-            raise ValueError(f"Could not find `{package}` on quayi.io/repository/biocontainers")
-
+            raise ValueError(f"Could not fine `{package}` on api.biocontainers.pro")
 
 def custom_yaml_dumper():
     """Overwrite default PyYAML output to make Prettier YAML linting happy"""

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -6,7 +6,6 @@ import nf_core
 
 from distutils import version
 import datetime
-import dateutil.parser
 import errno
 import git
 import hashlib
@@ -497,7 +496,7 @@ def get_biocontainer_tag(package, version):
         Format a date given by the biocontainers API
         Given format: '2021-03-25T08:53:00Z'
         """
-        return dateutil.parser.parse(tag_date)
+        return datetime.datetime.strptime(tag_date, "%Y-%m-%dT%H:%M:%SZ")
 
     try:
         response = requests.get(biocontainers_api_url)
@@ -509,7 +508,7 @@ def get_biocontainer_tag(package, version):
             singularity_image = None
             docker_image = None
             for img in images:
-                # Get most recent Docker and Singularity images
+                # Get most recent Docker and Singularity image
                 if img["image_type"] == "Docker":
                     modification_date = get_tag_date(img["updated"])
                     if not docker_image or modification_date > get_tag_date(docker_image["updated"]):

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -477,7 +477,7 @@ def pip_package(dep):
 
 def get_biocontainer_tag(package, version):
     """
-    Given a bioconda package and verion, looks for Docker and Singularity containers
+    Given a bioconda package and version, looks for Docker and Singularity containers
     using the biocontaineres API, e.g.:
     https://api.biocontainers.pro/ga4gh/trs/v2/tools/{tool}/versions/{tool}-{version}
     Returns the most recent container versions by default.

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -474,12 +474,13 @@ def pip_package(dep):
         else:
             raise ValueError("Could not find pip dependency using the PyPI API: `{}`".format(dep))
 
+
 def get_biocontainer_tag(package, version):
     """
     Given a bioconda package and verion, looks for Docker and Singularity containers
     using the biocontaineres API, e.g.:
     https://api.biocontainers.pro/ga4gh/trs/v2/tools/{tool}/versions/{tool}-{version}
-    Returns the most recent container versions by default.  
+    Returns the most recent container versions by default.
     Args:
         package (str): A bioconda package name.
         version (str): Version of the bioconda package
@@ -497,7 +498,7 @@ def get_biocontainer_tag(package, version):
         """
         tag_date = tag_date.split("T")[0].split("-")
         return datetime.date(year=int(tag_date[0]), month=int(tag_date[1]), day=int(tag_date[2]))
-        
+
     try:
         response = requests.get(biocontainers_api_url)
     except requests.exceptions.ConnectionError:
@@ -526,6 +527,7 @@ def get_biocontainer_tag(package, version):
             raise LookupError(f"Unexpected response code `{response.status_code}` for {biocontainers_api_url}")
         elif response.status_code == 404:
             raise ValueError(f"Could not fine `{package}` on api.biocontainers.pro")
+
 
 def custom_yaml_dumper():
     """Overwrite default PyYAML output to make Prettier YAML linting happy"""

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -505,22 +505,18 @@ def get_biocontainer_tag(package, version):
         raise LookupError("Could not connect to biocontainers.pro API")
     else:
         if response.status_code == 200:
-            
             images = response.json()["images"]
             singularity_image = None
             docker_image = None
             for img in images:
+                # Get most recent Docker and Singularity images
                 if img["image_type"] == "Docker":
                     modification_date = get_tag_date(img["updated"])
-                    if docker_image and modification_date < get_tag_date(docker_image["updated"]):
-                        continue
-                    else:
+                    if not docker_image or modification_date > get_tag_date(docker_image["updated"]):
                         docker_image = img
                 if img["image_type"] == "Singularity":
                     modification_date = get_tag_date(img["updated"])
-                    if singularity_image and modification_date < get_tag_date(singularity_image["updated"]):
-                        continue
-                    else:
+                    if not singularity_image or modification_date > get_tag_date(singularity_image["updated"]):
                         singularity_image = img
             return docker_image["image_name"], singularity_image["image_name"]
         elif response.status_code != 404:

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -505,7 +505,7 @@ def get_biocontainer_tag(package, version):
         raise LookupError("Could not connect to biocontainers.pro API")
     else:
         if response.status_code == 200:
-            print(response.json())
+            
             images = response.json()["images"]
             singularity_image = None
             docker_image = None


### PR DESCRIPTION
Use the Biocontainers API instead of quay.io to get container tags for Docker and Singularity containers as suggested in #875 

I have not implemented any questionary selection now, as you have suggested @ewels . Mainly because I think it would be good to have the most recent version as default, and allowing users to choose a container tag/version for both Docker and Singularity could mean they choose different builds. The linter should complain about this, or we could directly check within `nf-core modules create`, but easiest would be to just avoid this in the first place.

Wouldn't be too hard to add it in though so up for discussion I'd say :-) 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
