### PR TITLE
Update `nf-core modules list` to show module versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Refactored `nf-core modules` command into one file per command [#1124](https://github.com/nf-core/tools/pull/1124)
 * Updated `nf-core modules remove` to also remove entry in `modules.json` file ([#1115](https://github.com/nf-core/tools/issues/1115))
 * Bugfix: Interactive prompt for `nf-core modules install` was receiving too few arguments
+* Updated `nf-core modules list` to show versions of local modules
 
 #### Sync
 

--- a/nf_core/modules/list.py
+++ b/nf_core/modules/list.py
@@ -59,6 +59,8 @@ class ModuleList(ModuleCommand):
 
             modules_json = self.load_modules_json()
             if not modules_json:
+                # If the modules.json file is missing we show the old version
+                # of the list command, i.e only names
                 for mod in sorted(modules):
                     table.add_row(mod)
             else:

--- a/nf_core/modules/module_utils.py
+++ b/nf_core/modules/module_utils.py
@@ -54,7 +54,7 @@ def get_module_git_log(module_name, per_page=30, page_nbr=1, since="2020-11-25T0
 
 def get_commit_info(commit_sha):
     """
-    Fetches meta-data about the commit (dates, message, etc.)
+    Fetches metadata about the commit (dates, message, etc.)
     Args:
         module_name (str): Name of module
         commit_sha (str): The SHA of the requested commit
@@ -65,7 +65,7 @@ def get_commit_info(commit_sha):
         LookupError: If the call to the API fails.
     """
     api_url = f"https://api.github.com/repos/nf-core/modules/commits/{commit_sha}?stats=false"
-    log.debug(f"Fetching commit meta-data for commit at {commit_sha}")
+    log.debug(f"Fetching commit metadata for commit at {commit_sha}")
     response = requests.get(api_url, auth=nf_core.utils.github_api_auto_auth())
     if response.status_code == 200:
         commit = response.json()

--- a/nf_core/modules/module_utils.py
+++ b/nf_core/modules/module_utils.py
@@ -5,6 +5,7 @@ import requests
 import sys
 import logging
 import questionary
+import datetime
 from itertools import count
 
 from requests import api
@@ -49,6 +50,37 @@ def get_module_git_log(module_name, per_page=30, page_nbr=1, since="2020-11-25T0
         sys.exit(1)
     else:
         raise SystemError(f"Unable to fetch commit SHA for module {module_name}")
+
+
+def get_commit_info(commit_sha):
+    """
+    Fetches meta-data about the commit (dates, message, etc.)
+    Args:
+        module_name (str): Name of module
+        commit_sha (str): The SHA of the requested commit
+    Returns:
+        message (str): The commit message for the requested commit
+        date (str): The commit date for the requested commit
+    Raises:
+        LookupError: If the call to the API fails.
+    """
+    api_url = f"https://api.github.com/repos/nf-core/modules/commits/{commit_sha}?stats=false"
+    log.debug(f"Fetching commit meta-data for commit at {commit_sha}")
+    response = requests.get(api_url, auth=nf_core.utils.github_api_auto_auth())
+    if response.status_code == 200:
+        commit = response.json()
+        message = commit["commit"]["message"].partition("\n")[0]
+        raw_date = commit["commit"]["author"]["date"]
+
+        # Parse the date returned from the API
+        date_obj = datetime.datetime.strptime(raw_date, "%Y-%m-%dT%H:%M:%SZ")
+        date = str(date_obj.date())
+
+        return message, date
+    elif response.status_code == 404:
+        raise LookupError(f"Commit '{commit_sha}' not found in 'nf-core/modules/'\n{api_url}")
+    else:
+        raise LookupError(f"Unable to fetch meta-data for commit SHA {commit_sha}")
 
 
 def create_modules_json(pipeline_dir):

--- a/nf_core/modules/module_utils.py
+++ b/nf_core/modules/module_utils.py
@@ -80,7 +80,7 @@ def get_commit_info(commit_sha):
     elif response.status_code == 404:
         raise LookupError(f"Commit '{commit_sha}' not found in 'nf-core/modules/'\n{api_url}")
     else:
-        raise LookupError(f"Unable to fetch meta-data for commit SHA {commit_sha}")
+        raise LookupError(f"Unable to fetch metadata for commit SHA {commit_sha}")
 
 
 def create_modules_json(pipeline_dir):

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -99,6 +99,7 @@ class ModuleCommand:
         return True
 
     def load_modules_json(self):
+        """Loads the modules.json file"""
         modules_json_path = os.path.join(self.dir, "modules.json")
         try:
             with open(modules_json_path, "r") as fh:

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -98,8 +98,19 @@ class ModuleCommand:
         log.info("Downloaded {} files to {}".format(len(files), module_dir))
         return True
 
-    def update_modules_json(self, modules_json, modules_json_path, module_name, module_version):
+    def load_modules_json(self):
+        modules_json_path = os.path.join(self.dir, "modules.json")
+        try:
+            with open(modules_json_path, "r") as fh:
+                modules_json = json.load(fh)
+        except FileNotFoundError:
+            log.error("File 'modules.json' is missing")
+            modules_json = None
+        return modules_json
+
+    def update_modules_json(self, modules_json, module_name, module_version):
         """Updates the 'module.json' file with new module info"""
+        modules_json_path = os.path.join(self.dir, "modules.json")
         modules_json["modules"][module_name] = {"git_sha": module_version}
         with open(modules_json_path, "w") as fh:
             json.dump(modules_json, fh, indent=4)

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -60,7 +60,7 @@ class TestModules(unittest.TestCase):
         assert modrepo.name == "nf-core/modules"
         assert modrepo.branch == "master"
 
-    def test_modules_list(self):
+    def test_modules_list_remote(self):
         """Test listing available modules"""
         mods_list = nf_core.modules.ModuleList(None)
         listed_mods = mods_list.list_modules()
@@ -68,6 +68,26 @@ class TestModules(unittest.TestCase):
         console.print(listed_mods)
         output = console.export_text()
         assert "fastqc" in output
+
+    def test_modules_list_pipeline(self):
+        """Test listing locally installed modules"""
+        mods_list = nf_core.modules.ModuleList(self.pipeline_dir)
+        listed_mods = mods_list.list_modules()
+        console = Console(record=True)
+        console.print(listed_mods)
+        output = console.export_text()
+        assert "fastqc" in output
+        assert "multiqc" in output
+
+    def test_modules_install_and_list_pipeline(self):
+        """Test listing locally installed modules"""
+        self.mods_install.install("trimgalore")
+        mods_list = nf_core.modules.ModuleList(self.pipeline_dir)
+        listed_mods = mods_list.list_modules()
+        console = Console(record=True)
+        console.print(listed_mods)
+        output = console.export_text()
+        assert "trimgalore" in output
 
     def test_modules_install_nopipeline(self):
         """Test installing a module - no pipeline given"""


### PR DESCRIPTION
Updated `nf-core modules list` to show 
- the commit SHA
- the commit message
- the commit date

for the locally installed modules, if the `modules.json` file is present. If the `modules.json` file is missing the old version of the `list` command is shown, i.e. only the names of the installed modules

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
