### PR TITLE
Updated `modules remove` and `modules list` for restructuring 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Updated `nf-core modules lint` to work with new directory structure [[#1159](https://github.com/nf-core/tools/issues/1159)]
 * Updated `nf-core modules install` and `modules.json` to work with new directory structure ([#1159](https://github.com/nf-core/tools/issues/1159))
 * Updated `nf-core modules remove` to work with new directory structure [[#1159](https://github.com/nf-core/tools/issues/1159)]
+* Added cli prompt to specify remove repo in `nf-core modules remove` and removed old table style for `nf-core modules list`
 
 #### Sync
 

--- a/nf_core/modules/list.py
+++ b/nf_core/modules/list.py
@@ -77,31 +77,33 @@ class ModuleList(ModuleCommand):
             except UserWarning as e:
                 log.error(e)
                 return ""
+
             # Get installed modules
             self.get_pipeline_modules()
-            modules = self.module_names
 
-            # Filter the modules by keywords
-            modules = [mod for mod in modules if all(k in mod for k in keywords)]
+            # Filter by keywords
+            repos_with_mods = {
+                repo_name: [mod for mod in self.module_names[repo_name] if all(k in mod for k in keywords)]
+                for repo_name in self.module_names
+            }
 
             # Nothing found
-            if len(modules) == 0:
+            if sum(map(len, repos_with_mods)) == 0:
                 log.info(f"No nf-core modules found in '{self.dir}'{pattern_msg(keywords)}")
                 return ""
 
-            modules_json = self.load_modules_json()
-            if not modules_json:
-                # If the modules.json file is missing we show the old version
-                # of the list command, i.e only names
-                for mod in sorted(modules):
-                    table.add_row(mod)
-            else:
-                table.add_column("Version SHA")
-                table.add_column("Message")
-                table.add_column("Date")
+            table.add_column("Repository")
+            table.add_column("Version SHA")
+            table.add_column("Message")
+            table.add_column("Date")
 
+            # Load 'modules.json'
+            modules_json = self.load_modules_json()
+
+            for repo_name, modules in sorted(self.module_names.items(), key=lambda x: x[0]):
+                repo_entry = modules_json["repos"].get(repo_name, {})
                 for module in sorted(modules):
-                    module_entry = modules_json["repos"][self.modules_repo.name].get(module)
+                    module_entry = repo_entry.get(module)
                     if module_entry:
                         version_sha = module_entry["git_sha"]
                         try:
@@ -111,11 +113,11 @@ class ModuleList(ModuleCommand):
                             date = "[red]Not Available"
                             message = "[red]Not Available"
                     else:
-                        log.warning(f"Commit SHA for module {module} is missing from 'modules.json'")
+                        log.warning(f"Commit SHA for module '{repo_name}/{module}' is missing from 'modules.json'")
                         version_sha = "[red]Not Available"
                         date = "[red]Not Available"
                         message = "[red]Not Available"
-                    table.add_row(module, version_sha, message, date)
+                    table.add_row(module, repo_name, version_sha, message, date)
 
         if print_json:
             return json.dumps(modules, sort_keys=True, indent=4)

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -1,3 +1,4 @@
+from posixpath import dirname
 from nf_core import modules
 import os
 import glob
@@ -33,19 +34,44 @@ class ModuleCommand:
             raise UserWarning(e)
 
     def get_pipeline_modules(self):
-        """Get list of modules installed in the current directory"""
-        self.module_names = []
+        """
+        Get the modules installed in the current directory.
+
+        If the current directory is a pipeline, the `module_names`
+        field is set to a dictionary indexed by the different
+        installation repositories in the directory. If the directory
+        is a clone of nf-core/modules the filed is set to
+        `{"modules": modules_in_dir}`
+
+        """
+
+        self.module_names = {}
+
+        module_base_path = f"{self.dir}/modules/"
+
         if self.repo_type == "pipeline":
-            module_base_path = f"{self.dir}/modules/nf-core/modules"
+            repo_owners = (owner for owner in os.listdir(module_base_path) if owner != "local")
+            repo_names = (
+                f"{repo_owner}/{name}"
+                for repo_owner in repo_owners
+                for name in os.listdir(f"{module_base_path}/{repo_owner}")
+            )
+            for repo_name in repo_names:
+                repo_path = os.path.join(module_base_path, repo_name)
+                module_mains_path = f"{repo_path}/**/main.nf"
+                module_mains = glob.glob(module_mains_path, recursive=True)
+                self.module_names[repo_name] = [
+                    os.path.dirname(os.path.relpath(mod, repo_path)) for mod in module_mains
+                ]
         elif self.repo_type == "modules":
-            module_base_path = f"{self.dir}/modules"
+            module_mains_path = f"{module_base_path}/**/main.nf"
+            module_mains = glob.glob(module_mains_path, recursive=True)
+            self.module_names["modules"] = [
+                os.path.dirname(os.path.relpath(mod, module_base_path)) for mod in module_mains
+            ]
         else:
             log.error("Directory is neither a clone of nf-core/modules nor a pipeline")
             raise SystemError
-        module_mains_path = f"{module_base_path}/**/main.nf"
-        module_mains = glob.glob(module_mains_path, recursive=True)
-        for mod in module_mains:
-            self.module_names.append(os.path.dirname(os.path.relpath(mod, module_base_path)))
 
     def has_valid_directory(self):
         """Check that we were given a pipeline or clone of nf-core/modules"""

--- a/nf_core/modules/remove.py
+++ b/nf_core/modules/remove.py
@@ -41,7 +41,7 @@ class ModuleRemove(ModuleCommand):
         if self.modules_repo.name != "nf-core/modules":
             repo_name = self.modules_repo.name
         elif len(self.module_names) == 1:
-            repo_name = self.module_names.keys()[0]
+            repo_name = list(self.module_names.keys())[0]
         else:
             repo_name = questionary.autocomplete(
                 "Repo name:", choices=self.module_names.keys(), style=nf_core.utils.nfcore_question_style

--- a/nf_core/modules/remove.py
+++ b/nf_core/modules/remove.py
@@ -33,17 +33,27 @@ class ModuleRemove(ModuleCommand):
 
         # Get the installed modules
         self.get_pipeline_modules()
+        if sum(map(len, self.module_names)) == 0:
+            log.error("No installed modules found in pipeline")
+            return False
+
+        # Decide from which repo the module was installed
+        if self.modules_repo.name != "nf-core/modules":
+            repo_name = self.modules_repo.name
+        elif len(self.module_names) == 1:
+            repo_name = self.module_names.keys()[0]
+        else:
+            repo_name = questionary.autocomplete(
+                "Repo name:", choices=self.module_names.keys(), style=nf_core.utils.nfcore_question_style
+            ).ask()
 
         if module is None:
-            if len(self.module_names) == 0:
-                log.error("No installed modules found in pipeline")
-                return False
             module = questionary.autocomplete(
-                "Tool name:", choices=self.module_names, style=nf_core.utils.nfcore_question_style
+                "Tool name:", choices=self.module_names[repo_name], style=nf_core.utils.nfcore_question_style
             ).ask()
 
         # Set the remove folder based on the repository name
-        remove_folder = [self.modules_repo.owner, self.modules_repo.repo]
+        remove_folder = os.path.split(repo_name)
 
         # Get the module directory
         module_dir = os.path.join(self.dir, "modules", *remove_folder, module)
@@ -54,28 +64,24 @@ class ModuleRemove(ModuleCommand):
             log.info("The module you want to remove does not seem to be installed")
 
             modules_json = self.load_modules_json()
-            if (
-                self.modules_repo.name in modules_json["repos"]
-                and module in modules_json["repos"][self.module_repo.name]
-            ):
+            if self.modules_repo.name in modules_json["repos"] and module in modules_json["repos"][repo_name]:
                 log.error(f"Found entry for '{module}' in 'modules.json'. Removing...")
-                self.remove_modules_json_entry(module, modules_json)
+                self.remove_modules_json_entry(module, repo_name, modules_json)
             return False
 
         log.info("Removing {}".format(module))
 
         # Remove entry from modules.json
         modules_json = self.load_modules_json()
-        self.remove_modules_json_entry(module, modules_json)
+        self.remove_modules_json_entry(module, repo_name, modules_json)
 
         # Remove the module
         return self.clear_module_dir(module_name=module, module_dir=module_dir)
 
-    def remove_modules_json_entry(self, module, modules_json):
-        # Load 'modules.json'
+    def remove_modules_json_entry(self, module, repo_name, modules_json):
+
         if not modules_json:
             return False
-        repo_name = self.modules_repo.name
         if repo_name in modules_json.get("repos", {}):
             repo_entry = modules_json["repos"][repo_name]
             if module in repo_entry:
@@ -83,7 +89,7 @@ class ModuleRemove(ModuleCommand):
             if len(repo_entry) == 0:
                 modules_json["repos"].pop(repo_name)
         else:
-            log.error(f"Module '{module}' is missing from 'modules.json' file.")
+            log.warning(f"Module '{repo_name}/{module}' is missing from 'modules.json' file.")
             return False
 
         self.dump_modules_json(modules_json)


### PR DESCRIPTION
Updated `modules remove` and `modules list` for restructuring and changed some features: 
- `ModulesCommand.get_pipeline_modules()` now assigns a dictionary instead of a list to `module_names`.
- The install repository is now included in the `modules list` table. 
- Deprecated the old style of `modules list` (i.e. the one for pipelines without a `modules.json` file)
- `modules remove` prompts the user for the remove repository, if there is more than one present in the pipeline and the `--repository` option is set to `nf-core/modules`. 

I'm not sure about the last point, there should be a better way to configure this. My idea was to make it a bit more convenient for someone who has a pipeline with several install repos. 