### PR TITLE
Lint the `modules.json` for uninstalled modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 * Updated `nf-core modules remove` to remove module entry in `modules.json` if module directory is missing
 * Create extra tempdir as work directory for `nf-core modules create-test-yml` to avoid adding the temporary files to the `test.yml`
 * Refactored passing of command line arguments to `nf-core` commands and subcommands ([#1139](https://github.com/nf-core/tools/issues/1139), [#1140](https://github.com/nf-core/tools/issues/1140))
-* Check for `modules.json` for entires of modules that are not actually installed in the pipeline [[#1141]](https://github.com/nf-core/tools/issues/1141)
+* Check for `modules.json` for entries of modules that are not actually installed in the pipeline [[#1141](https://github.com/nf-core/tools/issues/1141)]
 
 #### Sync
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Updated `nf-core modules remove` to remove module entry in `modules.json` if module directory is missing
 * Create extra tempdir as work directory for `nf-core modules create-test-yml` to avoid adding the temporary files to the `test.yml`
 * Refactored passing of command line arguments to `nf-core` commands and subcommands ([#1139](https://github.com/nf-core/tools/issues/1139), [#1140](https://github.com/nf-core/tools/issues/1140))
+* Check for `modules.json` for entires of modules that are not actually installed in the pipeline [[#1141]](https://github.com/nf-core/tools/issues/1141)
 
 #### Sync
 

--- a/docs/api/_src/pipeline_lint_tests/modules_json.rst
+++ b/docs/api/_src/pipeline_lint_tests/modules_json.rst
@@ -1,0 +1,4 @@
+nextflow_config
+===============
+
+.. automethod:: nf_core.lint.PipelineLint.modules_json

--- a/nf_core/lint/__init__.py
+++ b/nf_core/lint/__init__.py
@@ -106,6 +106,7 @@ class PipelineLint(nf_core.utils.Pipeline):
     from .files_exist import files_exist
     from .files_unchanged import files_unchanged
     from .merge_markers import merge_markers
+    from .modules_json import modules_json
     from .nextflow_config import nextflow_config
     from .params_used import params_used
     from .pipeline_name_conventions import pipeline_name_conventions
@@ -154,6 +155,7 @@ class PipelineLint(nf_core.utils.Pipeline):
             "schema_description",
             "actions_schema_validation",
             "merge_markers",
+            "modules_json",
         ]
         if self.release_mode:
             self.lint_tests.extend(["version_consistency"])

--- a/nf_core/lint/modules_json.py
+++ b/nf_core/lint/modules_json.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+from logging import warn
+from nf_core.modules.remove import ModuleRemove
+
+
+def modules_json(self):
+    """Make sure all modules described in the ``modules.json`` file are actually installed
+
+    Every module installed from ``nf-core/modules`` must have an entry in the ``modules.json`` file
+    with an associated version git_sha hash.
+
+    * Failure: If module entries are found in ``modules.json`` for modules that are not installed
+    """
+    passed = []
+    warned = []
+    failed = []
+
+    # Load pipeline modules and modules.json
+    module_remove = ModuleRemove(self.wf_path)
+    modules_json = module_remove.load_modules_json()
+
+    if modules_json:
+        module_remove.get_pipeline_modules()
+
+        all_modules_passed = True
+
+        for key in modules_json["modules"].keys():
+            if not key in module_remove.module_names:
+                failed.append(f"Entry for`{key}` found in `modules.json` but module is not installed in pipeline.")
+                all_modules_passed = False
+
+        if all_modules_passed:
+            passed.append("Only installed modules found in `modules.json`")
+    else:
+        warned.append("Could not open modules.json file.")
+
+    return {"passed": passed, "warned": warned, "failed": failed}

--- a/nf_core/lint/modules_json.py
+++ b/nf_core/lint/modules_json.py
@@ -27,12 +27,12 @@ def modules_json(self):
 
         for key in modules_json["modules"].keys():
             if not key in module_remove.module_names:
-                failed.append(f"Entry for`{key}` found in `modules.json` but module is not installed in pipeline.")
+                failed.append(f"Entry for `{key}` found in `modules.json` but module is not installed in pipeline.")
                 all_modules_passed = False
 
         if all_modules_passed:
             passed.append("Only installed modules found in `modules.json`")
     else:
-        warned.append("Could not open modules.json file.")
+        warned.append("Could not open `modules.json` file.")
 
     return {"passed": passed, "warned": warned, "failed": failed}

--- a/nf_core/lint/modules_json.py
+++ b/nf_core/lint/modules_json.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from logging import warn
-from nf_core.modules.remove import ModuleRemove
+from nf_core.modules.modules_command import ModuleCommand
 
 
 def modules_json(self):
@@ -17,16 +17,16 @@ def modules_json(self):
     failed = []
 
     # Load pipeline modules and modules.json
-    module_remove = ModuleRemove(self.wf_path)
-    modules_json = module_remove.load_modules_json()
+    modules_command = ModuleCommand(self.wf_path)
+    modules_json = modules_command.load_modules_json()
 
     if modules_json:
-        module_remove.get_pipeline_modules()
+        modules_command.get_pipeline_modules()
 
         all_modules_passed = True
 
         for key in modules_json["modules"].keys():
-            if not key in module_remove.module_names:
+            if not key in modules_command.module_names:
                 failed.append(f"Entry for `{key}` found in `modules.json` but module is not installed in pipeline.")
                 all_modules_passed = False
 

--- a/tests/lint/modules_json.py
+++ b/tests/lint/modules_json.py
@@ -1,0 +1,8 @@
+import nf_core.lint
+
+def test_modules_json_fail(self):
+    self.lint_obj._load()
+    results = self.lint_obj.modules_json()
+    assert len(results.get("warned", [])) == 0
+    assert len(results.get("failed", [])) == 0
+    assert len(results.get("passed", [])) == 1

--- a/tests/lint/modules_json.py
+++ b/tests/lint/modules_json.py
@@ -1,5 +1,6 @@
 import nf_core.lint
 
+
 def test_modules_json_fail(self):
     self.lint_obj._load()
     results = self.lint_obj.modules_json()

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -215,6 +215,8 @@ class TestLint(unittest.TestCase):
 
     from lint.version_consistency import test_version_consistency
 
+    from lint.modules_json import test_modules_json_fail
+
 
 # TODO nf-core: Assess and strip out if no longer required for DSL2
 


### PR DESCRIPTION
This PR adds a new pipeline lint check (`nf-core lint`) which looks for module entries in the `modules.json` of modules that are not actually installed in the pipeline.

I thought it makes sense to package that into the `nf-core lint` command as it looks at a general pipeline file (`modules.json`) and compares that against all installed modules. The `nf-core modules lint` command is more module-centric, meaning that it runs specific lint tests for every module separately. Therefore I think it is more logical to add this check here.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
