### PR TITLE
Update flags with `-r` as short option

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -67,7 +67,7 @@ jobs:
             --from-branch dev \
             --pull-request \
             --username nf-core-bot \
-            --repository nf-core/${{ matrix.pipeline }}
+            --github-repository nf-core/${{ matrix.pipeline }}
 
       - name: Upload sync log file artifact
         if: ${{ always() }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### General
 
+* Changed names of some flags with `-r` as short options to make the flags more consistent between commands.
+
 ### Modules
 
 * Added consistency checks between installed modules and `modules.json` ([#1199](https://github.com/nf-core/tools/issues/1199))

--- a/README.md
+++ b/README.md
@@ -904,7 +904,7 @@ The nf-core DSL2 modules repository is at <https://github.com/nf-core/modules>
 
 The modules supercommand comes with two flags for specifying a custom remote:
 
-* `--github-repository`: Specify a repository from which the modules should be fetched. Defaults to `nf-core/modules`.
+* `--github-repository <github repo>`: Specify the repository from which the modules should be fetched. Defaults to `nf-core/modules`.
 * `--branch`: Specify the branch from which the modules shoudl be fetched. Defaults to `master`.
 
 Note that a custom remote must follow a similar directory structure to that of `nf-core/moduleś` for the `nf-core modules` commands to work properly.

--- a/README.md
+++ b/README.md
@@ -905,7 +905,7 @@ The nf-core DSL2 modules repository is at <https://github.com/nf-core/modules>
 The modules supercommand comes with two flags for specifying a custom remote:
 
 * `--github-repository <github repo>`: Specify the repository from which the modules should be fetched. Defaults to `nf-core/modules`.
-* `--branch`: Specify the branch from which the modules shoudl be fetched. Defaults to `master`.
+* `--branch <branch name>`: Specify the branch from which the modules shoudl be fetched. Defaults to `master`.
 
 Note that a custom remote must follow a similar directory structure to that of `nf-core/moduleś` for the `nf-core modules` commands to work properly.
 

--- a/README.md
+++ b/README.md
@@ -888,7 +888,7 @@ By default, the tool will collect workflow variables from the current branch in 
 You can supply the `--from-branch` flag to specific a different branch.
 
 Finally, if you give the `--pull-request` flag, the command will push any changes to the remote and attempt to create a pull request using the GitHub API.
-The GitHub username and repository name will be fetched from the remote url (see `git remote -v | grep origin`), or can be supplied with `--username` and `--repository`.
+The GitHub username and repository name will be fetched from the remote url (see `git remote -v | grep origin`), or can be supplied with `--username` and `--github-repository`.
 
 To create the pull request, a personal access token is required for API authentication.
 These can be created at [https://github.com/settings/tokens](https://github.com/settings/tokens).
@@ -901,6 +901,13 @@ These are software tool process definitions that can be imported into any pipeli
 This allows multiple pipelines to use the same code for share tools and gives a greater degree of granulairy and unit testing.
 
 The nf-core DSL2 modules repository is at <https://github.com/nf-core/modules>
+
+The modules supercommand comes with two flags for specifying a custom remote:
+
+* `--github-repository`: Specify a repository from which the modules should be fetched. Defaults to `nf-core/modules`.
+* `--branch`: Specify the branch from which the modules shoudl be fetched. Defaults to `master`.
+
+Note that a custom remote must follow a similar directory structure to that of `nf-core/moduleś` for the `nf-core modules` command to work properly.
 
 ### List modules
 

--- a/README.md
+++ b/README.md
@@ -907,7 +907,7 @@ The modules supercommand comes with two flags for specifying a custom remote:
 * `--github-repository`: Specify a repository from which the modules should be fetched. Defaults to `nf-core/modules`.
 * `--branch`: Specify the branch from which the modules shoudl be fetched. Defaults to `master`.
 
-Note that a custom remote must follow a similar directory structure to that of `nf-core/moduleś` for the `nf-core modules` command to work properly.
+Note that a custom remote must follow a similar directory structure to that of `nf-core/moduleś` for the `nf-core modules` commands to work properly.
 
 ### List modules
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -349,15 +349,15 @@ def lint(dir, release, fix, key, show_passed, fail_ignored, markdown, json):
 ## nf-core module subcommands
 @nf_core_cli.group(cls=CustomHelpOrder, help_priority=7)
 @click.option(
-    "-r",
-    "--repository",
+    "-g",
+    "--github-repository",
     type=str,
     default="nf-core/modules",
     help="GitHub repository hosting modules.",
 )
 @click.option("-b", "--branch", type=str, default="master", help="Branch of GitHub repository hosting modules.")
 @click.pass_context
-def modules(ctx, repository, branch):
+def modules(ctx, github_repository, branch):
     """
     Tools to manage Nextflow DSL2 modules as hosted on nf-core/modules.
     """
@@ -367,7 +367,7 @@ def modules(ctx, repository, branch):
 
     # Make repository object to pass to subcommands
     try:
-        ctx.obj["modules_repo_obj"] = nf_core.modules.ModulesRepo(repository, branch)
+        ctx.obj["modules_repo_obj"] = nf_core.modules.ModulesRepo(github_repository, branch)
     except LookupError as e:
         log.critical(e)
         sys.exit(1)

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -734,9 +734,9 @@ def bump_version(new_version, dir, nextflow):
 @click.option("-d", "--dir", type=click.Path(exists=True), default=".", help="Pipeline directory. Defaults to CWD")
 @click.option("-b", "--from-branch", type=str, help="The git branch to use to fetch workflow vars.")
 @click.option("-p", "--pull-request", is_flag=True, default=False, help="Make a GitHub pull-request with the changes.")
-@click.option("-r", "--repository", type=str, help="GitHub PR: target repository.")
+@click.option("-g", "--github-repository", type=str, help="GitHub PR: target repository.")
 @click.option("-u", "--username", type=str, help="GitHub PR: auth username.")
-def sync(dir, from_branch, pull_request, repository, username):
+def sync(dir, from_branch, pull_request, github_repository, username):
     """
     Sync a pipeline TEMPLATE branch with the nf-core template.
 
@@ -756,7 +756,7 @@ def sync(dir, from_branch, pull_request, repository, username):
         raise
 
     # Sync the given pipeline dir
-    sync_obj = nf_core.sync.PipelineSync(dir, from_branch, pull_request, repository, username)
+    sync_obj = nf_core.sync.PipelineSync(dir, from_branch, pull_request, github_repository, username)
     try:
         sync_obj.sync()
     except (nf_core.sync.SyncException, nf_core.sync.PullRequestException) as e:

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -209,7 +209,7 @@ def launch(pipeline, id, revision, command_only, params_in, params_out, save_all
 
 @nf_core_cli.command(help_priority=3)
 @click.argument("pipeline", required=False, metavar="<pipeline name>")
-@click.option("-r", "--release", type=str, help="Pipeline release")
+@click.option("-r", "--revision", type=str, help="Pipeline release")
 @click.option("-o", "--outdir", type=str, help="Output directory")
 @click.option(
     "-x", "--compress", type=click.Choice(["tar.gz", "tar.bz2", "zip", "none"]), help="Archive compression type"
@@ -223,7 +223,7 @@ def launch(pipeline, id, revision, command_only, params_in, params_out, save_all
     help="Don't / do copy images to the output directory and set 'singularity.cacheDir' in workflow",
 )
 @click.option("-p", "--parallel-downloads", type=int, default=4, help="Number of parallel image downloads")
-def download(pipeline, release, outdir, compress, force, container, singularity_cache_only, parallel_downloads):
+def download(pipeline, revision, outdir, compress, force, container, singularity_cache_only, parallel_downloads):
     """
     Download a pipeline, nf-core/configs and pipeline singularity images.
 
@@ -231,7 +231,7 @@ def download(pipeline, release, outdir, compress, force, container, singularity_
     workflow to use relative paths to the configs and singularity images.
     """
     dl = nf_core.download.DownloadWorkflow(
-        pipeline, release, outdir, compress, force, container, singularity_cache_only, parallel_downloads
+        pipeline, revision, outdir, compress, force, container, singularity_cache_only, parallel_downloads
     )
     dl.download_workflow()
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -524,7 +524,7 @@ def create_module(ctx, tool, dir, author, label, meta, no_meta, force, conda_nam
 @modules.command("create-test-yml", help_priority=6)
 @click.pass_context
 @click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
-@click.option("-r", "--run-tests", is_flag=True, default=False, help="Run the test workflows")
+@click.option("-t", "--run-tests", is_flag=True, default=False, help="Run the test workflows")
 @click.option("-o", "--output", type=str, help="Path for output YAML file")
 @click.option("-f", "--force", is_flag=True, default=False, help="Overwrite output YAML file if it already exists")
 @click.option("-p", "--no-prompts", is_flag=True, default=False, help="Use defaults without prompting")

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -30,7 +30,7 @@ class DownloadTest(unittest.TestCase):
             download_obj.wf_releases,
             download_obj.wf_branches,
         ) = nf_core.utils.get_repo_releases_branches(pipeline, wfs)
-        download_obj.get_release_hash()
+        download_obj.get_revisions_hash()
         assert download_obj.wf_sha == "b3e5e3b95aaf01d98391a62a10a3990c0a4de395"
         assert download_obj.outdir == "nf-core-methylseq-1.6"
         assert (
@@ -49,7 +49,7 @@ class DownloadTest(unittest.TestCase):
             download_obj.wf_releases,
             download_obj.wf_branches,
         ) = nf_core.utils.get_repo_releases_branches(pipeline, wfs)
-        download_obj.get_release_hash()
+        download_obj.get_revisions_hash()
         assert download_obj.wf_sha == "819cbac792b76cf66c840b567ed0ee9a2f620db7"
         assert download_obj.outdir == "nf-core-exoseq-dev"
         assert (
@@ -68,7 +68,7 @@ class DownloadTest(unittest.TestCase):
             download_obj.wf_releases,
             download_obj.wf_branches,
         ) = nf_core.utils.get_repo_releases_branches(pipeline, wfs)
-        download_obj.get_release_hash()
+        download_obj.get_revisions_hash()
 
     #
     # Tests for 'download_wf_files'

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -24,13 +24,13 @@ class DownloadTest(unittest.TestCase):
         wfs = nf_core.list.Workflows()
         wfs.get_remote_workflows()
         pipeline = "methylseq"
-        download_obj = DownloadWorkflow(pipeline=pipeline, release="1.6")
+        download_obj = DownloadWorkflow(pipeline=pipeline, revision="1.6")
         (
             download_obj.pipeline,
-            download_obj.wf_releases,
+            download_obj.wf_revisions,
             download_obj.wf_branches,
         ) = nf_core.utils.get_repo_releases_branches(pipeline, wfs)
-        download_obj.get_revisions_hash()
+        download_obj.get_revision_hash()
         assert download_obj.wf_sha == "b3e5e3b95aaf01d98391a62a10a3990c0a4de395"
         assert download_obj.outdir == "nf-core-methylseq-1.6"
         assert (
@@ -43,13 +43,13 @@ class DownloadTest(unittest.TestCase):
         wfs.get_remote_workflows()
         # Exoseq pipeline is archived, so `dev` branch should be stable
         pipeline = "exoseq"
-        download_obj = DownloadWorkflow(pipeline=pipeline, release="dev")
+        download_obj = DownloadWorkflow(pipeline=pipeline, revision="dev")
         (
             download_obj.pipeline,
-            download_obj.wf_releases,
+            download_obj.wf_revisions,
             download_obj.wf_branches,
         ) = nf_core.utils.get_repo_releases_branches(pipeline, wfs)
-        download_obj.get_revisions_hash()
+        download_obj.get_revision_hash()
         assert download_obj.wf_sha == "819cbac792b76cf66c840b567ed0ee9a2f620db7"
         assert download_obj.outdir == "nf-core-exoseq-dev"
         assert (
@@ -62,20 +62,20 @@ class DownloadTest(unittest.TestCase):
         wfs = nf_core.list.Workflows()
         wfs.get_remote_workflows()
         pipeline = "methylseq"
-        download_obj = DownloadWorkflow(pipeline=pipeline, release="thisisfake")
+        download_obj = DownloadWorkflow(pipeline=pipeline, revision="thisisfake")
         (
             download_obj.pipeline,
-            download_obj.wf_releases,
+            download_obj.wf_revisions,
             download_obj.wf_branches,
         ) = nf_core.utils.get_repo_releases_branches(pipeline, wfs)
-        download_obj.get_revisions_hash()
+        download_obj.get_revision_hash()
 
     #
     # Tests for 'download_wf_files'
     #
     def test_download_wf_files(self):
         outdir = tempfile.mkdtemp()
-        download_obj = DownloadWorkflow(pipeline="nf-core/methylseq", release="1.6")
+        download_obj = DownloadWorkflow(pipeline="nf-core/methylseq", revision="1.6")
         download_obj.outdir = outdir
         download_obj.wf_sha = "b3e5e3b95aaf01d98391a62a10a3990c0a4de395"
         download_obj.wf_download_url = (
@@ -89,7 +89,7 @@ class DownloadTest(unittest.TestCase):
     #
     def test_download_configs(self):
         outdir = tempfile.mkdtemp()
-        download_obj = DownloadWorkflow(pipeline="nf-core/methylseq", release="1.6")
+        download_obj = DownloadWorkflow(pipeline="nf-core/methylseq", revision="1.6")
         download_obj.outdir = outdir
         download_obj.download_configs()
         assert os.path.exists(os.path.join(outdir, "configs", "nfcore_custom.config"))
@@ -106,7 +106,7 @@ class DownloadTest(unittest.TestCase):
         create_obj.init_pipeline()
 
         test_outdir = tempfile.mkdtemp()
-        download_obj = DownloadWorkflow(pipeline="dummy", release="1.2.0", outdir=test_outdir)
+        download_obj = DownloadWorkflow(pipeline="dummy", revision="1.2.0", outdir=test_outdir)
         shutil.copytree(test_pipeline_dir, os.path.join(test_outdir, "workflow"))
         download_obj.download_configs()
 
@@ -192,7 +192,7 @@ class DownloadTest(unittest.TestCase):
             pipeline="nf-core/methylseq",
             outdir=os.path.join(tmp_dir, "new"),
             container="singularity",
-            release="1.6",
+            revision="1.6",
             compress_type="none",
         )
 


### PR DESCRIPTION
Changed the names of some flags with `-r` as short options to make the flags more consisten between commands:
- The `--release` flag for `nf-core download` is renamed to `--revision` (as well as some of the names in the code). 
- The `--repository` flag for `nf-core modules` and `nf-core sync` is renanmed to `--github-repository` with the accompanying short option renamed from `-r` to `-g`.
- The short option for the `--run-tests` flag for `nf-core modules create-test-yml` is renamed from `-r` to `-t`. 

Also added a section for the `nf-core modules` level flags in the docs.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Documentation in `docs` is updated
