### PR TITLE
Fix typo in `module_utils.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Modules
 
+* Fixed typo in `module_utils.py`.
+
 ## [v2.1 - Zinc Zebra](https://github.com/nf-core/tools/releases/tag/2.1) - [2021-07-27]
 
 ### Template

--- a/nf_core/modules/module_utils.py
+++ b/nf_core/modules/module_utils.py
@@ -396,7 +396,7 @@ def prompt_module_version_sha(module, modules_repo, installed_sha=None):
         log.warning(e)
         next_page_commits = None
 
-    while git_sha is "":
+    while git_sha == "":
         commits = next_page_commits
         try:
             next_page_commits = get_module_git_log(


### PR DESCRIPTION
Fixed a potentially dangerous typo in `module_utils.py`  

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
