### PR TITLE
Add new-line to main.nf after nf-core modules bump-versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Added prompt to choose between updating all modules or named module in  `nf-core modules update`
 * Check if modules is installed before trying to update in `nf-core modules update`
 * Verify that a commit SHA provided with `--sha` exists for `install/update` commands
+* Add new-line to `main.nf` after `bump-versions` command to make ECLint happy
 
 ## [v2.0.1 - Palladium Platypus Junior](https://github.com/nf-core/tools/releases/tag/2.0.1) - [2021-07-13]
 

--- a/nf_core/modules/bump_versions.py
+++ b/nf_core/modules/bump_versions.py
@@ -198,7 +198,7 @@ class ModuleVersionBumper(ModuleCommand):
                         newcontent.append(line)
 
                 if found_match:
-                    content = "\n".join(newcontent)
+                    content = "\n".join(newcontent) + "\n"
                 else:
                     self.failed.append(
                         (f"Did not find pattern {pattern[0]} in module {module.module_name}", module.module_name)


### PR DESCRIPTION
Using `nf-core modules bump-versions --all` fails the ECLint tests because a new-line isn't added to the end of `main.nf` once it is written. e.g.
https://github.com/nf-core/modules/pull/629/checks?check_run_id=3171084274