### PR TITLE
Add pipeline verification function to `nf-core lint` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Modules
 
 * Added consistency checks between installed modules and `modules.json` ([#1199](https://github.com/nf-core/tools/issues/1199))
+* Added missing function call to `nf-core lint` ([#1198](https://github.com/nf-core/tools/issues/1198))
 
 ## [v2.0.1 - Palladium Platypus Junior](https://github.com/nf-core/tools/releases/tag/2.0.1) - [2021-07-13]
 

--- a/nf_core/lint/__init__.py
+++ b/nf_core/lint/__init__.py
@@ -53,6 +53,12 @@ def run_linting(
     # Create the modules lint object
     module_lint_obj = ModuleLint(pipeline_dir)
 
+    # Verify that the pipeline is correctly configured
+    try:
+        module_lint_obj.has_valid_directory()
+    except UserWarning:
+        raise
+
     # Run only the tests we want
     module_lint_tests = ("module_changes", "module_version")
     module_lint_obj.filter_tests_by_key(module_lint_tests)


### PR DESCRIPTION
The `nf-core lint` command was complaining about missing the `modules.json` file, as reported in #1198. This PR adds the `ModulesCommand.has_valid_pipeline` function that checks whether the pipeline is valid and adds the `modules.json` file if it is missing. 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
