### PR TITLE
Fix create test yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Updated `nf-core modules list` to show versions of local modules
 * Improved exit behavior by replacing `sys.exit` with exceptions
 * Updated `nf-core modules remove` to remove module entry in `modules.json` if module directory is missing
+* Create extra tempdir as work directory for `nf-core modules create-test-yml` to avoid adding the temporary files to the `test.yml`
 
 #### Sync
 

--- a/nf_core/modules/test_yml_builder.py
+++ b/nf_core/modules/test_yml_builder.py
@@ -276,8 +276,9 @@ class ModulesTestYmlBuilder(object):
 
         tmp_dir = tempfile.mkdtemp()
         tmp_dir_repeat = tempfile.mkdtemp()
-        command_repeat = command + f" --outdir {tmp_dir_repeat} -work-dir {tmp_dir_repeat}"
-        command += f" --outdir {tmp_dir} -work-dir {tmp_dir}"
+        work_dir = tempfile.mkdtemp()
+        command_repeat = command + f" --outdir {tmp_dir_repeat} -work-dir {work_dir}"
+        command += f" --outdir {tmp_dir} -work-dir {work_dir}"
 
         log.info(f"Running '{self.module_name}' test with command:\n[violet]{command}")
         try:


### PR DESCRIPTION
Fixes a bug in `nf-core create-test-yml` (introduced by yours truly).
Because I moved the work directory to the temp dir that we use to create the output files and calculate the hash sums, things like `.command.out` and the entire content of the `work` dir is added to the `test.yml`

So instead we're just making an extra temp dir now and use that as the `work` directory. 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
