### PR TITLE
update fastqc module in template to latest version

### DIFF
--- a/nf_core/pipeline-template/modules/nf-core/modules/fastqc/main.nf
+++ b/nf_core/pipeline-template/modules/nf-core/modules/fastqc/main.nf
@@ -29,7 +29,7 @@ process FASTQC {
     script:
     // Add soft-links to original FastQs for consistent naming in pipeline
     def software = getSoftwareName(task.process)
-    def prefix   = options.suffix ? "${meta.id}.${options.suffix}" : "${meta.id}"
+    def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     if (meta.single_end) {
         """
         [ ! -f  ${prefix}.fastq.gz ] && ln -s $reads ${prefix}.fastq.gz


### PR DESCRIPTION
Just bring the fastqc module to the latest version so there are less linting warnings with a fresh template

