### PR TITLE
Change `questionary` `ask` to `unsafe_ask` to cancel execution on keyboard interupts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### General
 
+* Changed `questionary` `ask()` to `unsafe_ask()` to not catch `KeyboardInterupts` ([#1237](https://github.com/nf-core/tools/issues/1237))
+
 ### Modules
 
 ## [v2.1 - Zinc Zebra](https://github.com/nf-core/tools/releases/tag/2.1) - [2021-07-27]

--- a/nf_core/modules/bump_versions.py
+++ b/nf_core/modules/bump_versions.py
@@ -83,7 +83,7 @@ class ModuleVersionBumper(ModuleCommand):
                     "Tool name:",
                     choices=[m.module_name for m in nfcore_modules],
                     style=nf_core.utils.nfcore_question_style,
-                ).ask()
+                ).unsafe_ask()
 
         if module:
             self.show_up_to_date = True

--- a/nf_core/modules/create.py
+++ b/nf_core/modules/create.py
@@ -204,7 +204,7 @@ class ModuleCreate(object):
                 choices=process_label_defaults,
                 style=nf_core.utils.nfcore_question_style,
                 default="process_low",
-            ).ask()
+            ).unsafe_ask()
 
         if self.has_meta is None:
             log.info(

--- a/nf_core/modules/remove.py
+++ b/nf_core/modules/remove.py
@@ -46,12 +46,12 @@ class ModuleRemove(ModuleCommand):
         else:
             repo_name = questionary.autocomplete(
                 "Repo name:", choices=self.module_names.keys(), style=nf_core.utils.nfcore_question_style
-            ).ask()
+            ).unsafe_ask()
 
         if module is None:
             module = questionary.autocomplete(
                 "Tool name:", choices=self.module_names[repo_name], style=nf_core.utils.nfcore_question_style
-            ).ask()
+            ).unsafe_ask()
 
         # Set the remove folder based on the repository name
         remove_folder = os.path.split(repo_name)

--- a/nf_core/modules/update.py
+++ b/nf_core/modules/update.py
@@ -40,7 +40,7 @@ class ModuleUpdate(ModuleCommand):
                     "Update all modules or a single named module?",
                     choices=choices,
                     style=nf_core.utils.nfcore_question_style,
-                ).ask()
+                ).unsafe_ask()
                 == "All modules"
             )
 


### PR DESCRIPTION
A few of the commands weren't exiting properly or at all due to the `KeyboardInterupts` being caught by the `ask` function from `questionary`. They are now changed to `unsafe_ask` so the process exits on keyboard interupts. Should close #1237. 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
