### PR TITLE
Add prompt in `nf-core modules update` if neither module name nor `--all` flag are supplied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Added missing function call to `nf-core lint` ([#1198](https://github.com/nf-core/tools/issues/1198))
 * Fix `nf-core lint` not filtering modules test when run with `--key` ([#1203](https://github.com/nf-core/tools/issues/1203))
 * Fixed `nf-core modules install` not working when installing from branch with `-b` ([#1218](https://github.com/nf-core/tools/issues/1218))
+* Added prompt to choose between updating all modules or named module in  `nf-core modules update`
 
 ## [v2.0.1 - Palladium Platypus Junior](https://github.com/nf-core/tools/releases/tag/2.0.1) - [2021-07-13]
 

--- a/nf_core/modules/update.py
+++ b/nf_core/modules/update.py
@@ -33,6 +33,16 @@ class ModuleUpdate(ModuleCommand):
 
         tool_config = nf_core.utils.load_tools_config()
         update_config = tool_config.get("update", {})
+        if not self.update_all and module is None:
+            choices = ["All modules", "Named module"]
+            self.update_all = (
+                questionary.select(
+                    "Update all modules or a single named module?",
+                    choices=choices,
+                    style=nf_core.utils.nfcore_question_style,
+                ).ask()
+                == "All modules"
+            )
 
         if not self.update_all:
             # Get the available modules


### PR DESCRIPTION
Added an interactive prompt in `nf-core modules update` if neither a module name nor the `--all` flag is supplied. 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
