### PR TITLE
Refactor passing of command line arguments to `nf-core` commands

### DIFF
--- a/.github/workflows/create-lint-wf.yml
+++ b/.github/workflows/create-lint-wf.yml
@@ -32,7 +32,7 @@ jobs:
         run: nf-core --log-file log.txt create -n testpipeline -d "This pipeline is for testing" -a "Testing McTestface"
 
       - name: nf-core lint
-        run: nf-core --log-file log.txt lint nf-core-testpipeline --fail-ignored
+        run: nf-core --log-file log.txt lint --dir nf-core-testpipeline --fail-ignored
 
       - name: nf-core list
         run: nf-core --log-file log.txt list
@@ -41,19 +41,19 @@ jobs:
       #   run: nf-core --log-file log.txt licences nf-core-testpipeline
 
       - name: nf-core sync
-        run: nf-core --log-file log.txt sync nf-core-testpipeline/
+        run: nf-core --log-file log.txt sync --dir nf-core-testpipeline/
 
       - name: nf-core schema
-        run: nf-core --log-file log.txt schema build nf-core-testpipeline/ --no-prompts
+        run: nf-core --log-file log.txt schema build --dir nf-core-testpipeline/ --no-prompts
 
       - name: nf-core bump-version
-        run: nf-core --log-file log.txt bump-version nf-core-testpipeline/ 1.1
+        run: nf-core --log-file log.txt bump-version --dir nf-core-testpipeline/ 1.1
 
       - name: nf-core lint in release mode
-        run: nf-core --log-file log.txt lint nf-core-testpipeline --fail-ignored --release
+        run: nf-core --log-file log.txt lint --dir nf-core-testpipeline --fail-ignored --release
 
       - name: nf-core modules install
-        run: nf-core --log-file log.txt modules install nf-core-testpipeline/ --tool fastqc --latest
+        run: nf-core --log-file log.txt modules install --dir nf-core-testpipeline/ --tool fastqc --latest
 
       - name: Upload log file artifact
         if: ${{ always() }}

--- a/.github/workflows/create-lint-wf.yml
+++ b/.github/workflows/create-lint-wf.yml
@@ -53,7 +53,7 @@ jobs:
         run: nf-core --log-file log.txt lint --dir nf-core-testpipeline --fail-ignored --release
 
       - name: nf-core modules install
