### PR TITLE
f missing on f-string lint message conda version

### DIFF
--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -206,7 +206,7 @@ def check_process_section(self, lines):
                     ("bioconda_latest", f"Conda update: {package} `{ver}` -> `{last_ver}`", self.main_nf)
                 )
             else:
-                self.passed.append(("bioconda_latest", "Conda package is the latest available: `{bp}`", self.main_nf))
+                self.passed.append(("bioconda_latest", f"Conda package is the latest available: `{bp}`", self.main_nf))
 
     if docker_tag == singularity_tag:
         return True


### PR DESCRIPTION
`modules lint`command is not formatting correctly the line corresponding to the conda version

```
│ adapterremoval                           │ modules/adapterremoval/main.nf        │ Conda package is the latest available: {bp}                                                                                  
```

The reason is that the corresponding `f-string` is missing the  `f`

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
