### PR TITLE
Fix bug in module template due to restructuring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * Fixed bug causing `modules.json` creation to loop indefinitly
 * Added `--all` flag to `nf-core modules install`
 * Added `remote` and `local` subcommands to `nf-core modules list`
+* Fix bug due to restructuring in modules template
 
 #### Sync
 

--- a/nf_core/module-template/tests/main.nf
+++ b/nf_core/module-template/tests/main.nf
@@ -2,7 +2,7 @@
 
 nextflow.enable.dsl = 2
 
-include { {{ tool_name_underscore|upper }} } from '../../../{{ "../" if subtool else "" }}software/{{ tool_dir }}/main.nf' addParams( options: [:] )
+include { {{ tool_name_underscore|upper }} } from '../../../{{ "../" if subtool else "" }}modules/{{ tool_dir }}/main.nf' addParams( options: [:] )
 
 workflow test_{{ tool_name_underscore }} {
     {% if has_meta %}

--- a/nf_core/module-template/tests/test.yml
+++ b/nf_core/module-template/tests/test.yml
@@ -1,7 +1,7 @@
 ## TODO nf-core: Please run the following command to build this file:
 #                nf-core modules create-test-yml {{ tool }}{%- if subtool %}/{{ subtool }}{%- endif %}
 - name: {{ tool }}{{ ' '+subtool if subtool else '' }}
-  command: nextflow run ./tests/software/{{ tool_dir }} -entry test_{{ tool_name_underscore }} -c tests/config/nextflow.config
+  command: nextflow run ./tests/modules/{{ tool_dir }} -entry test_{{ tool_name_underscore }} -c tests/config/nextflow.config
   tags:
     - {{ tool }}
     {%- if subtool %}


### PR DESCRIPTION
The `tests` directory in the module template was not updated after the restructuring of `nf-core/modules`. This should fix the issue. 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