-        run: nf-core --log-file log.txt modules install --dir nf-core-testpipeline/ --tool fastqc --force --latest
+        run: nf-core --log-file log.txt modules install fastqc --dir nf-core-testpipeline/ --force --latest
 
       - name: Upload log file artifact
         if: ${{ always() }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 * Updated `nf-core modules list` to show versions of local modules
 * Improved exit behavior by replacing `sys.exit` with exceptions
 * Updated `nf-core modules remove` to remove module entry in `modules.json` if module directory is missing
-* Refactored passing of command line arguments to `nf-core` commands and subcommands
+* Refactored passing of command line arguments to `nf-core` commands and subcommands ([#1139](https://github.com/nf-core/tools/issues/1139), [#1140](https://github.com/nf-core/tools/issues/1140))
 
 #### Sync
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Updated `nf-core modules list` to show versions of local modules
 * Improved exit behavior by replacing `sys.exit` with exceptions
 * Updated `nf-core modules remove` to remove module entry in `modules.json` if module directory is missing
+* Refactored passing of command line arguments to `nf-core` commands and subcommands
 
 #### Sync
 

--- a/README.md
+++ b/README.md
@@ -943,7 +943,7 @@ INFO     Installing cat/fastq
 INFO     Downloaded 3 files to ./modules/nf-core/software/cat/fastq
 ```
 
-You can pass the module name as a optional argument to `nf-core modules install` instead of using the cli prompt, eg: `nf-core modules install fastqc`.
+You can pass the module name as an optional argument to `nf-core modules install` instead of using the cli prompt, eg: `nf-core modules install fastqc`.
 
 There are four flags that you can use with this command:
 
@@ -972,7 +972,7 @@ INFO     Removing star/align
 INFO     Successfully removed star/align module
 ```
 
-You can pass the module name as a optional argument to `nf-core modules install` instead of using the cli prompt, eg: `nf-core modules remove fastqc`. To specify the pipeline directory, use `--dir <pipeline_dir>`.
+You can pass the module name as an optional argument to `nf-core modules install` instead of using the cli prompt, eg: `nf-core modules remove fastqc`. To specify the pipeline directory, use `--dir <pipeline_dir>`.
 
 ### Create a new module
 

--- a/README.md
+++ b/README.md
@@ -624,7 +624,7 @@ Tip: Some of these linting errors can automatically be resolved with the followi
     nf-core lint . --fix conda_env_yaml
 ```
 
-You can use the `-k` / `--key` flag to run only named tests for faster debugging, eg: `nf-core lint . -k files_exist -k files_unchanged`
+You can use the `-k` / `--key` flag to run only named tests for faster debugging, eg: `nf-core lint -k files_exist -k files_unchanged`. The `nf-core lint` command lints the current working directory by default, to specify another directory you can use `--dir <directory>`.
 
 ### Linting documentation
 
@@ -719,7 +719,7 @@ If no existing schema is found it will create one for you.
 Once built, the tool can send the schema to the nf-core website so that you can use a graphical interface to organise and fill in the schema.
 The tool checks the status of your schema on the website and once complete, saves your changes locally.
 
-Usage is `nextflow schema build <pipeline_directory>`, eg:
+Usage is `nextflow schema build`, eg:
 
 ```console
 $ nf-core schema build nf-core-testpipeline
@@ -746,8 +746,9 @@ $ nf-core schema build nf-core-testpipeline
   INFO: Writing JSON schema with 25 params: nf-core-testpipeline/nextflow_schema.json
 ```
 
-There are three flags that you can use with this command:
+There are four flags that you can use with this command:
 
+* `--dir <pipeline_dir>`: Specify a pipeline directory other than the current working directory
 * `--no-prompts`: Make changes without prompting for confirmation each time. Does not launch web tool.
 * `--web-only`: Skips comparison of the schema against the pipeline parameters and only launches the web tool.
 * `--url <web_address>`: Supply a custom URL for the online tool. Useful when testing locally.
@@ -780,7 +781,7 @@ When releasing a new version of a nf-core pipeline, version numbers have to be u
 
 The command uses results from the linting process, so will only work with workflows that pass these tests.
 
-Usage is `nf-core bump-version <pipeline_dir> <new_version>`, eg:
+Usage is `nf-core bump-version <new_version>`, eg:
 
 ```console
 $ cd path/to/my_pipeline
@@ -822,7 +823,7 @@ INFO     Updated version in 'Dockerfile'
            + RUN conda env export --name nf-core-methylseq-1.7 > nf-core-methylseq-1.7.yml
 ```
 
-To change the required version of Nextflow instead of the pipeline version number, use the flag `--nextflow`.
+You can change the directory from the current working directory by specifying `--dir <pipeline_dir>`. To change the required version of Nextflow instead of the pipeline version number, use the flag `--nextflow`.
 
 ## Sync a pipeline with the template
 
@@ -836,7 +837,7 @@ Note that pipeline synchronisation happens automatically each time nf-core/tools
 **As such, you do not normally need to run this command yourself!**
 
 This command takes a pipeline directory and attempts to run this synchronisation.
-Usage is `nf-core sync <pipeline_dir>`, eg:
+Usage is `nf-core sync`, eg:
 
 ```console
 $ nf-core sync my_pipeline/
@@ -865,6 +866,8 @@ The sync command tries to check out the `TEMPLATE` branch from the `origin` remo
 It will fail if it cannot do either of these things.
 The `nf-core create` command should make this template automatically when you first start your pipeline.
 Please see the [nf-core website sync documentation](https://nf-co.re/developers/sync) if you have difficulties.
+
+To specify a directory to sync other than the current working directory, use the `--dir <pipline_dir>`.
 
 By default, the tool will collect workflow variables from the current branch in your pipeline directory.
 You can supply the `--from-branch` flag to specific a different branch.
@@ -918,13 +921,12 @@ INFO     Modules available from nf-core/modules (master)
 
 ### List installed modules
 
-The same `nf-core modules list` command can take an optional argument for a local pipeline directory.
-If given, it will instead list all installed modules in that pipeline.
+To list modules installed in a local pipeline directory you can use `nf-core modules list --installed <directory>`.
 
 ### Install a module into a pipeline
 
-You can install modules from [nf-core/modules](https://github.com/nf-core/modules) in your pipeline using `nf-core modules install <pipeline_dir>`.
-A module installed this way will be installed to the `<pipeline_dir>/modules/nf-core/software` directory.
+You can install modules from [nf-core/modules](https://github.com/nf-core/modules) in your pipeline using `nf-core modules install`.
+A module installed this way will be installed to the `./modules/nf-core/software` directory.
 
 ```console
 $ nf-core modules install .
@@ -941,11 +943,18 @@ INFO     Installing cat/fastq
 INFO     Downloaded 3 files to ./modules/nf-core/software/cat/fastq
 ```
 
-Use the `--tool` flat to specify a module name on the command line instead of using the cli prompt.
+You can pass the module name as a optional argument to `nf-core modules install` instead of using the cli prompt, eg: `nf-core modules install fastqc`.
+
+There are four flags that you can use with this command:
+
+* `--dir <pipeline_dir>`: Specify a pipeline directory other than the current working directory.
+* `--latest`: Install the latest version of the module instead of specifying the version using the cli prompt.
+* `--force`: Overwrite a previously installed version of the module.
+* `--sha <commit_sha>`: Install the module at a specific commit from the `nf-core/modules` repository.
 
 ### Remove a module from a pipeline
 
-To delete a module from your pipeline, run `nf-core modules remove <pipeline-directory>`
+To delete a module from your pipeline, run `nf-core modules remove`
 
 ```console
 $ nf-core modules remove .
@@ -963,13 +972,15 @@ INFO     Removing star/align
 INFO     Successfully removed star/align module
 ```
 
+You can pass the module name as a optional argument to `nf-core modules install` instead of using the cli prompt, eg: `nf-core modules remove fastqc`. To specify the pipeline directory, use `--dir <pipeline_dir>`.
+
 ### Create a new module
 
 This command creates a new nf-core module from the nf-core module template.
 This ensures that your module follows the nf-core guidelines.
 The template contains extensive `TODO` messages to walk you through the changes you need to make to the template.
 
-You can create a new module using `nf-core modules create <directory>`.
+You can create a new module using `nf-core modules create`. This will create the new module in the current working directory. To specify another directory, use `--dir <directory>`.
 
 If writing a module for the shared [nf-core/modules](https://github.com/nf-core/modules) repository, the `<directory>` argument should be the path to the clone of your fork of the modules repository.
 
@@ -1056,11 +1067,11 @@ INFO     Test workflow finished!
 INFO     Writing to 'tests/software/star/align/test.yml'
 ```
 
-## Check a module against nf-core guidelines
+### Check a module against nf-core guidelines
 
-Run this command to modules in a given directory (pipeline or nf-core/modules clone) against nf-core guidelines.
+Run the `nf-core modules lint` command to check modules in the current working directory (pipeline or nf-core/modules clone) against nf-core guidelines.
 
-Use the `--all` flag to run linting on all modules found.
+Use the `--all` flag to run linting on all modules found. Use `--dir <pipeline_dir>` to specify another directory than the current working directory.
 
 ```console
 $ nf-core modules lint nf-core-modules

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -431,15 +431,15 @@ def remove(ctx, dir, tool):
 
 @modules.command("create", help_priority=4)
 @click.pass_context
-@click.argument("directory", type=click.Path(exists=True), required=True, metavar="<directory>")
-@click.option("-t", "--tool", type=str, metavar="<tool> or <tool/subtool>")
+@click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
+@click.option("-d", "--dir", type=click.Path(exists=True), default=".", metavar="<directory>")
 @click.option("-a", "--author", type=str, metavar="<author>", help="Module author's GitHub username")
 @click.option("-l", "--label", type=str, metavar="<process label>", help="Standard resource label for process")
 @click.option("-m", "--meta", is_flag=True, default=False, help="Use Groovy meta map for sample information")
 @click.option("-n", "--no-meta", is_flag=True, default=False, help="Don't use meta map for sample information")
 @click.option("-f", "--force", is_flag=True, default=False, help="Overwrite any files if they already exist")
 @click.option("-c", "--conda-name", type=str, default=None, help="Name of the conda package to use")
-def create_module(ctx, directory, tool, author, label, meta, no_meta, force, conda_name):
+def create_module(ctx, tool, dir, author, label, meta, no_meta, force, conda_name):
     """
     Create a new DSL2 module from the nf-core template.
 
@@ -460,7 +460,7 @@ def create_module(ctx, directory, tool, author, label, meta, no_meta, force, con
 
     # Run function
     try:
-        module_create = nf_core.modules.ModuleCreate(directory, tool, author, label, has_meta, force, conda_name)
+        module_create = nf_core.modules.ModuleCreate(dir, tool, author, label, has_meta, force, conda_name)
         module_create.create()
     except UserWarning as e:
         log.critical(e)
@@ -469,7 +469,7 @@ def create_module(ctx, directory, tool, author, label, meta, no_meta, force, con
 
 @modules.command("create-test-yml", help_priority=5)
 @click.pass_context
-@click.option("-t", "--tool", type=str, metavar="<tool> or <tool/subtool>")
+@click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
 @click.option("-r", "--run-tests", is_flag=True, default=False, help="Run the test workflows")
 @click.option("-o", "--output", type=str, help="Path for output YAML file")
 @click.option("-f", "--force", is_flag=True, default=False, help="Overwrite output YAML file if it already exists")
@@ -491,13 +491,13 @@ def create_test_yml(ctx, tool, run_tests, output, force, no_prompts):
 
 @modules.command(help_priority=6)
 @click.pass_context
-@click.argument("pipeline_dir", type=click.Path(exists=True), required=True, metavar="<pipeline/modules directory>")
-@click.option("-t", "--tool", type=str, metavar="<tool> or <tool/subtool>")
+@click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
+@click.option("-d", "--dir", type=click.Path(exists=True), default=".", metavar="<pipeline/modules directory>")
 @click.option("-k", "--key", type=str, metavar="<test>", multiple=True, help="Run only these lint tests")
 @click.option("-a", "--all", is_flag=True, metavar="Run on all discovered tools")
 @click.option("--local", is_flag=True, help="Run additional lint tests for local modules")
 @click.option("--passed", is_flag=True, help="Show passed tests")
-def lint(ctx, pipeline_dir, tool, key, all, local, passed):
+def lint(ctx, tool, dir, key, all, local, passed):
     """
     Lint one or more modules in a directory.
 
@@ -508,7 +508,7 @@ def lint(ctx, pipeline_dir, tool, key, all, local, passed):
     nf-core/modules repository.
     """
     try:
-        module_lint = nf_core.modules.ModuleLint(dir=pipeline_dir, key=key)
+        module_lint = nf_core.modules.ModuleLint(dir=dir, key=key)
         module_lint.modules_repo = ctx.obj["modules_repo_obj"]
         module_lint.lint(module=tool, all_modules=all, print_results=True, local=local, show_passed=passed)
         if len(module_lint.failed) > 0:
@@ -520,16 +520,16 @@ def lint(ctx, pipeline_dir, tool, key, all, local, passed):
 
 @modules.command(help_priority=7)
 @click.pass_context
-@click.argument("modules_dir", type=click.Path(exists=True), required=True, metavar="<nf-core/modules directory>")
-@click.option("-t", "--tool", type=str, metavar="<tool> or <tool/subtool>")
+@click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
+@click.option("-d", "--dir", type=click.Path(exists=True), default=".", metavar="<nf-core/modules directory>")
 @click.option("-a", "--all", is_flag=True, metavar="Run on all discovered tools")
 @click.option("-s", "--show-all", is_flag=True, metavar="Show up-to-date modules in results")
-def bump_versions(ctx, modules_dir, tool, all, show_all):
+def bump_versions(ctx, tool, dir, all, show_all):
     """
     Bump versions for one or more modules in a directory.
     """
     try:
-        version_bumper = ModuleVersionBumper(pipeline_dir=modules_dir)
+        version_bumper = ModuleVersionBumper(pipeline_dir=dir)
         version_bumper.bump_versions(module=tool, all_modules=all, show_uptodate=show_all)
     except nf_core.modules.module_utils.ModuleException as e:
         log.error(e)

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -567,7 +567,7 @@ def validate(pipeline, params):
 
 
 @schema.command(help_priority=2)
-@click.argument("pipeline_dir", type=click.Path(exists=True), required=True, metavar="<pipeline directory>")
+@click.option("-d", "--dir", type=click.Path(exists=True), default=".", help="Pipeline directory. Defaults to CWD")
 @click.option("--no-prompts", is_flag=True, help="Do not confirm changes, just update parameters and exit")
 @click.option("--web-only", is_flag=True, help="Skip building using Nextflow config, just launch the web tool")
 @click.option(
@@ -576,7 +576,7 @@ def validate(pipeline, params):
     default="https://nf-co.re/pipeline_schema_builder",
     help="Customise the builder URL (for development work)",
 )
-def build(pipeline_dir, no_prompts, web_only, url):
+def build(dir, no_prompts, web_only, url):
     """
     Interactively build a pipeline schema from Nextflow params.
 
@@ -588,8 +588,12 @@ def build(pipeline_dir, no_prompts, web_only, url):
     https://nf-co.re website where you can annotate and organise parameters.
     Listens for this to be completed and saves the updated schema.
     """
-    schema_obj = nf_core.schema.PipelineSchema()
-    if schema_obj.build_schema(pipeline_dir, no_prompts, web_only, url) is False:
+    try:
+        schema_obj = nf_core.schema.PipelineSchema()
+        if schema_obj.build_schema(dir, no_prompts, web_only, url) is False:
+            sys.exit(1)
+    except UserWarning as e:
+        log.error(e)
         sys.exit(1)
 
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -382,9 +382,13 @@ def list(ctx, installed, json):
     If no pipeline directory is given, lists all currently available
     software wrappers in the nf-core/modules repository.
     """
-    module_list = nf_core.modules.ModuleList(installed)
-    module_list.modules_repo = ctx.obj["modules_repo_obj"]
-    print(module_list.list_modules(json))
+    try:
+        module_list = nf_core.modules.ModuleList(installed)
+        module_list.modules_repo = ctx.obj["modules_repo_obj"]
+        print(module_list.list_modules(json))
+    except UserWarning as e:
+        log.critical(e)
+        sys.exit(1)
 
 
 @modules.command(help_priority=2)
@@ -513,8 +517,11 @@ def lint(ctx, tool, dir, key, all, local, passed):
         module_lint.lint(module=tool, all_modules=all, print_results=True, local=local, show_passed=passed)
         if len(module_lint.failed) > 0:
             sys.exit(1)
-    except (UserWarning, nf_core.modules.lint.ModuleLintException) as e:
+    except nf_core.modules.lint.ModuleLintException as e:
         log.error(e)
+        sys.exit(1)
+    except UserWarning as e:
+        log.critical(e)
         sys.exit(1)
 
 
@@ -533,6 +540,9 @@ def bump_versions(ctx, tool, dir, all, show_all):
         version_bumper.bump_versions(module=tool, all_modules=all, show_uptodate=show_all)
     except nf_core.modules.module_utils.ModuleException as e:
         log.error(e)
+        sys.exit(1)
+    except UserWarning as e:
+        log.critical(e)
         sys.exit(1)
 
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -382,14 +382,14 @@ def list(ctx, pipeline_dir, json):
 
 @modules.command(help_priority=2)
 @click.pass_context
+@click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
 @click.option("-d", "--dir", type=click.Path(exists=True), default=".", help="Pipeline directory. Defaults to CWD")
-@click.option("-t", "--tool", type=str, metavar="<tool> or <tool/subtool>")
 @click.option("-l", "--latest", is_flag=True, default=False, help="Install the latest version of the module")
 @click.option(
     "-f", "--force", is_flag=True, default=False, help="Force installation of module if module already exists"
 )
 @click.option("-s", "--sha", type=str, metavar="<commit sha>", help="Install module at commit SHA")
-def install(ctx, dir, tool, latest, force, sha):
+def install(ctx, tool, dir, latest, force, sha):
     """
     Add a DSL2 software wrapper module to a pipeline.
 
@@ -407,8 +407,8 @@ def install(ctx, dir, tool, latest, force, sha):
 
 @modules.command(help_priority=3)
 @click.pass_context
+@click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
 @click.option("-d", "--dir", type=click.Path(exists=True), default=".", help="Pipeline directory. Defaults to CWD")
-@click.option("-t", "--tool", type=str, metavar="<tool> or <tool/subtool>")
 def remove(ctx, dir, tool):
     """
     Remove a software wrapper from a pipeline.

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -295,7 +295,7 @@ def create(name, description, author, version, no_git, force, outdir):
 
 
 @nf_core_cli.command(help_priority=6)
-@click.argument("pipeline_dir", type=click.Path(exists=True), required=True, metavar="<pipeline directory>")
+@click.option("-d", "--dir", type=click.Path(exists=True), default=".", help="Pipeline directory. Defaults to CWD")
 @click.option(
     "--release",
     is_flag=True,
@@ -312,7 +312,7 @@ def create(name, description, author, version, no_git, force, outdir):
 @click.option("-i", "--fail-ignored", is_flag=True, help="Convert ignored tests to failures")
 @click.option("--markdown", type=str, metavar="<filename>", help="File to write linting results to (Markdown)")
 @click.option("--json", type=str, metavar="<filename>", help="File to write linting results to (JSON)")
-def lint(pipeline_dir, release, fix, key, show_passed, fail_ignored, markdown, json):
+def lint(dir, release, fix, key, show_passed, fail_ignored, markdown, json):
     """
     Check pipeline code against nf-core guidelines.
 
@@ -326,11 +326,14 @@ def lint(pipeline_dir, release, fix, key, show_passed, fail_ignored, markdown, j
 
     # Run the lint tests!
     try:
-        lint_obj = nf_core.lint.run_linting(pipeline_dir, release, fix, key, show_passed, fail_ignored, markdown, json)
+        lint_obj = nf_core.lint.run_linting(dir, release, fix, key, show_passed, fail_ignored, markdown, json)
         if len(lint_obj.failed) > 0:
             sys.exit(1)
     except AssertionError as e:
         log.critical(e)
+        sys.exit(1)
+    except UserWarning as e:
+        log.error(e)
         sys.exit(1)
 
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -364,9 +364,9 @@ def modules(ctx, repository, branch):
 
 @modules.command(help_priority=1)
 @click.pass_context
-@click.argument("pipeline_dir", type=click.Path(exists=True), required=False, metavar="(<pipeline directory>)")
+@click.option("-i", "--installed", type=click.Path(exists=True), help="List modules installed in local directory")
 @click.option("-j", "--json", is_flag=True, help="Print as JSON to stdout")
-def list(ctx, pipeline_dir, json):
+def list(ctx, installed, json):
     """
     List available software modules.
 
@@ -375,7 +375,7 @@ def list(ctx, pipeline_dir, json):
     If no pipeline directory is given, lists all currently available
     software wrappers in the nf-core/modules repository.
     """
-    module_list = nf_core.modules.ModuleList(pipeline_dir)
+    module_list = nf_core.modules.ModuleList(installed)
     module_list.modules_repo = ctx.obj["modules_repo_obj"]
     print(module_list.list_modules(json))
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -662,7 +662,7 @@ def bump_version(new_version, dir, nextflow):
     As well as the pipeline version, you can also change the required version of Nextflow.
     """
     try:
-        # Check if pipeline directory contain necessary files
+        # Check if pipeline directory contains necessary files
         nf_core.utils.is_pipeline_directory(dir)
 
         # Make a pipeline object and load config etc
@@ -698,7 +698,7 @@ def sync(dir, from_branch, pull_request, repository, username):
     the pipeline. It is run automatically for all pipelines when ever a
     new release of nf-core/tools (and the included template) is made.
     """
-    # Check if pipeline directory contain necessary files
+    # Check if pipeline directory contains necessary files
     try:
         nf_core.utils.is_pipeline_directory(dir)
     except UserWarning:

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -324,6 +324,13 @@ def lint(dir, release, fix, key, show_passed, fail_ignored, markdown, json):
     See the documentation for details.
     """
 
+    # Check if pipeline directory is a pipeline
+    try:
+        nf_core.utils.is_pipeline_directory(dir)
+    except UserWarning as e:
+        log.error(e)
+        sys.exit(1)
+
     # Run the lint tests!
     try:
         lint_obj = nf_core.lint.run_linting(dir, release, fix, key, show_passed, fail_ignored, markdown, json)
@@ -645,6 +652,9 @@ def bump_version(new_version, dir, nextflow):
     As well as the pipeline version, you can also change the required version of Nextflow.
     """
     try:
+        # Check if pipeline directory contain necessary files
+        nf_core.utils.is_pipeline_directory(dir)
+
         # Make a pipeline object and load config etc
         pipeline_obj = nf_core.utils.Pipeline(dir)
         pipeline_obj._load()
@@ -678,6 +688,11 @@ def sync(dir, from_branch, pull_request, repository, username):
     the pipeline. It is run automatically for all pipelines when ever a
     new release of nf-core/tools (and the included template) is made.
     """
+    # Check if pipeline directory contain necessary files
+    try:
+        nf_core.utils.is_pipeline_directory(dir)
+    except UserWarning:
+        raise
 
     # Sync the given pipeline dir
     sync_obj = nf_core.sync.PipelineSync(dir, from_branch, pull_request, repository, username)

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -379,14 +379,14 @@ def list(ctx, pipeline_dir, json):
 
 @modules.command(help_priority=2)
 @click.pass_context
-@click.argument("pipeline_dir", type=click.Path(exists=True), required=True, metavar="<pipeline directory>")
+@click.option("-d", "--dir", type=click.Path(exists=True), default=".", help="Pipeline directory. Defaults to CWD")
 @click.option("-t", "--tool", type=str, metavar="<tool> or <tool/subtool>")
 @click.option("-l", "--latest", is_flag=True, default=False, help="Install the latest version of the module")
 @click.option(
     "-f", "--force", is_flag=True, default=False, help="Force installation of module if module already exists"
 )
 @click.option("-s", "--sha", type=str, metavar="<commit sha>", help="Install module at commit SHA")
-def install(ctx, pipeline_dir, tool, latest, force, sha):
+def install(ctx, dir, tool, latest, force, sha):
     """
     Add a DSL2 software wrapper module to a pipeline.
 
@@ -394,7 +394,7 @@ def install(ctx, pipeline_dir, tool, latest, force, sha):
     along with associated metadata.
     """
     try:
-        module_install = nf_core.modules.ModuleInstall(pipeline_dir, force=force, latest=latest, sha=sha)
+        module_install = nf_core.modules.ModuleInstall(dir, force=force, latest=latest, sha=sha)
         module_install.modules_repo = ctx.obj["modules_repo_obj"]
         module_install.install(tool)
     except UserWarning as e:
@@ -404,14 +404,14 @@ def install(ctx, pipeline_dir, tool, latest, force, sha):
 
 @modules.command(help_priority=3)
 @click.pass_context
-@click.argument("pipeline_dir", type=click.Path(exists=True), required=True, metavar="<pipeline directory>")
+@click.option("-d", "--dir", type=click.Path(exists=True), default=".", help="Pipeline directory. Defaults to CWD")
 @click.option("-t", "--tool", type=str, metavar="<tool> or <tool/subtool>")
-def remove(ctx, pipeline_dir, tool):
+def remove(ctx, dir, tool):
     """
     Remove a software wrapper from a pipeline.
     """
     try:
-        module_remove = nf_core.modules.ModuleRemove(pipeline_dir)
+        module_remove = nf_core.modules.ModuleRemove(dir)
         module_remove.modules_repo = ctx.obj["modules_repo_obj"]
         module_remove.remove(tool)
     except UserWarning as e:

--- a/nf_core/bump_version.py
+++ b/nf_core/bump_version.py
@@ -29,8 +29,8 @@ def bump_pipeline_version(pipeline_obj, new_version):
         log.warning("Stripping leading 'v' from new version number")
         new_version = new_version[1:]
     if not current_version:
-        log.error("Could not find config variable 'manifest.version'")
-        sys.exit(1)
+        raise UserWarning("Could not find config variable 'manifest.version'")
+
     log.info("Changing version number from '{}' to '{}'".format(current_version, new_version))
 
     # nextflow.config - workflow manifest version
@@ -60,8 +60,7 @@ def bump_nextflow_version(pipeline_obj, new_version):
     current_version = re.sub(r"^[^0-9\.]*", "", current_version)
     new_version = re.sub(r"^[^0-9\.]*", "", new_version)
     if not current_version:
-        log.error("Could not find config variable 'manifest.nextflowVersion'")
-        sys.exit(1)
+        raise UserWarning("Could not find config variable 'manifest.nextflowVersion'")
     log.info("Changing Nextlow version number from '{}' to '{}'".format(current_version, new_version))
 
     # nextflow.config - manifest minimum nextflowVersion

--- a/nf_core/lint/__init__.py
+++ b/nf_core/lint/__init__.py
@@ -121,7 +121,10 @@ class PipelineLint(nf_core.utils.Pipeline):
         """Initialise linting object"""
 
         # Initialise the parent object
-        super().__init__(wf_path)
+        try:
+            super().__init__(wf_path)
+        except UserWarning:
+            raise
 
         self.lint_config = {}
         self.release_mode = release_mode

--- a/nf_core/modules/module_utils.py
+++ b/nf_core/modules/module_utils.py
@@ -309,4 +309,4 @@ def get_repo_type(dir):
     elif os.path.exists(os.path.join(dir, "software")):
         return "modules"
     else:
-        raise LookupError("Could not determine repository type of {}".format(dir))
+        raise LookupError("Could not determine repository type of '{}'".format(dir))

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -23,10 +23,13 @@ class ModuleCommand:
         self.modules_repo = ModulesRepo()
         self.dir = dir
         self.module_names = []
-        if self.dir:
-            self.repo_type = nf_core.modules.module_utils.get_repo_type(self.dir)
-        else:
-            self.repo_type = None
+        try:
+            if self.dir:
+                self.repo_type = nf_core.modules.module_utils.get_repo_type(self.dir)
+            else:
+                self.repo_type = None
+        except LookupError as e:
+            raise UserWarning(e)
 
     def get_pipeline_modules(self):
         """Get list of modules installed in the current directory"""

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -334,6 +334,12 @@ class PipelineSchema(object):
     def build_schema(self, pipeline_dir, no_prompts, web_only, url):
         """Interactively build a new pipeline schema for a pipeline"""
 
+        # Check if supplied pipeline directory really is one
+        try:
+            nf_core.utils.is_pipeline_directory(pipeline_dir)
+        except UserWarning:
+            raise
+
         if no_prompts:
             self.no_prompts = True
         if web_only:

--- a/nf_core/sync.py
+++ b/nf_core/sync.py
@@ -66,6 +66,12 @@ class PipelineSync(object):
     ):
         """Initialise syncing object"""
 
+        # Check if 'pipeline_dir' is a pipeline directory
+        try:
+            nf_core.utils.is_pipeline_directory(pipeline_dir)
+        except UserWarning:
+            raise
+
         self.pipeline_dir = os.path.abspath(pipeline_dir)
         self.from_branch = from_branch
         self.original_branch = None

--- a/nf_core/sync.py
+++ b/nf_core/sync.py
@@ -66,12 +66,6 @@ class PipelineSync(object):
     ):
         """Initialise syncing object"""
 
-        # Check if 'pipeline_dir' is a pipeline directory
-        try:
-            nf_core.utils.is_pipeline_directory(pipeline_dir)
-        except UserWarning:
-            raise
-
         self.pipeline_dir = os.path.abspath(pipeline_dir)
         self.from_branch = from_branch
         self.original_branch = None

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -121,12 +121,6 @@ class Pipeline(object):
         self.pipeline_name = None
         self.schema_obj = None
 
-        # Check if 'wf_path' is a pipeline directory
-        try:
-            is_pipeline_directory(self.wf_path)
-        except UserWarning:
-            raise
-
         try:
             repo = git.Repo(self.wf_path)
             self.git_sha = repo.head.object.hexsha

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -121,6 +121,12 @@ class Pipeline(object):
         self.pipeline_name = None
         self.schema_obj = None
 
+        # Check if 'wf_path' is a pipeline directory
+        try:
+            is_pipeline_directory(self.wf_path)
+        except UserWarning:
+            raise
+
         try:
             repo = git.Repo(self.wf_path)
             self.git_sha = repo.head.object.hexsha
@@ -181,6 +187,23 @@ class Pipeline(object):
     def _fp(self, fn):
         """Convenience function to get full path to a file in the pipeline"""
         return os.path.join(self.wf_path, fn)
+
+
+def is_pipeline_directory(wf_path):
+    """
+    Checks if the specified directory have the minimum required files
+    ('main.nf', 'nextflow.config') for a pipeline directory
+
+    Args:
+        wf_path (str): The directory to be inspected
+
+    Raises:
+        UserWarning: If one of the files are missing
+    """
+    for fn in ["main.nf", "nextflow.config"]:
+        path = os.path.join(wf_path, fn)
+        if not os.path.isfile(path):
+            raise UserWarning(f"'{wf_path}' is not a pipeline - '{fn}' is missing")
 
 
 def fetch_wf_config(wf_path):


### PR DESCRIPTION
Updated passing of arguments to `nf-core` commands and subcommands:
- Pipeline directory is now passed with `--dir <pipeline directory>` with `.` as default, for all `nf-core` commands that previously had it as an argument. Resolves #1140
- Pipeline directory for `nf-core modules list` is now passed with `--installed <pipeline directory>`. Partially resolves #1139
- `--tool <tool name>` for `nf-core modules` subcommand are now replaced by optional argument `<tool>`. For example: `nf-core modules install fastqc`.
- Updated docs text, but not the console logs. 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Documentation in `docs` is updated
