### PR TITLE
List - message if no results, suggest similar but different command

### DIFF
--- a/nf_core/list.py
+++ b/nf_core/list.py
@@ -4,9 +4,7 @@
 from __future__ import print_function
 from collections import OrderedDict
 
-import click
 import datetime
-import errno
 import git
 import json
 import logging
@@ -15,8 +13,6 @@ import re
 import requests
 import rich.console
 import rich.table
-import subprocess
-import sys
 
 import nf_core.utils
 
@@ -259,8 +255,14 @@ class Workflows(object):
             else:
                 table.add_row(*rowdata)
 
-        # Print summary table
-        return table
+        if len(filtered_workflows) > 0:
+            # Print summary table
+            return table
+        else:
+            return_str = f"No pipelines found using filter keywords: '{', '.join(self.keyword_filters)}'"
+            if self.keyword_filters == ("modules",):
+                return_str += "\n\n:bulb: Did you mean 'nf-core modules list' instead?"
+            return return_str
 
     def print_json(self):
         """Dump JSON of all parsed information"""


### PR DESCRIPTION
I tried doing a live demo earlier today and ran `nf-core list modules`. To my confusion, this just returned an empty table.

This PR:

* Shows a message if no pipelines are found, instead of printing an empty table
* Shows a bonus help message if `modules` was the only filter keyword

```console
$ nf-core list modules

                                          ,--./,-.
          ___     __   __   __   ___     /,-._.--~\
    |\ | |__  __ /  ` /  \ |__) |__         }  {
    | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                          `._,._,'

    nf-core/tools version 1.14.dev0



No pipelines found using filter keywords: 'modules'

💡 Did you mean 'nf-core modules list' instead?
```