### PR TITLE
Fix `nf-core lint` running unwanted modules test when using `--key` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Modules
 
 * Added consistency checks between installed modules and `modules.json` ([#1199](https://github.com/nf-core/tools/issues/1199))
+* Fix `nf-core lint` not filtering modules test when run with `--key` ([#1203](https://github.com/nf-core/tools/issues/1203))
 
 ## [v2.0.1 - Palladium Platypus Junior](https://github.com/nf-core/tools/releases/tag/2.0.1) - [2021-07-13]
 

--- a/nf_core/lint/__init__.py
+++ b/nf_core/lint/__init__.py
@@ -56,7 +56,7 @@ def run_linting(
         log.info("Only running tests: '{}'".format("', '".join(key)))
 
     # Create the lint object
-    pipeline_keys = list(set(key).intersection(set(PipelineLint._get_all_lint_tests(release_mode)))) if key else None
+    pipeline_keys = list(set(key).intersection(set(PipelineLint._get_all_lint_tests(release_mode)))) if key else []
 
     lint_obj = PipelineLint(pipeline_dir, release_mode, fix, pipeline_keys, fail_ignored)
 

--- a/nf_core/lint/__init__.py
+++ b/nf_core/lint/__init__.py
@@ -42,8 +42,23 @@ def run_linting(
         An object of type :class:`PipelineLint` that contains all the linting results.
     """
 
+    # Verify that the requested tests exist
+    if key:
+        all_tests = set(PipelineLint._get_all_lint_tests(release_mode)).union(set(ModuleLint._get_all_lint_tests()))
+        bad_keys = [k for k in key if k not in all_tests]
+        if len(bad_keys) > 0:
+            raise AssertionError(
+                "Test name{} not recognised: '{}'".format(
+                    "s" if len(bad_keys) > 1 else "",
+                    "', '".join(bad_keys),
+                )
+            )
+        log.info("Only running tests: '{}'".format("', '".join(key)))
+
     # Create the lint object
-    lint_obj = PipelineLint(pipeline_dir, release_mode, fix, key, fail_ignored)
+    pipeline_keys = list(set(key).intersection(set(PipelineLint._get_all_lint_tests(release_mode)))) if key else None
+
+    lint_obj = PipelineLint(pipeline_dir, release_mode, fix, pipeline_keys, fail_ignored)
 
     # Load the various pipeline configs
     lint_obj._load_lint_config()
@@ -54,7 +69,12 @@ def run_linting(
     module_lint_obj = ModuleLint(pipeline_dir)
 
     # Run only the tests we want
-    module_lint_tests = ("module_changes", "module_version")
+    if key:
+        # Select only the module lint tests
+        module_lint_tests = list(set(key).intersection(set(ModuleLint._get_all_lint_tests())))
+    else:
+        # If no key is supplied, run the default modules tests
+        module_lint_tests = ("module_changes", "module_version")
     module_lint_obj.filter_tests_by_key(module_lint_tests)
 
     # Set up files for modules linting test
@@ -154,7 +174,14 @@ class PipelineLint(nf_core.utils.Pipeline):
         self.passed = []
         self.warned = []
         self.could_fix = []
-        self.lint_tests = [
+        self.lint_tests = self._get_all_lint_tests(self.release_mode)
+        self.fix = fix
+        self.key = key
+        self.progress_bar = None
+
+    @staticmethod
+    def _get_all_lint_tests(release_mode):
+        return [
             "files_exist",
             "nextflow_config",
             "files_unchanged",
@@ -171,12 +198,7 @@ class PipelineLint(nf_core.utils.Pipeline):
             "actions_schema_validation",
             "merge_markers",
             "modules_json",
-        ]
-        if self.release_mode:
-            self.lint_tests.extend(["version_consistency"])
-        self.fix = fix
-        self.key = key
-        self.progress_bar = None
+        ] + (["version_consistency"] if release_mode else [])
 
     def _load(self):
         """Load information about the pipeline into the PipelineLint object"""
@@ -234,7 +256,6 @@ class PipelineLint(nf_core.utils.Pipeline):
 
         # If -k supplied, only run these tests
         if self.key:
-            log.info("Only running tests: '{}'".format("', '".join(self.key)))
             self.lint_tests = [k for k in self.lint_tests if k in self.key]
 
         # Check that the pipeline_dir is a clean git repo

--- a/nf_core/modules/lint/__init__.py
+++ b/nf_core/modules/lint/__init__.py
@@ -79,8 +79,7 @@ class ModuleLint(ModuleCommand):
         self.warned = []
         self.failed = []
         self.modules_repo = ModulesRepo()
-        self.lint_tests = ["main_nf", "functions_nf", "meta_yml", "module_changes", "module_todos"]
-
+        self.lint_tests = self._get_all_lint_tests()
         # Get lists of modules install in directory
         self.all_local_modules, self.all_nfcore_modules = self.get_installed_modules()
 
@@ -94,6 +93,10 @@ class ModuleLint(ModuleCommand):
         if self.repo_type == "pipeline":
             # Add as first test to load git_sha before module_changes
             self.lint_tests.insert(0, "module_version")
+
+    @staticmethod
+    def _get_all_lint_tests():
+        return ["main_nf", "functions_nf", "meta_yml", "module_changes", "module_todos"]
 
     def lint(self, module=None, key=(), all_modules=False, print_results=True, show_passed=False, local=False):
         """


### PR DESCRIPTION
Fixed the `modules lint` tests not filtering properly when running `nf-core lint` with the `--key` option. One can now select both `modules lint` and `lint` tests with `--key`. Should close #1203. 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
