### PR TITLE
Add verification of SHA from `--sha`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Fixed `nf-core modules install` not working when installing from branch with `-b` ([#1218](https://github.com/nf-core/tools/issues/1218))
 * Added prompt to choose between updating all modules or named module in  `nf-core modules update`
 * Check if modules is installed before trying to update in `nf-core modules update`
+* Verify that a commit SHA provided with `--sha` exists for `install/update` commands
 
 ## [v2.0.1 - Palladium Platypus Junior](https://github.com/nf-core/tools/releases/tag/2.0.1) - [2021-07-13]
 

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -42,7 +42,7 @@ class ModuleInstall(ModuleCommand):
             log.error("Cannot use '--sha' and '--prompt' at the same time!")
             return False
 
-        # Verify that a provided SHA is exist in the repo
+        # Verify that the provided SHA exists in the repo
         if self.sha:
             try:
                 nf_core.modules.module_utils.sha_exists(self.sha, self.modules_repo)

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -1,4 +1,5 @@
 import os
+from re import I
 import questionary
 import logging
 
@@ -41,6 +42,17 @@ class ModuleInstall(ModuleCommand):
         if self.prompt and self.sha is not None:
             log.error("Cannot use '--sha' and '--prompt' at the same time!")
             return False
+
+        # Verify that a provided SHA is exist in the repo
+        if self.sha:
+            try:
+                nf_core.modules.module_utils.sha_exists(self.sha, self.modules_repo)
+            except UserWarning:
+                log.error(f"Commit SHA '{self.sha}' doesn't exist in '{self.modules_repo.name}'")
+                return False
+            except LookupError as e:
+                log.error(e)
+                return False
 
         if module is None:
             module = questionary.autocomplete(

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -1,5 +1,4 @@
 import os
-from re import I
 import questionary
 import logging
 

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -262,7 +262,7 @@ class ModuleCommand:
             dl_filename = os.path.join(self.dir, "modules", *install_folder, *split_filename[1:])
             try:
                 self.modules_repo.download_gh_file(dl_filename, api_url)
-            except SystemError as e:
+            except (SystemError, LookupError) as e:
                 log.error(e)
                 return False
         log.info("Downloaded {} files to {}".format(len(files), module_dir))

--- a/nf_core/modules/update.py
+++ b/nf_core/modules/update.py
@@ -48,7 +48,7 @@ class ModuleUpdate(ModuleCommand):
             log.error("Cannot use '--sha' and '--prompt' at the same time!")
             return False
 
-        # Verify that a provided SHA is exist in the repo
+        # Verify that the provided SHA exists in the repo
         if self.sha:
             try:
                 nf_core.modules.module_utils.sha_exists(self.sha, self.modules_repo)

--- a/nf_core/modules/update.py
+++ b/nf_core/modules/update.py
@@ -44,16 +44,27 @@ class ModuleUpdate(ModuleCommand):
                 == "All modules"
             )
 
+        if self.prompt and self.sha is not None:
+            log.error("Cannot use '--sha' and '--prompt' at the same time!")
+            return False
+
+        # Verify that a provided SHA is exist in the repo
+        if self.sha:
+            try:
+                nf_core.modules.module_utils.sha_exists(self.sha, self.modules_repo)
+            except UserWarning:
+                log.error(f"Commit SHA '{self.sha}' doesn't exist in '{self.modules_repo.name}'")
+                return False
+            except LookupError as e:
+                log.error(e)
+                return False
+
         if not self.update_all:
             # Get the available modules
             try:
                 self.modules_repo.get_modules_file_tree()
             except LookupError as e:
                 log.error(e)
-                return False
-
-            if self.prompt and self.sha is not None:
-                log.error("Cannot use '--sha' and '--prompt' at the same time!")
                 return False
 
             # Check if there are any modules installed from


### PR DESCRIPTION
Added verification that a commit SHA provided through `--sha` in `nf-core modules update/install` exist in the remote. 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
