### PR TITLE
Add --dir parameter to pipeline template linting CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Template
 
+* Add `--dir` declaration to `nf-core lint` Actions CI in `linting.yml`
+
 ### General
 
 Nothing yet

--- a/nf_core/pipeline-template/.github/workflows/linting.yml
+++ b/nf_core/pipeline-template/.github/workflows/linting.yml
@@ -127,7 +127,7 @@ jobs:
           GITHUB_COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_COMMIT: ${{ github.event.pull_request.head.sha }}
-        run: nf-core -l lint_log.txt lint ${GITHUB_WORKSPACE} --markdown lint_results.md
+        run: nf-core -l lint_log.txt lint --dir ${GITHUB_WORKSPACE} --markdown lint_results.md
 
       - name: Save PR number
         if: ${{ always() }}


### PR DESCRIPTION
`nf-core lint` is failing for all pipelines because we missed a `--dir` declaration in the `linting.yml` Github Actions used by pipelines.