### PR TITLE
Updated `nf-core modules remove` to remove entry in `modules.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Use Biocontainers API instead of quayi.io API for `nf-core modules create` [[#875](https://github.com/nf-core/tools/issues/875)]
 * Update `nf-core modules install` to handle different versions of modules  [#1116](https://github.com/nf-core/tools/pull/1116)
 * Refactored `nf-core modules` command into one file per command [#1124](https://github.com/nf-core/tools/pull/1124)
+* Updated `nf-core modules remove` to also remove entry in `modules.json` file ([#1115](https://github.com/nf-core/tools/issues/1115))
 
 #### Sync
 

--- a/nf_core/modules/remove.py
+++ b/nf_core/modules/remove.py
@@ -59,8 +59,7 @@ class ModuleRemove(ModuleCommand):
         log.info("Removing {}".format(module))
 
         # Remove entry from modules.json
-        if not self.remove_modules_json_entry(module):
-            return False
+        self.remove_modules_json_entry(module)
 
         # Remove the module
         return self.clear_module_dir(module_name=module, module_dir=module_dir)

--- a/nf_core/modules/remove.py
+++ b/nf_core/modules/remove.py
@@ -68,17 +68,19 @@ class ModuleRemove(ModuleCommand):
     def remove_modules_json_entry(self, module):
         # Load 'modules.json'
         modules_json_path = os.path.join(self.dir, "modules.json")
-        with open(modules_json_path, "r") as fh:
-            modules_json = json.load(fh)
+        try:
+            with open(modules_json_path, "r") as fh:
+                modules_json = json.load(fh)
+        except FileNotFoundError:
+            log.error("File 'modules.json' is missing")
+            return False
         if module in modules_json.get("modules", {}):
             modules_json["modules"].pop(module)
         else:
-            # If the module is missing from modules.json we can still clear the directory
-            # in which the untracked module resides
             log.error(f"Module '{module}' is missing from 'modules.json' file.")
-            return questionary.confirm(
-                f"Do you wish to continue removing module '{module}'?", default=False
-            ).unsafe_ask()
+            return False
+
         with open(modules_json_path, "w") as fh:
             json.dump(modules_json, fh, indent=4)
+
         return True

--- a/nf_core/modules/remove.py
+++ b/nf_core/modules/remove.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import json
 import questionary
 import logging
 
@@ -43,7 +44,6 @@ class ModuleRemove(ModuleCommand):
 
         # Set the install folder based on the repository name
         install_folder = ["nf-core", "software"]
-        print(self.modules_repo.name)
         if not self.modules_repo.name == "nf-core/modules":
             install_folder = ["external"]
 
@@ -58,5 +58,27 @@ class ModuleRemove(ModuleCommand):
 
         log.info("Removing {}".format(module))
 
+        # Remove entry from modules.json
+        if not self.remove_modules_json_entry(module):
+            return False
+
         # Remove the module
         return self.clear_module_dir(module_name=module, module_dir=module_dir)
+
+    def remove_modules_json_entry(self, module):
+        # Load 'modules.json'
+        modules_json_path = os.path.join(self.dir, "modules.json")
+        with open(modules_json_path, "r") as fh:
+            modules_json = json.load(fh)
+        if module in modules_json.get("modules", {}):
+            modules_json["modules"].pop(module)
+        else:
+            # If the module is missing from modules.json we can still clear the directory
+            # in which the untracked module resides
+            log.error(f"Module '{module}' is missing from 'modules.json' file.")
+            return questionary.confirm(
+                f"Do you wish to continue removing module '{module}'?", default=False
+            ).unsafe_ask()
+        with open(modules_json_path, "w") as fh:
+            json.dump(modules_json, fh, indent=4)
+        return True


### PR DESCRIPTION
Updated `nf-core modules remove` to remove entry in `modules.json` as suggested in #1115. If entry is missing from `modules.json` the user is asked if they want to continue removing the module directory.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
