### PR TITLE
Fix #1177; modules moved from 'software' to 'modules'

### DIFF
--- a/nf_core/modules/pipeline_modules.py
+++ b/nf_core/modules/pipeline_modules.py
@@ -75,7 +75,7 @@ class ModulesRepo(object):
         self.modules_current_hash = result["sha"]
         self.modules_file_tree = result["tree"]
         for f in result["tree"]:
-            if f["path"].startswith("software/") and f["path"].endswith("/main.nf") and "/test/" not in f["path"]:
+            if f["path"].startswith("modules/") and f["path"].endswith("/main.nf") and "/test/" not in f["path"]:
                 # remove software/ and /main.nf
                 self.modules_avail_module_names.append(f["path"][9:-8])
 


### PR DESCRIPTION
[nf-core/modules](https://github.com/nf-core/modules/) directory structure was recently reorganized in commit [e937c7950af70930d1f34bb961403d9d2aa81c7d](https://github.com/nf-core/modules/commit/e937c7950af70930d1f34bb961403d9d2aa81c7d)

This PR updates the modules location from `software` to `modules` (#1177).

Please let me know if this PR should be for a merge into dev branch instead.

## PR checklist

 - [X] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
