### PR TITLE
Fix bug in `nf-core modules create` due to bad Anaconda API error handling

### DIFF
--- a/nf_core/modules/create.py
+++ b/nf_core/modules/create.py
@@ -145,7 +145,9 @@ class ModuleCreate(object):
                 log.info(f"Using Bioconda package: '{self.bioconda}'")
                 break
             except (ValueError, LookupError) as e:
-                log.warning(f"Could not find Conda dependency using the Anaconda API: '{self.tool}'")
+                log.warning(
+                    f"Could not find Conda dependency using the Anaconda API: '{self.tool_conda_name if self.tool_conda_name else self.tool}'"
+                )
                 if rich.prompt.Confirm.ask(f"[violet]Do you want to enter a different Bioconda package name?"):
                     self.tool_conda_name = rich.prompt.Prompt.ask("[violet]Name of Bioconda package").strip()
                     continue


### PR DESCRIPTION
The `nf-core modules create` was the module name as missing from the Anaconda API even when `-c <conda name>` was specified, which was causing the issue in #1255. Fixed by updating the error message when the Anaconda API call fails. 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
