### PR TITLE
Add `--all` flag to `nf-core modules install`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Updated `nf-core modules remove` to work with new directory structure [[#1159](https://github.com/nf-core/tools/issues/1159)]
 * Restructured code and removed old table style in `nf-core modules list`
 * Fixed bug causing `modules.json` creation to loop indefinitly
+* Added `--all` flag to `nf-core modules install`
 
 #### Sync
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -401,7 +401,7 @@ def list(ctx, keywords, installed, json):
     "-f", "--force", is_flag=True, default=False, help="Force installation of module if module already exists"
 )
 @click.option("-s", "--sha", type=str, metavar="<commit sha>", help="Install module at commit SHA")
-@click.option("--all", is_flag=True, default=False, help="Update all modules installed in pipeline")
+@click.option("-a", "--all", is_flag=True, default=False, help="Update all modules installed in pipeline")
 def install(ctx, tool, dir, latest, force, sha, all):
     """
     Add a DSL2 software wrapper module to a pipeline.

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -401,7 +401,8 @@ def list(ctx, keywords, installed, json):
     "-f", "--force", is_flag=True, default=False, help="Force installation of module if module already exists"
 )
 @click.option("-s", "--sha", type=str, metavar="<commit sha>", help="Install module at commit SHA")
-def install(ctx, tool, dir, latest, force, sha):
+@click.option("--all", is_flag=True, default=False, help="Update all modules installed in pipeline")
+def install(ctx, tool, dir, latest, force, sha, all):
     """
     Add a DSL2 software wrapper module to a pipeline.
 
@@ -409,9 +410,14 @@ def install(ctx, tool, dir, latest, force, sha):
     along with associated metadata.
     """
     try:
-        module_install = nf_core.modules.ModuleInstall(dir, force=force, latest=latest, sha=sha)
+        module_install = nf_core.modules.ModuleInstall(dir, force=force, latest=latest, sha=sha, update_all=all)
         module_install.modules_repo = ctx.obj["modules_repo_obj"]
-        module_install.install(tool)
+        exit_status = module_install.install(tool)
+        if not exit_status and all:
+            raise UserWarning(
+                "Install command exited with bad exit status. "
+                "Some of your module files might have been erroneously removed."
+            )
     except UserWarning as e:
         log.critical(e)
         sys.exit(1)

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -414,12 +414,13 @@ def install(ctx, tool, dir, latest, force, sha, all):
         module_install.modules_repo = ctx.obj["modules_repo_obj"]
         exit_status = module_install.install(tool)
         if not exit_status and all:
-            raise UserWarning(
+            log.critical(
                 "Install command exited with bad exit status. "
                 "Some of your module files might have been erroneously removed."
             )
+            sys.exit(1)
     except UserWarning as e:
-        log.critical(e)
+        log.error(e)
         sys.exit(1)
 
 

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -5,17 +5,19 @@ import logging
 import nf_core.utils
 
 from .modules_command import ModuleCommand
-from .module_utils import get_module_git_log
+from .module_utils import get_installed_modules, get_module_git_log
+from .modules_repo import ModulesRepo
 
 log = logging.getLogger(__name__)
 
 
 class ModuleInstall(ModuleCommand):
-    def __init__(self, pipeline_dir, force=False, latest=False, sha=None):
+    def __init__(self, pipeline_dir, force=False, latest=False, sha=None, update_all=False):
         super().__init__(pipeline_dir)
         self.force = force
         self.latest = latest
         self.sha = sha
+        self.update_all = update_all
 
     def install(self, module):
         if self.repo_type == "modules":
@@ -23,117 +25,134 @@ class ModuleInstall(ModuleCommand):
             return False
         # Check whether pipelines is valid
         self.has_valid_directory()
+        if not self.update_all:
+            # Get the available modules
+            try:
+                self.modules_repo.get_modules_file_tree()
+            except LookupError as e:
+                log.error(e)
+                return False
 
-        # Get the available modules
-        try:
-            self.modules_repo.get_modules_file_tree()
-        except LookupError as e:
-            log.error(e)
-            return False
+            if self.latest and self.sha is not None:
+                log.error("Cannot use '--sha' and '--latest' at the same time!")
+                return False
 
-        if self.latest and self.sha is not None:
-            log.error("Cannot use '--sha' and '--latest' at the same time!")
-            return False
+            if module is None:
+                module = questionary.autocomplete(
+                    "Tool name:",
+                    choices=self.modules_repo.modules_avail_module_names,
+                    style=nf_core.utils.nfcore_question_style,
+                ).unsafe_ask()
 
-        if module is None:
-            module = questionary.autocomplete(
-                "Tool name:",
-                choices=self.modules_repo.modules_avail_module_names,
-                style=nf_core.utils.nfcore_question_style,
-            ).unsafe_ask()
+            # Check that the supplied name is an available module
+            if module and module not in self.modules_repo.modules_avail_module_names:
+                log.error("Module '{}' not found in list of available modules.".format(module))
+                log.info("Use the command 'nf-core modules list' to view available software")
+                return False
+            repos_and_modules = [(self.modules_repo, module)]
+        else:
+            if self.force:
+                log.warning("'--force' doesn't do anything when used with '--all'")
+            else:
+                self.force = True
 
-        # Check that the supplied name is an available module
-        if module not in self.modules_repo.modules_avail_module_names:
-            log.error("Module '{}' not found in list of available modules.".format(module))
-            log.info("Use the command 'nf-core modules list' to view available software")
-            return False
-
-        # Set the install folder based on the repository name
-        install_folder = [self.modules_repo.owner, self.modules_repo.repo]
-
-        # Compute the module directory
-        module_dir = os.path.join(self.dir, "modules", *install_folder, module)
+            self.get_pipeline_modules()
+            repos_and_modules = [
+                (ModulesRepo(repo=repo_name), modules) for repo_name, modules in self.module_names.items()
+            ]
+            # Load the modules file trees
+            for repo, _ in repos_and_modules:
+                repo.get_modules_file_tree()
+            repos_and_modules = [(repo, module) for repo, modules in repos_and_modules for module in modules]
 
         # Load 'modules.json'
         modules_json = self.load_modules_json()
         if not modules_json:
             return False
 
-        if self.modules_repo.name in modules_json["repos"]:
-            current_entry = modules_json["repos"][self.modules_repo.name].get(module)
-        else:
-            current_entry = None
-
-        if current_entry is not None and self.sha is None:
-            # Fetch the latest commit for the module
-            current_version = current_entry["git_sha"]
-            git_log = get_module_git_log(module, modules_repo=self.modules_repo, per_page=1, page_nbr=1)
-            if len(git_log) == 0:
-                log.error(f"Was unable to fetch version of module '{module}'")
-                return False
-            latest_version = git_log[0]["git_sha"]
-            if current_version == latest_version and not self.force:
-                log.info("Already up to date")
-                return True
-            elif not self.force:
-                log.error("Found newer version of module.")
-                self.latest = self.force = questionary.confirm(
-                    "Do you want install it? (--force --latest)", default=False
-                ).unsafe_ask()
-                if not self.latest:
-                    return False
-        else:
-            latest_version = None
-
-        # Check that we don't already have a folder for this module
-        if not self.check_module_files_installed(module, module_dir):
-            return False
-
-        if self.sha:
-            if not current_entry is None and not self.force:
-                return False
-            if self.download_module_file(module, self.sha, install_folder, module_dir):
-                self.update_modules_json(modules_json, module, self.sha)
-                return True
+        exit_value = True
+        for modules_repo, module in repos_and_modules:
+            if modules_repo.name in modules_json["repos"]:
+                current_entry = modules_json["repos"][modules_repo.name].get(module)
             else:
-                try:
-                    version = self.prompt_module_version_sha(
-                        module, installed_sha=current_entry["git_sha"] if not current_entry is None else None
-                    )
-                except SystemError as e:
-                    log.error(e)
-                    return False
-        else:
-            if self.latest:
+                current_entry = None
+
+            # Set the install folder based on the repository name
+            install_folder = [modules_repo.owner, modules_repo.repo]
+
+            # Compute the module directory
+            module_dir = os.path.join(self.dir, "modules", *install_folder, module)
+
+            if current_entry is not None and self.sha is None:
                 # Fetch the latest commit for the module
-                if latest_version is None:
-                    git_log = get_module_git_log(module, modules_repo=self.modules_repo, per_page=1, page_nbr=1)
-                    if len(git_log) == 0:
-                        log.error(f"Was unable to fetch version of module '{module}'")
-                        return False
-                    latest_version = git_log[0]["git_sha"]
-                version = latest_version
+                current_version = current_entry["git_sha"]
+                git_log = get_module_git_log(module, modules_repo=modules_repo, per_page=1, page_nbr=1)
+                if len(git_log) == 0:
+                    log.error(f"Was unable to fetch version of '{modules_repo.name}/{module}'")
+                    exit_value = False
+                    continue
+                latest_version = git_log[0]["git_sha"]
+                if current_version == latest_version and (not self.force or self.update_all):
+                    log.info(f"'{modules_repo.name}/{module}' is already up to date")
+                    continue
+                elif not self.force:
+                    log.error("Found newer version of module.")
+                    self.latest = self.force = questionary.confirm(
+                        "Do you want install it? (--force --latest)", default=False
+                    ).unsafe_ask()
+                    if not self.latest:
+                        exit_value = False
+                        continue
             else:
-                try:
-                    version = self.prompt_module_version_sha(
-                        module, installed_sha=current_entry["git_sha"] if not current_entry is None else None
-                    )
-                except SystemError as e:
-                    log.error(e)
+                latest_version = None
+
+            # Check that we don't already have a folder for this module
+            if not self.check_module_files_installed(module, module_dir):
+                exit_value = False
+
+            if self.sha:
+                if current_entry is not None and not self.force:
                     return False
+                if self.download_module_file(module, self.sha, modules_repo, install_folder, module_dir):
+                    self.update_modules_json(modules_json, modules_repo.name, module, self.sha)
+                else:
+                    exit_value = False
+                continue
+            else:
+                if self.latest or self.update_all:
+                    # Fetch the latest commit for the module
+                    if latest_version is None:
+                        git_log = get_module_git_log(module, modules_repo=modules_repo, per_page=1, page_nbr=1)
+                        if len(git_log) == 0:
+                            log.error(f"Was unable to fetch version of module '{module}'")
+                            exit_value = False
+                            continue
+                        latest_version = git_log[0]["git_sha"]
+                    version = latest_version
+                else:
+                    try:
+                        version = self.prompt_module_version_sha(
+                            module,
+                            installed_sha=current_entry["git_sha"] if not current_entry is None else None,
+                            modules_repo=modules_repo,
+                        )
+                    except SystemError as e:
+                        log.error(e)
+                        exit_value = False
+                        continue
+            log.info(f"Installing {module}")
+            log.debug(
+                f"Installing module '{module}' at modules hash {modules_repo.modules_current_hash} from {self.modules_repo.name}"
+            )
 
-        log.info(f"Installing {module}")
-        log.debug(
-            f"Installing module '{module}' at modules hash {self.modules_repo.modules_current_hash} from {self.modules_repo.name}"
-        )
+            # Download module files
+            if not self.download_module_file(module, version, modules_repo, install_folder, module_dir):
+                exit_value = False
+                continue
 
-        # Download module files
-        if not self.download_module_file(module, version, install_folder, module_dir):
-            return False
-
-        # Update module.json with newly installed module
-        self.update_modules_json(modules_json, self.modules_repo.name, module, version)
-        return True
+            # Update module.json with newly installed module
+            self.update_modules_json(modules_json, modules_repo.name, module, version)
+        return exit_value
 
     def check_module_files_installed(self, module_name, module_dir):
         """Checks if a module is already installed"""
@@ -151,17 +170,19 @@ class ModuleInstall(ModuleCommand):
         else:
             return True
 
-    def prompt_module_version_sha(self, module, installed_sha=None):
+    def prompt_module_version_sha(self, module, installed_sha=None, modules_repo=None):
+        if modules_repo is None:
+            modules_repo = self.modules_repo
         older_commits_choice = questionary.Choice(
             title=[("fg:ansiyellow", "older commits"), ("class:choice-default", "")], value=""
         )
         git_sha = ""
         page_nbr = 1
-        next_page_commits = get_module_git_log(module, modules_repo=self.modules_repo, per_page=10, page_nbr=page_nbr)
+        next_page_commits = get_module_git_log(module, modules_repo=modules_repo, per_page=10, page_nbr=page_nbr)
         while git_sha is "":
             commits = next_page_commits
             next_page_commits = get_module_git_log(
-                module, modules_repo=self.modules_repo, per_page=10, page_nbr=page_nbr + 1
+                module, modules_repo=modules_repo, per_page=10, page_nbr=page_nbr + 1
             )
             choices = []
             for title, sha in map(lambda commit: (commit["trunc_message"], commit["git_sha"]), commits):

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -51,6 +51,8 @@ class ModuleInstall(ModuleCommand):
                 return False
             repos_and_modules = [(self.modules_repo, module)]
         else:
+            if module:
+                raise UserWarning("You cannot specify a module and use '--all' flag at the same time")
             if self.force:
                 log.warning("'--force' doesn't do anything when used with '--all'")
             else:

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -95,7 +95,7 @@ class ModuleInstall(ModuleCommand):
                     exit_value = False
                     continue
                 latest_version = git_log[0]["git_sha"]
-                if current_version == latest_version and (not self.force or self.update_all):
+                if current_version == latest_version and (not self.force or self.latest):
                     log.info(f"'{modules_repo.name}/{module}' is already up to date")
                     continue
                 elif not self.force:
@@ -134,7 +134,7 @@ class ModuleInstall(ModuleCommand):
                     exit_value = False
                 continue
             else:
-                if self.latest or self.update_all:
+                if self.latest:
                     # Fetch the latest commit for the module
                     if latest_version is None:
                         try:
@@ -195,17 +195,14 @@ class ModuleInstall(ModuleCommand):
         git_sha = ""
         page_nbr = 1
         try:
-            next_page_commits = get_module_git_log(
-                module, modules_repo=self.modules_repo, per_page=10, page_nbr=page_nbr
-            )
+            next_page_commits = get_module_git_log(module, modules_repo=modules_repo, per_page=10, page_nbr=page_nbr)
         except UserWarning:
             next_page_commits = None
-
         while git_sha is "":
             commits = next_page_commits
             try:
                 next_page_commits = get_module_git_log(
-                    module, modules_repo=self.modules_repo, per_page=10, page_nbr=page_nbr + 1
+                    module, modules_repo=modules_repo, per_page=10, page_nbr=page_nbr + 1
                 )
             except UserWarning:
                 next_page_commits = None

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -52,11 +52,8 @@ class ModuleInstall(ModuleCommand):
             repos_and_modules = [(self.modules_repo, module)]
         else:
             if module:
-                raise UserWarning("You cannot specify a module and use '--all' flag at the same time")
-            if self.force:
-                log.warning("'--force' doesn't do anything when used with '--all'")
-            else:
-                self.force = True
+                raise UserWarning("You cannot specify a module and use the '--all' flag at the same time")
+            self.force = True
 
             self.get_pipeline_modules()
             repos_and_modules = [
@@ -101,7 +98,7 @@ class ModuleInstall(ModuleCommand):
                 elif not self.force:
                     log.error("Found newer version of module.")
                     self.latest = self.force = questionary.confirm(
-                        "Do you want install it? (--force --latest)", default=False
+                        "Do you want to install it? (--force --latest)", default=False
                     ).unsafe_ask()
                     if not self.latest:
                         exit_value = False

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -86,8 +86,9 @@ class ModuleInstall(ModuleCommand):
             if current_entry is not None and self.sha is None:
                 # Fetch the latest commit for the module
                 current_version = current_entry["git_sha"]
-                git_log = get_module_git_log(module, modules_repo=modules_repo, per_page=1, page_nbr=1)
-                if len(git_log) == 0:
+                try:
+                    git_log = get_module_git_log(module, modules_repo=modules_repo, per_page=1, page_nbr=1)
+                except UserWarning:
                     log.error(f"Was unable to fetch version of '{modules_repo.name}/{module}'")
                     exit_value = False
                     continue
@@ -112,7 +113,7 @@ class ModuleInstall(ModuleCommand):
 
             if self.sha:
                 if current_entry is not None and not self.force:
-                    return False
+                    exit_value = False
                 if self.download_module_file(module, self.sha, modules_repo, install_folder, module_dir):
                     self.update_modules_json(modules_json, modules_repo.name, module, self.sha)
                 else:
@@ -122,8 +123,9 @@ class ModuleInstall(ModuleCommand):
                 if self.latest or self.update_all:
                     # Fetch the latest commit for the module
                     if latest_version is None:
-                        git_log = get_module_git_log(module, modules_repo=modules_repo, per_page=1, page_nbr=1)
-                        if len(git_log) == 0:
+                        try:
+                            git_log = get_module_git_log(module, modules_repo=modules_repo, per_page=1, page_nbr=1)
+                        except UserWarning:
                             log.error(f"Was unable to fetch version of module '{module}'")
                             exit_value = False
                             continue

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -119,9 +119,9 @@ class ModuleCommand:
             log.error("Could not remove module: {}".format(e))
             return False
 
-    def download_module_file(self, module_name, module_version, install_folder, module_dir):
+    def download_module_file(self, module_name, module_version, modules_repo, install_folder, module_dir):
         """Downloads the files of a module from the remote repo"""
-        files = self.modules_repo.get_module_file_urls(module_name, module_version)
+        files = modules_repo.get_module_file_urls(module_name, module_version)
         log.debug("Fetching module files:\n - {}".format("\n - ".join(files.keys())))
         for filename, api_url in files.items():
             split_filename = filename.split("/")


### PR DESCRIPTION
Added `--all` flag to `nf-core modules update`. When running with the `--all` flag the command  has the same effect as looping `nf-core modules install --force` over all installed modules. For example:
- When `nf-core modules install --all` is run, there is a cli prompt for every module.
- To update all modules to the latest version _without a prompt_: `nf-core modules install --all --latest`
- To change all modules to a specific version _without a prompt_: `nf-core modules install --all --sha <commit sha>`


## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
