### PR TITLE
Added filtering by keywords to `nf-core modules list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Improved exit behavior by replacing `sys.exit` with exceptions
 * Updated `nf-core modules remove` to remove module entry in `modules.json` if module directory is missing
 * Refactored passing of command line arguments to `nf-core` commands and subcommands ([#1139](https://github.com/nf-core/tools/issues/1139), [#1140](https://github.com/nf-core/tools/issues/1140))
+* Added `<keywords>` argument to `nf-core modules list` for filtering the listed modules. ([#1139](https://github.com/nf-core/tools/issues/1139)
 
 #### Sync
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -371,9 +371,10 @@ def modules(ctx, repository, branch):
 
 @modules.command(help_priority=1)
 @click.pass_context
+@click.argument("keywords", required=False, nargs=-1, metavar="<filter keywords>")
 @click.option("-i", "--installed", type=click.Path(exists=True), help="List modules installed in local directory")
 @click.option("-j", "--json", is_flag=True, help="Print as JSON to stdout")
-def list(ctx, installed, json):
+def list(ctx, keywords, installed, json):
     """
     List available software modules.
 
@@ -385,7 +386,7 @@ def list(ctx, installed, json):
     try:
         module_list = nf_core.modules.ModuleList(installed)
         module_list.modules_repo = ctx.obj["modules_repo_obj"]
-        print(module_list.list_modules(json))
+        print(module_list.list_modules(keywords, json))
     except UserWarning as e:
         log.critical(e)
         sys.exit(1)

--- a/nf_core/modules/list.py
+++ b/nf_core/modules/list.py
@@ -14,7 +14,7 @@ class ModuleList(ModuleCommand):
     def __init__(self, pipeline_dir):
         super().__init__(pipeline_dir)
 
-    def list_modules(self, keywords, print_json=False):
+    def list_modules(self, keywords=None, print_json=False):
         """
         Get available module names from GitHub tree for repo
         and print as list to stdout


### PR DESCRIPTION
Added new positional argument `<keywords>` to `nf-core modules list` which takes zero or more keywords and uses them to filter the retrieved modules. Should close #1139.   

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
