### PR TITLE
Add `nf-core modules update`

### DIFF
--- a/.github/workflows/create-lint-wf.yml
+++ b/.github/workflows/create-lint-wf.yml
@@ -53,7 +53,7 @@ jobs:
         run: nf-core --log-file log.txt lint --dir nf-core-testpipeline --fail-ignored --release
 
       - name: nf-core modules install
-        run: nf-core --log-file log.txt modules install fastqc --dir nf-core-testpipeline/ --force --latest
+        run: nf-core --log-file log.txt modules install fastqc --dir nf-core-testpipeline/ --force
 
       - name: Upload log file artifact
         if: ${{ always() }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Modules
 
 * Added consistency checks between installed modules and `modules.json` ([#1199](https://github.com/nf-core/tools/issues/1199))
+* Created `nf-core modules update` and removed updating options from `nf-core modules install`
 
 ## [v2.0.1 - Palladium Platypus Junior](https://github.com/nf-core/tools/releases/tag/2.0.1) - [2021-07-13]
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ A python package with helper tools for the nf-core community.
     * [`modules list` - List available modules](#list-modules)
         * [`modules list remote` - List remote modules](#list-remote-modules)
         * [`modules list local` - List installed modules](#list-installed-modules)
-    * [`modules install` - Install or update modules in pipeline](#install-or-update-modules-in-a-pipeline)
+    * [`modules install` - Install modules in pipeline](#install-modules-in-a-pipeline)
+    * [`modules update` - Update modules in pipeline](#update-modules-in-a-pipeline)
     * [`modules remove` - Remove a module from a pipeline](#remove-a-module-from-a-pipeline)
     * [`modules create` - Create a module from the template](#create-a-new-module)
     * [`modules create-test-yml` - Create the `test.yml` file for a module](#create-a-module-test-config-file)
@@ -962,7 +963,7 @@ INFO     Modules installed in '.':
 └─────────────┴─────────────────┴─────────────┴────────────────────────────────────────────────────────┴────────────┘
 ```
 
-### Install or update modules in a pipeline
+### Install modules in a pipeline
 
 You can install modules from [nf-core/modules](https://github.com/nf-core/modules) in your pipeline using `nf-core modules install`.
 A module installed this way will be installed to the `./modules/nf-core/modules` directory.
@@ -978,9 +979,36 @@ $ nf-core modules install
     nf-core/tools version 2.0
 
 ? Tool name: cat/fastq
-? Select 'cat/fastq' version: Rename software/ directory to modules/ to re-organise module structure ...truncated...
 INFO     Installing cat/fastq
 INFO     Downloaded 3 files to ./modules/nf-core/modules/cat/fastq
+```
+
+You can pass the module name as an optional argument to `nf-core modules install` instead of using the cli prompt, eg: `nf-core modules install fastqc`.
+
+There are four flags that you can use with this command:
+
+* `--dir <pipeline_dir>`: Specify a pipeline directory other than the current working directory.
+* `--prompt`: Select the module version using a cli prompt.
+* `--force`: Overwrite a previously installed version of the module.
+* `--sha <commit_sha>`: Install the module at a specific commit from the `nf-core/modules` repository.
+
+### Update modules in a pipeline
+
+You can update modules installed from a remote repository in your pipeline using `nf-core modules update`.
+
+```console
+$ nf-core modules update
+                                          ,--./,-.
+          ___     __   __   __   ___     /,-._.--~\
+    |\ | |__  __ /  ` /  \ |__) |__         }  {
+    | \| |       \__, \__/ |  \ |___     \`-._,-`-,
+                                          `._,._,'
+
+    nf-core/tools version 2.0
+
+? Tool name: fastqc
+INFO     Updating 'nf-core/modules/fastqc'
+INFO     Downloaded 3 files to ./modules/nf-core/modules/fastqc
 ```
 
 You can pass the module name as an optional argument to `nf-core modules install` instead of using the cli prompt, eg: `nf-core modules install fastqc`.
@@ -988,10 +1016,10 @@ You can pass the module name as an optional argument to `nf-core modules install
 There are five flags that you can use with this command:
 
 * `--dir <pipeline_dir>`: Specify a pipeline directory other than the current working directory.
-* `--latest`: Install the latest version of the module instead of specifying the version using the cli prompt.
-* `--force`: Overwrite a previously installed version of the module.
+* `--force`: Reinstall module even if it appears to be up to date
+* `--prompt`: Select the module version using a cli prompt.
 * `--sha <commit_sha>`: Install the module at a specific commit from the `nf-core/modules` repository.
-* `--all`: Use this flag to change versions on all installed modules. Has the same effect as running `nf-core modules install --force --latest` on all installed modules. To change all modules to a specific version you can run `nf-core modules install --all --sha <commit sha>`.
+* `--all`: Use this flag to run the command on all modules in the pipeline.
 
 ### Remove a module from a pipeline
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -421,18 +421,17 @@ def local(ctx, keywords, json, dir):
 @click.pass_context
 @click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
 @click.option("-d", "--dir", type=click.Path(exists=True), default=".", help="Pipeline directory. Defaults to CWD")
-@click.option("-l", "--latest", is_flag=True, default=False, help="Install the latest version of the module")
+@click.option("-p", "--prompt", is_flag=True, default=False, help="Prompt for the version of the module")
 @click.option("-f", "--force", is_flag=True, default=False, help="Force installation of module if it already exists")
 @click.option("-s", "--sha", type=str, metavar="<commit sha>", help="Install module at commit SHA")
-@click.option("-a", "--all", is_flag=True, default=False, help="Update all modules installed in pipeline")
-def install(ctx, tool, dir, latest, force, sha, all):
+def install(ctx, tool, dir, prompt, force, sha):
     """
     Install/update DSL2 modules within a pipeline.
 
     Fetches and installs module files from a remote repo e.g. nf-core/modules.
     """
     try:
-        module_install = nf_core.modules.ModuleInstall(dir, force=force, latest=latest, sha=sha, update_all=all)
+        module_install = nf_core.modules.ModuleInstall(dir, force=force, prompt=prompt, sha=sha)
         module_install.modules_repo = ctx.obj["modules_repo_obj"]
         exit_status = module_install.install(tool)
         if not exit_status and all:
@@ -443,6 +442,31 @@ def install(ctx, tool, dir, latest, force, sha, all):
 
 
 @modules.command(help_priority=3)
+@click.pass_context
+@click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
+@click.option("-d", "--dir", type=click.Path(exists=True), default=".", help="Pipeline directory. Defaults to CWD")
+@click.option("-f", "--force", is_flag=True, default=False, help="Force update of module even if it already up to date")
+@click.option("-p", "--prompt", is_flag=True, default=False, help="Prompt for the version of the module")
+@click.option("-s", "--sha", type=str, metavar="<commit sha>", help="Install module at commit SHA")
+@click.option("-a", "--all", is_flag=True, default=False, help="Update all modules installed in pipeline")
+def update(ctx, tool, dir, force, prompt, sha, all):
+    """
+    Install/update DSL2 modules within a pipeline.
+
+    Fetches and installs module files from a remote repo e.g. nf-core/modules.
+    """
+    try:
+        module_install = nf_core.modules.ModuleUpdate(dir, force=force, prompt=prompt, sha=sha, update_all=all)
+        module_install.modules_repo = ctx.obj["modules_repo_obj"]
+        exit_status = module_install.update(tool)
+        if not exit_status and all:
+            sys.exit(1)
+    except UserWarning as e:
+        log.error(e)
+        sys.exit(1)
+
+
+@modules.command(help_priority=4)
 @click.pass_context
 @click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
 @click.option("-d", "--dir", type=click.Path(exists=True), default=".", help="Pipeline directory. Defaults to CWD")
@@ -459,7 +483,7 @@ def remove(ctx, dir, tool):
         sys.exit(1)
 
 
-@modules.command("create", help_priority=4)
+@modules.command("create", help_priority=5)
 @click.pass_context
 @click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
 @click.option("-d", "--dir", type=click.Path(exists=True), default=".", metavar="<directory>")
@@ -497,7 +521,7 @@ def create_module(ctx, tool, dir, author, label, meta, no_meta, force, conda_nam
         sys.exit(1)
 
 
-@modules.command("create-test-yml", help_priority=5)
+@modules.command("create-test-yml", help_priority=6)
 @click.pass_context
 @click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
 @click.option("-r", "--run-tests", is_flag=True, default=False, help="Run the test workflows")
@@ -519,7 +543,7 @@ def create_test_yml(ctx, tool, run_tests, output, force, no_prompts):
         sys.exit(1)
 
 
-@modules.command(help_priority=6)
+@modules.command(help_priority=7)
 @click.pass_context
 @click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
 @click.option("-d", "--dir", type=click.Path(exists=True), default=".", metavar="<pipeline/modules directory>")
@@ -551,7 +575,7 @@ def lint(ctx, tool, dir, key, all, local, passed):
         sys.exit(1)
 
 
-@modules.command(help_priority=7)
+@modules.command(help_priority=8)
 @click.pass_context
 @click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
 @click.option("-d", "--dir", type=click.Path(exists=True), default=".", metavar="<nf-core/modules directory>")

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -422,11 +422,11 @@ def local(ctx, keywords, json, dir):
 @click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
 @click.option("-d", "--dir", type=click.Path(exists=True), default=".", help="Pipeline directory. Defaults to CWD")
 @click.option("-p", "--prompt", is_flag=True, default=False, help="Prompt for the version of the module")
-@click.option("-f", "--force", is_flag=True, default=False, help="Force installation of module if it already exists")
+@click.option("-f", "--force", is_flag=True, default=False, help="Force reinstallation of module if it already exists")
 @click.option("-s", "--sha", type=str, metavar="<commit sha>", help="Install module at commit SHA")
 def install(ctx, tool, dir, prompt, force, sha):
     """
-    Install/update DSL2 modules within a pipeline.
+    Install DSL2 modules within a pipeline.
 
     Fetches and installs module files from a remote repo e.g. nf-core/modules.
     """
@@ -445,15 +445,15 @@ def install(ctx, tool, dir, prompt, force, sha):
 @click.pass_context
 @click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
 @click.option("-d", "--dir", type=click.Path(exists=True), default=".", help="Pipeline directory. Defaults to CWD")
-@click.option("-f", "--force", is_flag=True, default=False, help="Force update of module even if it already up to date")
+@click.option("-f", "--force", is_flag=True, default=False, help="Force update of module")
 @click.option("-p", "--prompt", is_flag=True, default=False, help="Prompt for the version of the module")
 @click.option("-s", "--sha", type=str, metavar="<commit sha>", help="Install module at commit SHA")
 @click.option("-a", "--all", is_flag=True, default=False, help="Update all modules installed in pipeline")
 def update(ctx, tool, dir, force, prompt, sha, all):
     """
-    Install/update DSL2 modules within a pipeline.
+    Update DSL2 modules within a pipeline.
 
-    Fetches and installs module files from a remote repo e.g. nf-core/modules.
+    Fetches and updates module files from a remote repo e.g. nf-core/modules.
     """
     try:
         module_install = nf_core.modules.ModuleUpdate(dir, force=force, prompt=prompt, sha=sha, update_all=all)

--- a/nf_core/modules/__init__.py
+++ b/nf_core/modules/__init__.py
@@ -6,4 +6,5 @@ from .bump_versions import ModuleVersionBumper
 from .module_utils import ModuleException
 from .list import ModuleList
 from .install import ModuleInstall
+from .update import ModuleUpdate
 from .remove import ModuleRemove

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -3,6 +3,7 @@ import questionary
 import logging
 
 import nf_core.utils
+import nf_core.modules.module_utils
 
 from .modules_command import ModuleCommand
 from .module_utils import get_installed_modules, get_module_git_log, module_exist_in_repo
@@ -12,10 +13,10 @@ log = logging.getLogger(__name__)
 
 
 class ModuleInstall(ModuleCommand):
-    def __init__(self, pipeline_dir, force=False, latest=False, sha=None, update_all=False):
+    def __init__(self, pipeline_dir, force=False, prompt=False, sha=None, update_all=False):
         super().__init__(pipeline_dir)
         self.force = force
-        self.latest = latest
+        self.prompt = prompt
         self.sha = sha
         self.update_all = update_all
 
@@ -30,44 +31,30 @@ class ModuleInstall(ModuleCommand):
         # Verify that 'modules.json' is consistent with the installed modules
         self.modules_json_up_to_date()
 
-        if not self.update_all:
-            # Get the available modules
-            try:
-                self.modules_repo.get_modules_file_tree()
-            except LookupError as e:
-                log.error(e)
-                return False
+        # Get the available modules
+        try:
+            self.modules_repo.get_modules_file_tree()
+        except LookupError as e:
+            log.error(e)
+            return False
 
-            if self.latest and self.sha is not None:
-                log.error("Cannot use '--sha' and '--latest' at the same time!")
-                return False
+        if self.prompt and self.sha is not None:
+            log.error("Cannot use '--sha' and '--prompt' at the same time!")
+            return False
 
-            if module is None:
-                module = questionary.autocomplete(
-                    "Tool name:",
-                    choices=self.modules_repo.modules_avail_module_names,
-                    style=nf_core.utils.nfcore_question_style,
-                ).unsafe_ask()
+        if module is None:
+            module = questionary.autocomplete(
+                "Tool name:",
+                choices=self.modules_repo.modules_avail_module_names,
+                style=nf_core.utils.nfcore_question_style,
+            ).unsafe_ask()
 
-            # Check that the supplied name is an available module
-            if module and module not in self.modules_repo.modules_avail_module_names:
-                log.error("Module '{}' not found in list of available modules.".format(module))
-                log.info("Use the command 'nf-core modules list' to view available software")
-                return False
-            repos_and_modules = [(self.modules_repo, module)]
-        else:
-            if module:
-                raise UserWarning("You cannot specify a module and use the '--all' flag at the same time")
-            self.force = True
-
-            self.get_pipeline_modules()
-            repos_and_modules = [
-                (ModulesRepo(repo=repo_name), modules) for repo_name, modules in self.module_names.items()
-            ]
-            # Load the modules file trees
-            for repo, _ in repos_and_modules:
-                repo.get_modules_file_tree()
-            repos_and_modules = [(repo, module) for repo, modules in repos_and_modules for module in modules]
+        # Check that the supplied name is an available module
+        if module and module not in self.modules_repo.modules_avail_module_names:
+            log.error("Module '{}' not found in list of available modules.".format(module))
+            log.info("Use the command 'nf-core modules list' to view available software")
+            return False
+        repos_and_modules = [(self.modules_repo, module)]
 
         # Load 'modules.json'
         modules_json = self.load_modules_json()
@@ -78,8 +65,6 @@ class ModuleInstall(ModuleCommand):
         for modules_repo, module in repos_and_modules:
             if not module_exist_in_repo(module, modules_repo):
                 warn_msg = f"Module '{module}' not found in remote '{modules_repo.name}' ({modules_repo.branch})"
-                if self.update_all:
-                    warn_msg += ". Skipping..."
                 log.warning(warn_msg)
                 exit_value = False
                 continue
@@ -95,81 +80,41 @@ class ModuleInstall(ModuleCommand):
             # Compute the module directory
             module_dir = os.path.join(self.dir, "modules", *install_folder, module)
 
-            if current_entry is not None and self.sha is None:
-                # Fetch the latest commit for the module
-                current_version = current_entry["git_sha"]
-                try:
-                    git_log = get_module_git_log(module, modules_repo=modules_repo, per_page=1, page_nbr=1)
-                except LookupError as e:
-                    log.error(e)
-                    exit_value = False
-                    continue
-                except UserWarning:
-                    log.error(f"Was unable to fetch version of '{modules_repo.name}/{module}'")
-                    exit_value = False
-                    continue
-                latest_version = git_log[0]["git_sha"]
-                if current_version == latest_version and (not self.force or self.latest or self.update_all):
-                    log.info(f"'{modules_repo.name}/{module}' is already up to date")
-                    continue
-                elif not self.force:
-                    log.error("Found newer version of module.")
-                    self.latest = self.force = questionary.confirm(
-                        "Do you want to install it? (--force --latest)", default=False
-                    ).unsafe_ask()
-                    if not self.latest:
-                        exit_value = False
-                        continue
-            else:
-                latest_version = None
-
-            # Check that we don't already have a folder for this module
-            if not self.check_module_files_installed(module, module_dir):
+            # Check that the module is not already installed
+            if (current_entry is not None and not self.force) or not self.check_module_files_installed(
+                module, module_dir
+            ):
+                log.error(f"Module is already installed.")
+                log.info(
+                    f"To update '{module}' run 'nf-core modules update {module}'. To force reinstallation use '--force'"
+                )
                 exit_value = False
                 continue
 
             if self.sha:
-                if current_entry is not None:
-                    if self.force:
-                        if current_entry["git_sha"] == self.sha:
-                            log.info(f"Module {modules_repo.name}/{module} already installed at {self.sha}")
-                            continue
-                    else:
-                        exit_value = False
-                        continue
-
-                if self.force:
-                    log.info(f"Removing old version of module '{module}'")
-                    self.clear_module_dir(module, module_dir)
-
-                if self.download_module_file(module, self.sha, modules_repo, install_folder, module_dir):
-                    self.update_modules_json(modules_json, modules_repo.name, module, self.sha)
-                else:
+                version = self.sha
+            elif self.prompt:
+                try:
+                    version = nf_core.modules.module_utils.prompt_module_version_sha(
+                        module,
+                        installed_sha=current_entry["git_sha"] if not current_entry is None else None,
+                        modules_repo=modules_repo,
+                    )
+                except SystemError as e:
+                    log.error(e)
                     exit_value = False
-                continue
+                    continue
             else:
-                if self.latest or self.update_all:
-                    # Fetch the latest commit for the module
-                    if latest_version is None:
-                        try:
-                            git_log = get_module_git_log(module, modules_repo=modules_repo, per_page=1, page_nbr=1)
-                        except UserWarning:
-                            log.error(f"Was unable to fetch version of module '{module}'")
-                            exit_value = False
-                            continue
-                        latest_version = git_log[0]["git_sha"]
-                    version = latest_version
-                else:
-                    try:
-                        version = self.prompt_module_version_sha(
-                            module,
-                            installed_sha=current_entry["git_sha"] if not current_entry is None else None,
-                            modules_repo=modules_repo,
-                        )
-                    except SystemError as e:
-                        log.error(e)
-                        exit_value = False
-                        continue
+                # Fetch the latest commit for the module
+                try:
+                    git_log = get_module_git_log(module, modules_repo=modules_repo, per_page=1, page_nbr=1)
+                except UserWarning:
+                    log.error(f"Was unable to fetch version of module '{module}'")
+                    exit_value = False
+                    continue
+                latest_version = git_log[0]["git_sha"]
+                version = latest_version
+
             log.info(f"Installing {module}")
             log.debug(
                 f"Installing module '{module}' at modules hash {modules_repo.modules_current_hash} from {self.modules_repo.name}"
@@ -199,48 +144,3 @@ class ModuleInstall(ModuleCommand):
             return self.force
         else:
             return True
-
-    def prompt_module_version_sha(self, module, installed_sha=None, modules_repo=None):
-        if modules_repo is None:
-            modules_repo = self.modules_repo
-        older_commits_choice = questionary.Choice(
-            title=[("fg:ansiyellow", "older commits"), ("class:choice-default", "")], value=""
-        )
-        git_sha = ""
-        page_nbr = 1
-        try:
-            next_page_commits = get_module_git_log(module, modules_repo=modules_repo, per_page=10, page_nbr=page_nbr)
-        except UserWarning:
-            next_page_commits = None
-        except LookupError as e:
-            log.warning(e)
-            next_page_commits = None
-
-        while git_sha is "":
-            commits = next_page_commits
-            try:
-                next_page_commits = get_module_git_log(
-                    module, modules_repo=modules_repo, per_page=10, page_nbr=page_nbr + 1
-                )
-            except UserWarning:
-                next_page_commits = None
-            except LookupError as e:
-                log.warning(e)
-                next_page_commits = None
-
-            choices = []
-            for title, sha in map(lambda commit: (commit["trunc_message"], commit["git_sha"]), commits):
-
-                display_color = "fg:ansiblue" if sha != installed_sha else "fg:ansired"
-                message = f"{title} {sha}"
-                if installed_sha == sha:
-                    message += " (installed version)"
-                commit_display = [(display_color, message), ("class:choice-default", "")]
-                choices.append(questionary.Choice(title=commit_display, value=sha))
-            if next_page_commits is not None:
-                choices += [older_commits_choice]
-            git_sha = questionary.select(
-                f"Select '{module}' version:", choices=choices, style=nf_core.utils.nfcore_question_style
-            ).unsafe_ask()
-            page_nbr += 1
-        return git_sha

--- a/nf_core/modules/module_utils.py
+++ b/nf_core/modules/module_utils.py
@@ -5,6 +5,7 @@ import requests
 import logging
 import rich
 import datetime
+import questionary
 
 
 import nf_core.utils
@@ -376,3 +377,47 @@ def verify_pipeline_dir(dir):
                 )
                 error_msg += "\nThe 'nf-core/software' directory should therefore be renamed to 'nf-core/modules'"
             raise UserWarning(error_msg)
+
+
+def prompt_module_version_sha(module, modules_repo, installed_sha=None):
+    older_commits_choice = questionary.Choice(
+        title=[("fg:ansiyellow", "older commits"), ("class:choice-default", "")], value=""
+    )
+    git_sha = ""
+    page_nbr = 1
+    try:
+        next_page_commits = get_module_git_log(module, modules_repo=modules_repo, per_page=10, page_nbr=page_nbr)
+    except UserWarning:
+        next_page_commits = None
+    except LookupError as e:
+        log.warning(e)
+        next_page_commits = None
+
+    while git_sha is "":
+        commits = next_page_commits
+        try:
+            next_page_commits = get_module_git_log(
+                module, modules_repo=modules_repo, per_page=10, page_nbr=page_nbr + 1
+            )
+        except UserWarning:
+            next_page_commits = None
+        except LookupError as e:
+            log.warning(e)
+            next_page_commits = None
+
+        choices = []
+        for title, sha in map(lambda commit: (commit["trunc_message"], commit["git_sha"]), commits):
+
+            display_color = "fg:ansiblue" if sha != installed_sha else "fg:ansired"
+            message = f"{title} {sha}"
+            if installed_sha == sha:
+                message += " (installed version)"
+            commit_display = [(display_color, message), ("class:choice-default", "")]
+            choices.append(questionary.Choice(title=commit_display, value=sha))
+        if next_page_commits is not None:
+            choices += [older_commits_choice]
+        git_sha = questionary.select(
+            f"Select '{module}' version:", choices=choices, style=nf_core.utils.nfcore_question_style
+        ).unsafe_ask()
+        page_nbr += 1
+    return git_sha

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -68,9 +68,11 @@ class ModuleCommand:
                 repo_path = os.path.join(module_base_path, repo_name)
                 module_mains_path = f"{repo_path}/**/main.nf"
                 module_mains = glob.glob(module_mains_path, recursive=True)
-                self.module_names[repo_name] = [
-                    os.path.dirname(os.path.relpath(mod, repo_path)) for mod in module_mains
-                ]
+                if len(module_mains) > 0:
+                    self.module_names[repo_name] = [
+                        os.path.dirname(os.path.relpath(mod, repo_path)) for mod in module_mains
+                    ]
+
         elif self.repo_type == "modules":
             module_mains_path = f"{module_base_path}/**/main.nf"
             module_mains = glob.glob(module_mains_path, recursive=True)

--- a/nf_core/modules/update.py
+++ b/nf_core/modules/update.py
@@ -1,0 +1,179 @@
+import os
+import questionary
+import logging
+
+import nf_core.utils
+import nf_core.modules.module_utils
+
+from .modules_command import ModuleCommand
+from .module_utils import get_installed_modules, get_module_git_log, module_exist_in_repo
+from .modules_repo import ModulesRepo
+
+log = logging.getLogger(__name__)
+
+
+class ModuleUpdate(ModuleCommand):
+    def __init__(self, pipeline_dir, force=False, prompt=False, sha=None, update_all=False):
+        super().__init__(pipeline_dir)
+        self.force = force
+        self.prompt = prompt
+        self.sha = sha
+        self.update_all = update_all
+
+    def update(self, module):
+        if self.repo_type == "modules":
+            log.error("You cannot update a module in a clone of nf-core/modules")
+            return False
+        # Check whether pipelines is valid
+        if not self.has_valid_directory():
+            return False
+
+        # Verify that 'modules.json' is consistent with the installed modules
+        self.modules_json_up_to_date()
+
+        if not self.update_all:
+            # Get the available modules
+            try:
+                self.modules_repo.get_modules_file_tree()
+            except LookupError as e:
+                log.error(e)
+                return False
+
+            if self.prompt and self.sha is not None:
+                log.error("Cannot use '--sha' and '--prompt' at the same time!")
+                return False
+
+            if module is None:
+                self.get_pipeline_modules()
+                repo_name = self.modules_repo.name
+                if repo_name not in self.module_names:
+                    log.error(f"No modules installed from '{repo_name}'")
+                    return False
+                module = questionary.autocomplete(
+                    "Tool name:",
+                    choices=self.module_names[repo_name],
+                    style=nf_core.utils.nfcore_question_style,
+                ).unsafe_ask()
+
+            # Check that the supplied name is an available module
+            if module and module not in self.modules_repo.modules_avail_module_names:
+                log.error("Module '{}' not found in list of available modules.".format(module))
+                log.info("Use the command 'nf-core modules list remote' to view available software")
+                return False
+
+            repos_and_modules = [(self.modules_repo, module)]
+        else:
+            if module:
+                raise UserWarning("You cannot specify a module and use the '--all' flag at the same time")
+            self.force = True
+
+            self.get_pipeline_modules()
+            repos_and_modules = [
+                (ModulesRepo(repo=repo_name), modules) for repo_name, modules in self.module_names.items()
+            ]
+            # Load the modules file trees
+            for repo, _ in repos_and_modules:
+                repo.get_modules_file_tree()
+            repos_and_modules = [(repo, module) for repo, modules in repos_and_modules for module in modules]
+
+        # Load 'modules.json'
+        modules_json = self.load_modules_json()
+        if not modules_json:
+            return False
+
+        exit_value = True
+        for modules_repo, module in repos_and_modules:
+            if not module_exist_in_repo(module, modules_repo):
+                warn_msg = f"Module '{module}' not found in remote '{modules_repo.name}' ({modules_repo.branch})"
+                if self.update_all:
+                    warn_msg += ". Skipping..."
+                log.warning(warn_msg)
+                exit_value = False
+                continue
+
+            if modules_repo.name in modules_json["repos"]:
+                current_entry = modules_json["repos"][modules_repo.name].get(module)
+            else:
+                current_entry = None
+
+            # Set the install folder based on the repository name
+            install_folder = [modules_repo.owner, modules_repo.repo]
+
+            # Compute the module directory
+            module_dir = os.path.join(self.dir, "modules", *install_folder, module)
+
+            if current_entry is not None and self.sha is None:
+                # Fetch the latest commit for the module
+                current_version = current_entry["git_sha"]
+                try:
+                    git_log = get_module_git_log(module, modules_repo=modules_repo, per_page=1, page_nbr=1)
+                except LookupError as e:
+                    log.error(e)
+                    exit_value = False
+                    continue
+                except UserWarning:
+                    log.error(f"Was unable to fetch version of '{modules_repo.name}/{module}'")
+                    exit_value = False
+                    continue
+                latest_version = git_log[0]["git_sha"]
+                if current_version == latest_version and not self.prompt:
+                    log.info(f"'{modules_repo.name}/{module}' is already up to date")
+                    continue
+            else:
+                latest_version = None
+
+            if self.sha:
+                if current_entry is not None and not self.force:
+                    if current_entry["git_sha"] == self.sha:
+                        log.info(f"Module {modules_repo.name}/{module} already installed at {self.sha}")
+                        continue
+
+                # Remove installed module files
+                log.info(f"Removing old version of module '{module}'")
+                self.clear_module_dir(module, module_dir)
+
+                if self.download_module_file(module, self.sha, modules_repo, install_folder, module_dir):
+                    self.update_modules_json(modules_json, modules_repo.name, module, self.sha)
+                else:
+                    exit_value = False
+                continue
+            else:
+                if not self.prompt:
+                    # Fetch the latest commit for the module
+                    if latest_version is None:
+                        try:
+                            git_log = get_module_git_log(module, modules_repo=modules_repo, per_page=1, page_nbr=1)
+                        except UserWarning:
+                            log.error(f"Was unable to fetch version of module '{module}'")
+                            exit_value = False
+                            continue
+                        latest_version = git_log[0]["git_sha"]
+                    version = latest_version
+                else:
+                    try:
+                        version = nf_core.modules.module_utils.prompt_module_version_sha(
+                            module,
+                            modules_repo=modules_repo,
+                            installed_sha=current_entry["git_sha"] if not current_entry is None else None,
+                        )
+                    except SystemError as e:
+                        log.error(e)
+                        exit_value = False
+                        continue
+
+            log.info(f"Updating '{modules_repo.name}/{module}'")
+            log.debug(
+                f"Updating module '{module}' to {modules_repo.modules_current_hash} from {self.modules_repo.name}"
+            )
+
+            log.debug(f"Removing old version of module '{module}'")
+            self.clear_module_dir(module, module_dir)
+
+            # Download module files
+            if not self.download_module_file(module, version, modules_repo, install_folder, module_dir):
+                exit_value = False
+                continue
+
+            # Update module.json with newly installed module
+            self.update_modules_json(modules_json, modules_repo.name, module, version)
+        return exit_value

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -39,8 +39,8 @@ class TestModules(unittest.TestCase):
 
         # Set up install objects
         print("Setting up install objects")
-        self.mods_install = nf_core.modules.ModuleInstall(self.pipeline_dir, latest=True, force=True)
-        self.mods_install_alt = nf_core.modules.ModuleInstall(self.pipeline_dir, latest=True, force=True)
+        self.mods_install = nf_core.modules.ModuleInstall(self.pipeline_dir, prompt=False, force=True)
+        self.mods_install_alt = nf_core.modules.ModuleInstall(self.pipeline_dir, prompt=True, force=True)
 
         # TODO Remove comments once external repository to have same structure as nf-core/modules
         # self.mods_install_alt.modules_repo = nf_core.modules.ModulesRepo(repo="ewels/nf-core-modules", branch="master")


### PR DESCRIPTION
Moved the module updating duties from `nf-core modules install` to `nf-core modules update`. 
`nf-core modules install` has the following changes:
- The `--all` flag is removed
- `--latest` is made default. One can select the version using the cli prompt with `--prompt`. 

`nf-core modules update` has the following features:
- Checking the version of a single module and updating if needed: `nf-core modules update`
- Selecting a specific version to update to `nf-core modules update --prompt`
- Updating a single module to a specific version if needed: `nf-core modules update --sha <commit sha>`
- Forcing the reinstallation of the module files: `nf-core modules --force`
- Running the command on all modules in the pipeline `nf-core modules update --all`. All of the other flags works with `--all` now. 


## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Documentation in `docs` is updated
