### PR TITLE
Fix bug in `nf-core modules install` version prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Update `nf-core modules install` to handle different versions of modules  [#1116](https://github.com/nf-core/tools/pull/1116)
 * Refactored `nf-core modules` command into one file per command [#1124](https://github.com/nf-core/tools/pull/1124)
 * Updated `nf-core modules remove` to also remove entry in `modules.json` file ([#1115](https://github.com/nf-core/tools/issues/1115))
+* Bugfix: Interactive prompt for `nf-core modules install` was receiving too few arguments
 
 #### Sync
 

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -98,8 +98,19 @@ class ModuleCommand:
         log.info("Downloaded {} files to {}".format(len(files), module_dir))
         return True
 
-    def update_modules_json(self, modules_json, modules_json_path, module_name, module_version):
+    def load_modules_json(self):
+        modules_json_path = os.path.join(self.dir, "modules.json")
+        try:
+            with open(modules_json_path, "r") as fh:
+                modules_json = json.load(fh)
+        except FileNotFoundError:
+            log.error("File 'modules.json' is missing")
+            modules_json = None
+        return modules_json
+
+    def update_modules_json(self, modules_json, module_name, module_version):
         """Updates the 'module.json' file with new module info"""
+        modules_json_path = os.path.join(self.dir, "modules.json")
         modules_json["modules"][module_name] = {"git_sha": module_version}
         with open(modules_json_path, "w") as fh:
             json.dump(modules_json, fh, indent=4)

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -108,9 +108,12 @@ class ModuleCommand:
             modules_json = None
         return modules_json
 
-    def update_modules_json(self, modules_json, module_name, module_version):
-        """Updates the 'module.json' file with new module info"""
+    def dump_modules_json(self, modules_json):
         modules_json_path = os.path.join(self.dir, "modules.json")
-        modules_json["modules"][module_name] = {"git_sha": module_version}
         with open(modules_json_path, "w") as fh:
             json.dump(modules_json, fh, indent=4)
+
+    def update_modules_json(self, modules_json, module_name, module_version):
+        """Updates the 'module.json' file with new module info"""
+        modules_json["modules"][module_name] = {"git_sha": module_version}
+        self.dump_modules_json(modules_json)

--- a/nf_core/modules/remove.py
+++ b/nf_core/modules/remove.py
@@ -66,12 +66,8 @@ class ModuleRemove(ModuleCommand):
 
     def remove_modules_json_entry(self, module):
         # Load 'modules.json'
-        modules_json_path = os.path.join(self.dir, "modules.json")
-        try:
-            with open(modules_json_path, "r") as fh:
-                modules_json = json.load(fh)
-        except FileNotFoundError:
-            log.error("File 'modules.json' is missing")
+        modules_json = self.load_modules_json()
+        if not modules_json:
             return False
         if module in modules_json.get("modules", {}):
             modules_json["modules"].pop(module)
@@ -79,7 +75,6 @@ class ModuleRemove(ModuleCommand):
             log.error(f"Module '{module}' is missing from 'modules.json' file.")
             return False
 
-        with open(modules_json_path, "w") as fh:
-            json.dump(modules_json, fh, indent=4)
+        self.dump_modules_json(modules_json)
 
         return True


### PR DESCRIPTION
Fixed the interactive prompt in `nf-core modules install` for selecting modules version which was failing due to too few arguments. I took the liberty of placing the reads and writes to the `modules.json` file in their own methods also. 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
