### PR TITLE
Added additional checks for module remote repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Please use a `v1.x` pipeline of `tools` for such pipeline or, better yet, make t
 * Added `remote` and `local` subcommands to `nf-core modules list`
 * Fix bug due to restructuring in modules template
 * Added checks for verifying that the remote repository is well formed
+* Added checks to `ModulesCommand` for verifying validity of remote repositories
 
 #### Sync
 

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -33,6 +33,12 @@ class ModuleCommand:
         except LookupError as e:
             raise UserWarning(e)
 
+        if self.repo_type == "pipeline":
+            try:
+                nf_core.modules.module_utils.verify_pipeline_dir(self.dir)
+            except UserWarning:
+                raise
+
     def get_pipeline_modules(self):
         """
         Get the modules installed in the current directory.


### PR DESCRIPTION
`nf-core modules list local` (and probably other commands as well)  were failing on pipelines with the older directory structure. This should fix the issue, by checking that the remote modules directories in the pipeline have a valid GitHub repository before doing anything else. 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
