### PR TITLE
Fix duplication of links by `nf-core modules create`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Remove `.` from nf-core/tools command examples
 * Update Nextflow installation link in pipeline template ([#1201](https://github.com/nf-core/tools/issues/1201))
 * Command `hostname` is not portable [[#1212](https://github.com/nf-core/tools/pull/1212)]
+* Changed how singularity and docker links are written in template to avoid duplicate links
 
 ### General
 

--- a/nf_core/module-template/modules/main.nf
+++ b/nf_core/module-template/modules/main.nf
@@ -15,7 +15,7 @@ include { initOptions; saveFiles; getSoftwareName } from './functions'
 //               unless there is a run-time, storage advantage in implementing in this way
 //               e.g. it's ok to have a single module for bwa to output BAM instead of SAM:
 //                 bwa mem | samtools view -B -T ref.fasta
-// TODO nf-core: Optional inputs are not currently supported by Nextflow. However, using an empty 
+// TODO nf-core: Optional inputs are not currently supported by Nextflow. However, using an empty
 //               list (`[]`) instead of a file can be used to work around this issue.
 
 params.options = [:]
@@ -34,9 +34,9 @@ process {{ tool_name_underscore|upper }} {
     // TODO nf-core: See section in main README for further information regarding finding and adding container addresses to the section below.
     conda (params.enable_conda ? "{{ bioconda if bioconda else 'YOUR-TOOL-HERE' }}" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/{{ singularity_container if singularity_container else 'YOUR-TOOL-HERE' }}"
+        container "{{ singularity_container if singularity_container else 'https://depot.galaxyproject.org/singularity/YOUR-TOOL-HERE' }}"
     } else {
-        container "quay.io/biocontainers/{{ docker_container if docker_container else 'YOUR-TOOL-HERE' }}"
+        container "{{ docker_container if docker_container else 'quay.io/biocontainers/YOUR-TOOL-HERE' }}"
     }
 
     input:


### PR DESCRIPTION
Fixed `nf-core modules create` duplicating parts of the links to the docker and singularity containers. 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
