### PR TITLE
Add subcommands to `nf-core modules list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * Restructured code and removed old table style in `nf-core modules list`
 * Fixed bug causing `modules.json` creation to loop indefinitly
 * Added `--all` flag to `nf-core modules install`
+* Added `remote` and `local` subcommands to `nf-core modules list`
 
 #### Sync
 

--- a/nf_core/modules/list.py
+++ b/nf_core/modules/list.py
@@ -11,8 +11,9 @@ log = logging.getLogger(__name__)
 
 
 class ModuleList(ModuleCommand):
-    def __init__(self, pipeline_dir):
+    def __init__(self, pipeline_dir, remote=True):
         super().__init__(pipeline_dir)
+        self.remote = remote
 
     def list_modules(self, keywords=None, print_json=False):
         """
@@ -38,7 +39,7 @@ class ModuleList(ModuleCommand):
                 return f" matching patterns {', '.join(quoted_keywords)}"
 
         # No pipeline given - show all remote
-        if self.dir is None:
+        if self.remote:
             log.info(
                 f"Modules available from {self.modules_repo.name} ({self.modules_repo.branch})"
                 f"{pattern_msg(keywords)}:\n"
@@ -86,7 +87,6 @@ class ModuleList(ModuleCommand):
                 repo_name: [mod for mod in self.module_names[repo_name] if all(k in mod for k in keywords)]
                 for repo_name in self.module_names
             }
-
             # Nothing found
             if sum(map(len, repos_with_mods)) == 0:
                 log.info(f"No nf-core modules found in '{self.dir}'{pattern_msg(keywords)}")
@@ -100,7 +100,7 @@ class ModuleList(ModuleCommand):
             # Load 'modules.json'
             modules_json = self.load_modules_json()
 
-            for repo_name, modules in sorted(self.module_names.items(), key=lambda x: x[0]):
+            for repo_name, modules in sorted(repos_with_mods.items(), key=lambda x: x[0]):
                 repo_entry = modules_json["repos"].get(repo_name, {})
                 for module in sorted(modules):
                     module_entry = repo_entry.get(module)

--- a/nf_core/modules/list.py
+++ b/nf_core/modules/list.py
@@ -52,10 +52,8 @@ class ModuleList(ModuleCommand):
                 log.error(e)
                 return False
 
-            modules = self.modules_repo.modules_avail_module_names
-
             # Filter the modules by keywords
-            modules = [mod for mod in modules if all(k in mod for k in keywords)]
+            modules = [mod for mod in self.modules_repo.modules_avail_module_names if all(k in mod for k in keywords)]
 
             # Nothing found
             if len(modules) == 0:
@@ -87,6 +85,7 @@ class ModuleList(ModuleCommand):
                 repo_name: [mod for mod in self.module_names[repo_name] if all(k in mod for k in keywords)]
                 for repo_name in self.module_names
             }
+
             # Nothing found
             if sum(map(len, repos_with_mods)) == 0:
                 log.info(f"No nf-core modules found in '{self.dir}'{pattern_msg(keywords)}")
@@ -100,7 +99,7 @@ class ModuleList(ModuleCommand):
             # Load 'modules.json'
             modules_json = self.load_modules_json()
 
-            for repo_name, modules in sorted(repos_with_mods.items(), key=lambda x: x[0]):
+            for repo_name, modules in sorted(repos_with_mods.items()):
                 repo_entry = modules_json["repos"].get(repo_name, {})
                 for module in sorted(modules):
                     module_entry = repo_entry.get(module)

--- a/tests/modules/list.py
+++ b/tests/modules/list.py
@@ -4,7 +4,7 @@ from rich.console import Console
 
 def test_modules_list_remote(self):
     """Test listing available modules"""
-    mods_list = nf_core.modules.ModuleList(None)
+    mods_list = nf_core.modules.ModuleList(None, remote=True)
     listed_mods = mods_list.list_modules()
     console = Console(record=True)
     console.print(listed_mods)
@@ -14,7 +14,7 @@ def test_modules_list_remote(self):
 
 def test_modules_list_pipeline(self):
     """Test listing locally installed modules"""
-    mods_list = nf_core.modules.ModuleList(self.pipeline_dir)
+    mods_list = nf_core.modules.ModuleList(self.pipeline_dir, remote=False)
     listed_mods = mods_list.list_modules()
     console = Console(record=True)
     console.print(listed_mods)
@@ -26,7 +26,7 @@ def test_modules_list_pipeline(self):
 def test_modules_install_and_list_pipeline(self):
     """Test listing locally installed modules"""
     self.mods_install.install("trimgalore")
-    mods_list = nf_core.modules.ModuleList(self.pipeline_dir)
+    mods_list = nf_core.modules.ModuleList(self.pipeline_dir, remote=False)
     listed_mods = mods_list.list_modules()
     console = Console(record=True)
     console.print(listed_mods)


### PR DESCRIPTION
Added `remote` and `local` subcommands to `nf-core modules list` for listing modules available from the `nf-core/modules` repository and modules installed in the current pipeline respectively. 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
