### PR TITLE
Update Nextflow installation link in pipeline template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Template
 
+* Update Nextflow installation link in pipeline template ([#1201](https://github.com/nf-core/tools/issues/1201))
+
 ### General
 
 ### Modules

--- a/nf_core/bump_version.py
+++ b/nf_core/bump_version.py
@@ -98,10 +98,13 @@ def bump_nextflow_version(pipeline_obj, new_version):
                 "nextflow%20DSL2-%E2%89%A5{}-23aa62.svg".format(new_version),
             ),
             (
+                # Replace links to 'nf-co.re' installation page with links to Nextflow installation page
+                r"https://nf-co.re/usage/installation",
+                "https://www.nextflow.io/docs/latest/getstarted.html#installation",
+            ),
+            (
                 # example: 1. Install [`Nextflow`](https://www.nextflow.io/docs/latest/getstarted.html#installation) (`>=20.04.0`)
-                r"1\.\s*Install\s*\[`Nextflow`\]\(https://www.nextflow.io/docs/latest/getstarted.html#installation\)\s*\(`>={}`\)".format(
-                    current_version.replace(".", r"\.")
-                ),
+                r"1\.\s*Install\s*\[`Nextflow`\]\(y\)\s*\(`>={}`\)".format(current_version.replace(".", r"\.")),
                 "1. Install [`Nextflow`](https://www.nextflow.io/docs/latest/getstarted.html#installation) (`>={}`)".format(
                     new_version
                 ),

--- a/nf_core/pipeline-template/README.md
+++ b/nf_core/pipeline-template/README.md
@@ -33,7 +33,7 @@ On release, automated continuous integration tests run the pipeline on a full-si
 
 ## Quick Start
 
-1. Install [`Nextflow`](https://nf-co.re/usage/installation) (`>=21.04.0`)
+1. Install [`Nextflow`](https://www.nextflow.io/docs/latest/getstarted.html#installation) (`>=21.04.0`)
 
 2. Install any of [`Docker`](https://docs.docker.com/engine/installation/), [`Singularity`](https://www.sylabs.io/guides/3.0/user-guide/), [`Podman`](https://podman.io/), [`Shifter`](https://nersc.gitlab.io/development/shifter/how-to-use/) or [`Charliecloud`](https://hpc.github.io/charliecloud/) for full pipeline reproducibility _(please only use [`Conda`](https://conda.io/miniconda.html) as a last resort; see [docs](https://nf-co.re/usage/configuration#basic-configuration-profiles))_
 


### PR DESCRIPTION
Updated changed link for Nextflow installation from `nf-co.re/usage/installation` to `https://www.nextflow.io/docs/latest/getstarted.html#installation` as suggested in #1201. Updated `nf-core bump-version` to check for references to `nf-co.re/usage/installation` and replace them with the Nextflow link.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
