### PR TITLE
Update linting for versions.yml

### DIFF
--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -116,9 +116,15 @@ def main_nf(module_lint_object, module):
 def check_script_section(self, lines):
     """
     Lint the script section
-    Checks whether 'def sotware' and 'def prefix' are defined
+    Checks whether 'def prefix'  is defined and whether getProcessName is used for `versions.yml`.
     """
     script = "".join(lines)
+
+    # check that process name is used for `versions.yml`
+    if re.search("\${\s*getProcessName(\s*task.process\s*)\s*}", script):
+        self.passed.append(("main_nf_version_script", "Process name used for versions.yml", self.main_nf))
+    else:
+        self.failed.append(("main_nf_version_script", "Process name not used for versions.yml", self.main_nf))
 
     # check for prefix (only if module has a meta map as input)
     if self.has_meta:

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -121,7 +121,7 @@ def check_script_section(self, lines):
     script = "".join(lines)
 
     # check that process name is used for `versions.yml`
-    if re.search("\${\s*getProcessName(\s*task.process\s*)\s*}", script):
+    if re.search("\$\{\s*getProcessName\s*\(\s*task\.process\s*\)\s*\}", script):
         self.passed.append(("main_nf_version_script", "Process name used for versions.yml", self.main_nf))
     else:
         self.failed.append(("main_nf_version_script", "Process name not used for versions.yml", self.main_nf))


### PR DESCRIPTION
The script section must contain `getProcessName(task.process)` - The process name must be contained
in the `versions.yml` file. 

PR related to https://github.com/nf-core/modules/pull/744