### PR TITLE
Add consistency checks between installed modules and `modules.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Modules
 
+* Added consistency checks between installed modules and `modules.json` ([#1199](https://github.com/nf-core/tools/issues/1199))
+
 ## [v2.0.1 - Palladium Platypus Junior](https://github.com/nf-core/tools/releases/tag/2.0.1) - [2021-07-13]
 
 ### Template

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -25,6 +25,10 @@ class ModuleInstall(ModuleCommand):
             return False
         # Check whether pipelines is valid
         self.has_valid_directory()
+
+        # Verify that 'modules.json' is consistent with the installed modules
+        self.modules_json_up_to_date()
+
         if not self.update_all:
             # Get the available modules
             try:

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -24,7 +24,8 @@ class ModuleInstall(ModuleCommand):
             log.error("You cannot install a module in a clone of nf-core/modules")
             return False
         # Check whether pipelines is valid
-        self.has_valid_directory()
+        if not self.has_valid_directory():
+            return False
 
         # Verify that 'modules.json' is consistent with the installed modules
         self.modules_json_up_to_date()

--- a/nf_core/modules/list.py
+++ b/nf_core/modules/list.py
@@ -40,10 +40,6 @@ class ModuleList(ModuleCommand):
 
         # No pipeline given - show all remote
         if self.remote:
-            log.info(
-                f"Modules available from {self.modules_repo.name} ({self.modules_repo.branch})"
-                f"{pattern_msg(keywords)}:\n"
-            )
 
             # Get the list of available modules
             try:
@@ -68,14 +64,15 @@ class ModuleList(ModuleCommand):
 
         # We have a pipeline - list what's installed
         else:
-            log.info(f"Modules installed in '{self.dir}'{pattern_msg(keywords)}:\n")
-
             # Check whether pipelines is valid
             try:
                 self.has_valid_directory()
             except UserWarning as e:
                 log.error(e)
                 return ""
+
+            # Verify that 'modules.json' is consistent with the installed modules
+            self.modules_json_up_to_date()
 
             # Get installed modules
             self.get_pipeline_modules()
@@ -120,4 +117,12 @@ class ModuleList(ModuleCommand):
 
         if print_json:
             return json.dumps(modules, sort_keys=True, indent=4)
+
+        if self.remote:
+            log.info(
+                f"Modules available from {self.modules_repo.name} ({self.modules_repo.branch})"
+                f"{pattern_msg(keywords)}:\n"
+            )
+        else:
+            log.info(f"Modules installed in '{self.dir}'{pattern_msg(keywords)}:\n")
         return table

--- a/nf_core/modules/module_utils.py
+++ b/nf_core/modules/module_utils.py
@@ -154,7 +154,7 @@ def create_modules_json(pipeline_dir):
         file_progress = progress_bar.add_task(
             "Creating 'modules.json' file", total=sum(map(len, repo_module_names.values())), test_name="module.json"
         )
-        for repo_name, module_names in repo_module_names.items():
+        for repo_name, module_names in sorted(repo_module_names.items()):
             try:
                 modules_repo = ModulesRepo(repo=repo_name)
             except LookupError as e:
@@ -162,7 +162,7 @@ def create_modules_json(pipeline_dir):
 
             repo_path = os.path.join(modules_dir, repo_name)
             modules_json["repos"][repo_name] = dict()
-            for module_name in module_names:
+            for module_name in sorted(module_names):
                 module_path = os.path.join(repo_path, module_name)
                 progress_bar.update(file_progress, advance=1, test_name=f"{repo_name}/{module_name}")
                 try:
@@ -197,7 +197,6 @@ def find_correct_commit_sha(module_name, module_path, modules_repo):
         correct_commit_sha = None
         commit_page_nbr = 1
         while correct_commit_sha is None:
-
             commit_shas = [
                 commit["git_sha"]
                 for commit in get_module_git_log(module_name, modules_repo=modules_repo, page_nbr=commit_page_nbr)

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -9,6 +9,7 @@ import logging
 import yaml
 
 import nf_core.modules.module_utils
+import nf_core.utils
 from nf_core.modules.modules_repo import ModulesRepo
 
 log = logging.getLogger(__name__)
@@ -285,6 +286,9 @@ class ModuleCommand:
 
     def dump_modules_json(self, modules_json):
         modules_json_path = os.path.join(self.dir, "modules.json")
+        # Sort the 'modules.json' repo entries
+        modules_json["repos"] = nf_core.utils.sort_dictionary(modules_json["repos"])
+
         with open(modules_json_path, "w") as fh:
             json.dump(modules_json, fh, indent=4)
 

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -113,7 +113,7 @@ class ModuleCommand:
         Checks whether the modules installed in the directory
         are consistent with the entries in the 'modules.json' file and vice versa.
 
-        If a module has an entry in the 'modules.json' file but is missing the in the directory,
+        If a module has an entry in the 'modules.json' file but is missing in the directory,
         we first try to reinstall the module from the remote and if that fails we remove the entry
         in 'modules.json'.
 

--- a/nf_core/modules/modules_repo.py
+++ b/nf_core/modules/modules_repo.py
@@ -121,7 +121,7 @@ class ModulesRepo(object):
             results[f["path"]] = f["url"]
         if commit != "":
             for path in results:
-                results[path] = f"https://api.github.com/repos/nf-core/modules/contents/{path}?ref={commit}"
+                results[path] = f"https://api.github.com/repos/{self.name}/contents/{path}?ref={commit}"
         return results
 
     def download_gh_file(self, dl_filename, api_url):

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -773,3 +773,14 @@ def load_tools_config(dir="."):
         return {}
 
     return tools_config
+
+
+def sort_dictionary(d):
+    """Sorts a nested dictionary recursively"""
+    result = dict()
+    for k, v in sorted(d.items()):
+        if isinstance(v, dict):
+            result[k] = sort_dictionary(v)
+        else:
+            result[k] = v
+    return result


### PR DESCRIPTION
Added consistency checks between modules present in pipeline and `modules.json`:
- If a module is missing from the directory but is present in the `modules.json` file we try to reinstall it at the given commit SHA
- If the install fails, we remove the entry in `modules.json`
- If a module is present in the directory, but missing from `modules.json` we try figure out the correct one using the file contents. If that fails, we continue but warn the user. 

These checks are run when either `nf-core modules install` or `nf-core modules list local` are run. Should resolve #1199. 
## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
