### PR TITLE
Update `nf-core modules create` help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Fixed typo in `module_utils.py`.
 * Added `--diff` flag to `nf-core modules update` which shows the diff between the installed files and the versions
+* Update `nf-core modules create` help texts which were not changed with the introduction of the `--dir` flag
 
 ## [v2.1 - Zinc Zebra](https://github.com/nf-core/tools/releases/tag/2.1) - [2021-07-27]
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -502,10 +502,10 @@ def create_module(ctx, tool, dir, author, label, meta, no_meta, force, conda_nam
     """
     Create a new DSL2 module from the nf-core template.
 
-    If <directory> is a pipeline, this function creates a file called
+    If the working directory is a pipeline, this function creates a file called
     'modules/local/tool_subtool.nf'
 
-    If <directory> is a clone of nf-core/modules, it creates or modifies files
+    If the working directory is a clone of nf-core/modules, it creates or modifies files
     in 'modules/', 'tests/modules' and 'tests/config/pytest_modules.yml'
     """
     # Combine two bool flags into one variable

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -502,7 +502,7 @@ def create_module(ctx, tool, dir, author, label, meta, no_meta, force, conda_nam
     """
     Create a new DSL2 module from the nf-core template.
 
-    If the specified is a pipeline, this function creates a file called
+    If the specified directory is a pipeline, this function creates a file called
     'modules/local/tool_subtool.nf'
 
     If the specified directory is a clone of nf-core/modules, it creates or modifies files

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -502,10 +502,10 @@ def create_module(ctx, tool, dir, author, label, meta, no_meta, force, conda_nam
     """
     Create a new DSL2 module from the nf-core template.
 
-    If the working directory is a pipeline, this function creates a file called
+    If the specified is a pipeline, this function creates a file called
     'modules/local/tool_subtool.nf'
 
-    If the working directory is a clone of nf-core/modules, it creates or modifies files
+    If the specified directory is a clone of nf-core/modules, it creates or modifies files
     in 'modules/', 'tests/modules' and 'tests/config/pytest_modules.yml'
     """
     # Combine two bool flags into one variable


### PR DESCRIPTION
Updated help text for `nf-core modules create`which were not changed after the introduction of the `--dir`flag. 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
