### PR TITLE
Clean up program exits in `modules`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Updated `nf-core modules remove` to also remove entry in `modules.json` file ([#1115](https://github.com/nf-core/tools/issues/1115))
 * Bugfix: Interactive prompt for `nf-core modules install` was receiving too few arguments
 * Updated `nf-core modules list` to show versions of local modules
+* Improved exit behavior by replacing `sys.exit` with exceptions
 
 #### Sync
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -522,7 +522,7 @@ def lint(ctx, pipeline_dir, tool, key, all, local, passed):
         module_lint.lint(module=tool, all_modules=all, print_results=True, local=local, show_passed=passed)
         if len(module_lint.failed) > 0:
             sys.exit(1)
-    except nf_core.modules.lint.ModuleLintException as e:
+    except (UserWarning, nf_core.modules.lint.ModuleLintException) as e:
         log.error(e)
         sys.exit(1)
 

--- a/nf_core/modules/create.py
+++ b/nf_core/modules/create.py
@@ -74,7 +74,10 @@ class ModuleCreate(object):
         """
 
         # Check whether the given directory is a nf-core pipeline or a clone of nf-core/modules
-        self.repo_type = self.get_repo_type(self.directory)
+        try:
+            self.repo_type = self.get_repo_type(self.directory)
+        except LookupError as e:
+            raise UserWarning(e)
 
         log.info(
             "[yellow]Press enter to use default values [cyan bold](shown in brackets)[/] [yellow]or type your own responses. "

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -24,10 +24,19 @@ class ModuleInstall(ModuleCommand):
             log.error("You cannot install a module in a clone of nf-core/modules")
             return False
         # Check whether pipelines is valid
-        self.has_valid_directory()
+        try:
+            self.has_valid_directory()
+        except UserWarning as e:
+            log.error(e)
+            return False
 
         # Get the available modules
-        self.modules_repo.get_modules_file_tree()
+        try:
+            self.modules_repo.get_modules_file_tree()
+        except LookupError as e:
+            log.error(e)
+            return False
+
         if self.latest and self.sha is not None:
             log.error("Cannot use '--sha' and '--latest' at the same time!")
             return False

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -24,11 +24,7 @@ class ModuleInstall(ModuleCommand):
             log.error("You cannot install a module in a clone of nf-core/modules")
             return False
         # Check whether pipelines is valid
-        try:
-            self.has_valid_directory()
-        except UserWarning as e:
-            log.error(e)
-            return False
+        self.has_valid_directory()
 
         # Get the available modules
         try:

--- a/nf_core/modules/lint/__init__.py
+++ b/nf_core/modules/lint/__init__.py
@@ -66,7 +66,11 @@ class ModuleLint(object):
 
     def __init__(self, dir, key=()):
         self.dir = dir
-        self.repo_type = nf_core.modules.module_utils.get_repo_type(self.dir)
+        try:
+            self.repo_type = nf_core.modules.module_utils.get_repo_type(self.dir)
+        except LookupError as e:
+            raise UserWarning(e)
+
         self.passed = []
         self.warned = []
         self.failed = []

--- a/nf_core/modules/lint/module_tests.py
+++ b/nf_core/modules/lint/module_tests.py
@@ -34,8 +34,7 @@ def module_tests(module_lint_object, module):
             else:
                 module.failed.append(("test_pytest_yml", "missing entry in pytest_software.yml", pytest_yml_path))
     except FileNotFoundError as e:
-        log.error(f"Could not open pytest_software.yml file: {e}")
-        sys.exit(1)
+        module.failed.append((f"Could not open pytest_software.yml file: {e}"), pytest_yml_path)
 
     # Lint the test.yml file
     try:

--- a/nf_core/modules/lint/module_tests.py
+++ b/nf_core/modules/lint/module_tests.py
@@ -34,7 +34,7 @@ def module_tests(module_lint_object, module):
             else:
                 module.failed.append(("test_pytest_yml", "missing entry in pytest_software.yml", pytest_yml_path))
     except FileNotFoundError as e:
-        module.failed.append((f"Could not open pytest_software.yml file: {e}"), pytest_yml_path)
+        module.failed.append(("test_pytest_yml", f"Could not open pytest_software.yml file", pytest_yml_path))
 
     # Lint the test.yml file
     try:

--- a/nf_core/modules/list.py
+++ b/nf_core/modules/list.py
@@ -30,7 +30,12 @@ class ModuleList(ModuleCommand):
             log.info(f"Modules available from {self.modules_repo.name} ({self.modules_repo.branch}):\n")
 
             # Get the list of available modules
-            self.modules_repo.get_modules_file_tree()
+            try:
+                self.modules_repo.get_modules_file_tree()
+            except LookupError as e:
+                log.error(e)
+                return False
+
             modules = self.modules_repo.modules_avail_module_names
             # Nothing found
             if len(modules) == 0:

--- a/nf_core/modules/module_utils.py
+++ b/nf_core/modules/module_utils.py
@@ -46,10 +46,9 @@ def get_module_git_log(module_name, per_page=30, page_nbr=1, since="2020-11-25T0
                 for commit in commits
             ]
     elif response.status_code == 404:
-        log.error(f"Module '{module_name}' not found in 'nf-core/modules/'\n{api_url}")
-        sys.exit(1)
+        raise LookupError(f"Module '{module_name}' not found in 'nf-core/modules/'\n{api_url}")
     else:
-        raise SystemError(f"Unable to fetch commit SHA for module {module_name}")
+        raise LookupError(f"Unable to fetch commit SHA for module {module_name}")
 
 
 def get_commit_info(commit_sha):
@@ -116,10 +115,10 @@ def create_modules_json(pipeline_dir):
                 commit_page_nbr += 1
 
             modules_json["modules"][module_name] = {"git_sha": correct_commit_sha}
-        except SystemError as e:
+        except LookupError as e:
             log.error(e)
-            log.error("Will not create 'modules.json' file")
-            sys.exit(1)
+            raise UserWarning("Will not create 'modules.json' file")
+
     modules_json_path = os.path.join(pipeline_dir, "modules.json")
     with open(modules_json_path, "w") as fh:
         json.dump(modules_json, fh, indent=4)
@@ -197,8 +196,7 @@ def get_repo_type(dir):
     """
     # Verify that the pipeline dir exists
     if dir is None or not os.path.exists(dir):
-        log.error("Could not find directory: {}".format(dir))
-        sys.exit(1)
+        raise LookupError("Could not find directory: {}".format(dir))
 
     # Determine repository type
     if os.path.exists(os.path.join(dir, "main.nf")):
@@ -206,5 +204,4 @@ def get_repo_type(dir):
     elif os.path.exists(os.path.join(dir, "software")):
         return "modules"
     else:
-        log.error("Could not determine repository type of {}".format(dir))
-        sys.exit(1)
+        raise LookupError("Could not determine repository type of {}".format(dir))

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -54,15 +54,21 @@ class ModuleCommand:
         nf_config = os.path.join(self.dir, "nextflow.config")
         if not os.path.exists(main_nf) and not os.path.exists(nf_config):
             raise UserWarning(f"Could not find a 'main.nf' or 'nextflow.config' file in '{self.dir}'")
-        self.has_modules_file()
-        return True
+        try:
+            self.has_modules_file()
+            return True
+        except UserWarning as e:
+            raise
 
     def has_modules_file(self):
         """Checks whether a module.json file has been created and creates one if it is missing"""
         modules_json_path = os.path.join(self.dir, "modules.json")
         if not os.path.exists(modules_json_path):
             log.info("Creating missing 'module.json' file.")
-            nf_core.modules.module_utils.create_modules_json(self.dir)
+            try:
+                nf_core.modules.module_utils.create_modules_json(self.dir)
+            except UserWarning as e:
+                raise
 
     def clear_module_dir(self, module_name, module_dir):
         """Removes all files in the module directory"""

--- a/nf_core/modules/modules_repo.py
+++ b/nf_core/modules/modules_repo.py
@@ -34,10 +34,9 @@ class ModulesRepo(object):
         api_url = "https://api.github.com/repos/{}/git/trees/{}?recursive=1".format(self.name, self.branch)
         r = requests.get(api_url, auth=nf_core.utils.github_api_auto_auth())
         if r.status_code == 404:
-            log.error("Repository / branch not found: {} ({})\n{}".format(self.name, self.branch, api_url))
-            sys.exit(1)
+            raise LookupError("Repository / branch not found: {} ({})\n{}".format(self.name, self.branch, api_url))
         elif r.status_code != 200:
-            raise SystemError(
+            raise LookupError(
                 "Could not fetch {} ({}) tree: {}\n{}".format(self.name, self.branch, r.status_code, api_url)
             )
 
@@ -105,7 +104,7 @@ class ModulesRepo(object):
         # Call the GitHub API
         r = requests.get(api_url, auth=nf_core.utils.github_api_auto_auth())
         if r.status_code != 200:
-            raise SystemError("Could not fetch {} file: {}\n {}".format(self.name, r.status_code, api_url))
+            raise LookupError("Could not fetch {} file: {}\n {}".format(self.name, r.status_code, api_url))
         result = r.json()
         file_contents = base64.b64decode(result["content"])
 

--- a/nf_core/modules/remove.py
+++ b/nf_core/modules/remove.py
@@ -29,7 +29,11 @@ class ModuleRemove(ModuleCommand):
             return False
 
         # Check whether pipelines is valid
-        self.has_valid_directory()
+        try:
+            self.has_valid_directory()
+        except UserWarning as e:
+            log.error(e)
+            return False
 
         # Get the installed modules
         self.get_pipeline_modules()

--- a/nf_core/modules/remove.py
+++ b/nf_core/modules/remove.py
@@ -29,11 +29,7 @@ class ModuleRemove(ModuleCommand):
             return False
 
         # Check whether pipelines is valid
-        try:
-            self.has_valid_directory()
-        except UserWarning as e:
-            log.error(e)
-            return False
+        self.has_valid_directory()
 
         # Get the installed modules
         self.get_pipeline_modules()


### PR DESCRIPTION
Cleaned up exit behavior in `modules` directory. Instead of doing hard exits with `sys.exit` we raise exceptions which are passed down the calling stack and causes the program to exit from `__main__.py`. 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
