### PR TITLE
fix create-test-yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Refactored passing of command line arguments to `nf-core` commands and subcommands ([#1139](https://github.com/nf-core/tools/issues/1139), [#1140](https://github.com/nf-core/tools/issues/1140))
 * Check for `modules.json` for entries of modules that are not actually installed in the pipeline [[#1141](https://github.com/nf-core/tools/issues/1141)]
 * Added `<keywords>` argument to `nf-core modules list` for filtering the listed modules. ([#1139](https://github.com/nf-core/tools/issues/1139)
+* Fixed `nf-core modules create-test-yml` so it doesn't break when the output directory is supplied [[#1148](https://github.com/nf-core/tools/issues/1148)]
 
 #### Sync
 

--- a/nf_core/modules/test_yml_builder.py
+++ b/nf_core/modules/test_yml_builder.py
@@ -234,15 +234,18 @@ class ModulesTestYmlBuilder(object):
                     results_dir = None
 
         test_files = self.create_test_file_dict(results_dir=results_dir)
-        test_files_repeat = self.create_test_file_dict(results_dir=results_dir_repeat)
 
-        # Compare both test.yml files
-        for i in range(len(test_files)):
-            if not test_files[i]["md5sum"] == test_files_repeat[i]["md5sum"]:
-                test_files[i].pop("md5sum")
-                test_files[i][
-                    "contains"
-                ] = "[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]"
+        # If test was repeated, compare the md5 sums
+        if results_dir_repeat:
+            test_files_repeat = self.create_test_file_dict(results_dir=results_dir_repeat)
+
+            # Compare both test.yml files
+            for i in range(len(test_files)):
+                if not test_files[i]["md5sum"] == test_files_repeat[i]["md5sum"]:
+                    test_files[i].pop("md5sum")
+                    test_files[i][
+                        "contains"
+                    ] = "[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]"
 
         if len(test_files) == 0:
             raise UserWarning(f"Could not find any test result files in '{results_dir}'")


### PR DESCRIPTION
Fix bug in `nf-core modules create-test-yml` that occurs when specifying the output directory.

Now the simply doesn't compare md5 sums when a output directory is specified. Otherwise we'd have to ask the user for two directories which gets a bit much. The best way is to run it without a specified directory anyway.

Fixes #1148 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
