### PR TITLE
Fixed `nf-core launch` not passing `--revision` value to the Nextflow command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### General
 
 * Changed `questionary` `ask()` to `unsafe_ask()` to not catch `KeyboardInterupts` ([#1237](https://github.com/nf-core/tools/issues/1237))
+* Fixed bug in `nf-core launch` due to revisions specified with `-r` not being added to nextflow command. ([#1246](https://github.com/nf-core/tools/issues/1246))
 
 ### Modules
 

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -209,7 +209,7 @@ class Launch(object):
                     return False
 
                 self.pipeline_revision = nf_core.utils.prompt_pipeline_release_branch(wf_releases, wf_branches)
-                self.nextflow_cmd += " -r {}".format(self.pipeline_revision)
+            self.nextflow_cmd += " -r {}".format(self.pipeline_revision)
 
         # Get schema from name, load it and lint it
         try:


### PR DESCRIPTION
Fixed bug due to pipeline revision specified with the `-r` flag to `nf-core launch` command not being added to the Nextflow command, as reported in #1246.  
## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
