### PR TITLE
Add API response code to error from `module_utils/get_module_git_log`

### DIFF
--- a/nf_core/modules/module_utils.py
+++ b/nf_core/modules/module_utils.py
@@ -56,7 +56,9 @@ def get_module_git_log(module_name, per_page=30, page_nbr=1, since="2020-11-25T0
     elif response.status_code == 404:
         raise LookupError(f"Module '{module_name}' not found in 'nf-core/modules/'\n{api_url}")
     else:
-        raise LookupError(f"Unable to fetch commit SHA for module {module_name}")
+        raise LookupError(
+            f"Unable to fetch commit SHA for module {module_name}. API responded with '{response.status_code}'"
+        )
 
 
 def get_commit_info(commit_sha):


### PR DESCRIPTION
Added API response code to error when `module_utils/get_module_git_log` fails to fetch the git log of a module.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
