### PR TITLE
refactor: enhance sample checking script

### DIFF
--- a/nf_core/pipeline-template/bin/check_samplesheet.py
+++ b/nf_core/pipeline-template/bin/check_samplesheet.py
@@ -19,8 +19,6 @@ logger = logging.getLogger()
 class RowChecker:
 
     VALID_FORMATS = (
-        ".fq",
-        ".fastq",
         ".fq.gz",
         ".fastq.gz",
     )

--- a/nf_core/pipeline-template/bin/check_samplesheet.py
+++ b/nf_core/pipeline-template/bin/check_samplesheet.py
@@ -85,9 +85,7 @@ class RowChecker:
 
     def _validate_first(self, row):
         """Assert that the first FASTQ entry is non-empty and has the right format."""
-        assert (
-            len(row[self._first_col]) > 0
-        ), "At least the first FASTQ file is required."
+        assert len(row[self._first_col]) > 0, "At least the first FASTQ file is required."
         self._validate_fastq_format(row[self._first_col])
 
     def _validate_second(self, row):
@@ -100,8 +98,7 @@ class RowChecker:
         if row[self._first_col] and row[self._second_col]:
             row[self._single_col] = False
             assert (
-                Path(row[self._first_col]).suffixes
-                == Path(row[self._second_col]).suffixes
+                Path(row[self._first_col]).suffixes == Path(row[self._second_col]).suffixes
             ), "FASTQ pairs must have the same file extensions."
         else:
             row[self._single_col] = True
@@ -121,9 +118,7 @@ class RowChecker:
         FASTQ file combination exists.
 
         """
-        assert len(self._seen) == len(
-            self.modified
-        ), "The pair of sample name and FASTQ must be unique."
+        assert len(self._seen) == len(self.modified), "The pair of sample name and FASTQ must be unique."
         if len({pair[0] for pair in self._seen}) < len(self._seen):
             counts = Counter(pair[0] for pair in self._seen)
             seen = Counter()
@@ -191,10 +186,7 @@ def check_samplesheet(file_in, file_out):
         reader = csv.DictReader(in_handle, dialect=sniff_format(in_handle))
         # Validate the existence of the expected header columns.
         if not required_columns.issubset(reader.fieldnames):
-            logger.critical(
-                f"The sample sheet **must** contain the column headers: "
-                f"{', '.join(required_columns)}."
-            )
+            logger.critical(f"The sample sheet **must** contain the column headers: {', '.join(required_columns)}.")
             sys.exit(1)
         # Validate each row.
         checker = RowChecker()

--- a/nf_core/pipeline-template/bin/check_samplesheet.py
+++ b/nf_core/pipeline-template/bin/check_samplesheet.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 
-# TODO nf-core: Update the script to check the samplesheet
-# This script is based on the example at:
-# https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/samplesheet/samplesheet_test_illumina_amplicon.csv
+
+"""Provide a command line tool to validate and transform tabular samplesheets."""
 
 
 import argparse
@@ -17,6 +16,14 @@ logger = logging.getLogger()
 
 
 class RowChecker:
+    """
+    Define a service that can validate and transform each given row.
+
+    Attributes:
+        modified (list): A list of dicts, where each dict corresponds to a previously
+            validated and transformed row. The order of rows is maintained.
+
+    """
 
     VALID_FORMATS = (
         ".fq.gz",
@@ -31,115 +38,201 @@ class RowChecker:
         single_col="single_end",
         **kwargs,
     ):
+        """
+        Initialize the row checker with the expected column names.
+
+        Args:
+            sample_col (str): The name of the column that contains the sample name
+                (default "sample").
+            first_col (str): The name of the column that contains the first (or only)
+                FASTQ file path (default "fastq_1").
+            second_col (str): The name of the column that contains the second (if any)
+                FASTQ file path (default "fastq_2").
+            single_col (str): The name of the new column that will be inserted and
+                records whether the sample contains single- or paired-end sequencing
+                reads (default "single_end").
+
+        """
         super().__init__(**kwargs)
-        self.sample_col = sample_col
-        self.first_col = first_col
-        self.second_col = second_col
-        self.single_col = single_col
-        self.seen = set()
+        self._sample_col = sample_col
+        self._first_col = first_col
+        self._second_col = second_col
+        self._single_col = single_col
+        self._seen = set()
         self.modified = []
 
-    def validate(self, row):
+    def validate_and_transform(self, row):
+        """
+        Perform all validations on the given row and insert the read pairing status.
+
+        Args:
+            row (dict): A mapping from column headers (keys) to elements of that row
+                (values).
+
+        """
         self._validate_sample(row)
         self._validate_first(row)
         self._validate_second(row)
         self._validate_pair(row)
-        self.seen.add((row[self.sample_col], row[self.first_col]))
+        self._seen.add((row[self._sample_col], row[self._first_col]))
         self.modified.append(row)
 
     def _validate_sample(self, row):
-        assert len(row[self.sample_col]) > 0, "Sample input is required."
+        """Assert that the sample name exists and convert spaces to underscores."""
+        assert len(row[self._sample_col]) > 0, "Sample input is required."
         # Sanitize samples slightly.
-        row[self.sample_col] = row[self.sample_col].replace(" ", "_")
+        row[self._sample_col] = row[self._sample_col].replace(" ", "_")
 
     def _validate_first(self, row):
-        assert len(row[self.first_col]) > 0, "At least the first FASTQ file is required."
-        self._validate_fastq_format(row[self.first_col])
+        """Assert that the first FASTQ entry is non-empty and has the right format."""
+        assert (
+            len(row[self._first_col]) > 0
+        ), "At least the first FASTQ file is required."
+        self._validate_fastq_format(row[self._first_col])
 
     def _validate_second(self, row):
-        if len(row[self.second_col]) > 0:
-            self._validate_fastq_format(row[self.second_col])
+        """Assert that the second FASTQ entry has the right format if it exists."""
+        if len(row[self._second_col]) > 0:
+            self._validate_fastq_format(row[self._second_col])
 
     def _validate_pair(self, row):
-        if row[self.first_col] and row[self.second_col]:
-            row[self.single_col] = False
+        """Assert that read pairs have the same file extension. Report pair status."""
+        if row[self._first_col] and row[self._second_col]:
+            row[self._single_col] = False
             assert (
-                Path(row[self.first_col]).suffixes == Path(row[self.second_col]).suffixes
+                Path(row[self._first_col]).suffixes
+                == Path(row[self._second_col]).suffixes
             ), "FASTQ pairs must have the same file extensions."
         else:
-            row[self.single_col] = True
+            row[self._single_col] = True
 
     def _validate_fastq_format(self, filename):
+        """Assert that a given filename has one of the expected FASTQ extensions."""
         assert any(filename.endswith(extension) for extension in self.VALID_FORMATS), (
             f"The FASTQ file has an unrecognized extension: {filename}\n"
             f"It should be one of: {', '.join(self.VALID_FORMATS)}"
         )
 
     def validate_unique_samples(self):
-        assert len(self.seen) == len(self.modified), "The pair of sample name and FASTQ must be unique."
-        if len({pair[0] for pair in self.seen}) < len(self.seen):
-            counts = Counter(pair[0] for pair in self.seen)
+        """
+        Assert that the combination of sample name and FASTQ filename is unique.
+
+        In addition to the validation, also rename the sample if more than one sample,
+        FASTQ file combination exists.
+
+        """
+        assert len(self._seen) == len(
+            self.modified
+        ), "The pair of sample name and FASTQ must be unique."
+        if len({pair[0] for pair in self._seen}) < len(self._seen):
+            counts = Counter(pair[0] for pair in self._seen)
             seen = Counter()
             for row in self.modified:
-                sample = row[self.sample_col]
+                sample = row[self._sample_col]
                 seen[sample] += 1
                 if counts[sample] > 1:
-                    row[self.sample_col] = f"{sample}_T{seen[sample]}"
+                    row[self._sample_col] = f"{sample}_T{seen[sample]}"
 
 
-# TODO nf-core: Update the check_samplesheet function
+def sniff_format(handle):
+    """
+    Detect the tabular format.
+
+    Args:
+        handle (text file): A handle to a `text file`_ object. The read position is
+        expected to be at the beginning (index 0).
+
+    Returns:
+        csv.Dialect: The detected tabular format.
+
+    .. _text file:
+        https://docs.python.org/3/glossary.html#term-text-file
+
+    """
+    peek = handle.read(2048)
+    sniffer = csv.Sniffer()
+    if not sniffer.has_header(peek):
+        logger.critical(f"The given sample sheet does not appear to contain a header.")
+        sys.exit(1)
+    dialect = sniffer.sniff(peek)
+    handle.seek(0)
+    return dialect
+
+
 def check_samplesheet(file_in, file_out):
     """
-    This function checks that the samplesheet follows the following structure:
+    Check that the tabular samplesheet has the structure expected by nf-core pipelines.
 
-    sample,fastq_1,fastq_2
-    SAMPLE_PE,SAMPLE_PE_RUN1_1.fastq.gz,SAMPLE_PE_RUN1_2.fastq.gz
-    SAMPLE_PE,SAMPLE_PE_RUN2_1.fastq.gz,SAMPLE_PE_RUN2_2.fastq.gz
-    SAMPLE_SE,SAMPLE_SE_RUN1_1.fastq.gz,
+    Validate the general shape of the table, expected columns, and each row. Also add
+    an additional column which records whether one or two FASTQ reads were found.
 
-    For an example see:
-    https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/samplesheet/samplesheet_test_illumina_amplicon.csv
+    Args:
+        file_in (pathlib.Path): The given tabular samplesheet. The format can be either
+            CSV, TSV, or any other format automatically recognized by ``csv.Sniffer``.
+        file_out (pathlib.Path): Where the validated and transformed samplesheet should
+            be created; always in CSV format.
+
+    Example:
+        This function checks that the samplesheet follows the following structure,
+        see also the `viral recon samplesheet`_::
+
+            sample,fastq_1,fastq_2
+            SAMPLE_PE,SAMPLE_PE_RUN1_1.fastq.gz,SAMPLE_PE_RUN1_2.fastq.gz
+            SAMPLE_PE,SAMPLE_PE_RUN2_1.fastq.gz,SAMPLE_PE_RUN2_2.fastq.gz
+            SAMPLE_SE,SAMPLE_SE_RUN1_1.fastq.gz,
+
+    .. _viral recon samplesheet:
+        https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/samplesheet/samplesheet_test_illumina_amplicon.csv
+
     """
     required_columns = {"sample", "fastq_1", "fastq_2"}
-    with file_in.open() as in_handle:
+    # See https://docs.python.org/3.9/library/csv.html#id3 to read up on `newline=""`.
+    with file_in.open(newline="") as in_handle:
+        reader = csv.DictReader(in_handle, dialect=sniff_format(in_handle))
         # Validate the existence of the expected header columns.
-        peek = in_handle.read(2048)
-        sniffer = csv.Sniffer()
-        if not sniffer.has_header(peek):
-            logger.critical(f"The given sample sheet does not appear to contain a header.")
-            sys.exit(1)
-        dialect = sniffer.sniff(peek)
-        in_handle.seek(0)
-        reader = csv.DictReader(in_handle, dialect=dialect)
         if not required_columns.issubset(reader.fieldnames):
-            logger.critical(f"The sample sheet **must** contain the column headers: {', '.join(required_columns)}.")
+            logger.critical(
+                f"The sample sheet **must** contain the column headers: "
+                f"{', '.join(required_columns)}."
+            )
             sys.exit(1)
         # Validate each row.
         checker = RowChecker()
         for i, row in enumerate(reader):
             try:
-                checker.validate(row)
+                checker.validate_and_transform(row)
             except AssertionError as error:
                 logger.critical(f"{str(error)} On line {i + 2}.")
                 sys.exit(1)
         checker.validate_unique_samples()
     header = list(reader.fieldnames)
     header.insert(1, "single_end")
-    with file_out.open("w") as out_handle:
+    # See https://docs.python.org/3.9/library/csv.html#id3 to read up on `newline=""`.
+    with file_out.open(mode="w", newline="") as out_handle:
         writer = csv.DictWriter(out_handle, header, delimiter=",")
         writer.writeheader()
         for row in checker.modified:
             writer.writerow(row)
 
 
-def parse_args(args=None):
+def parse_args(argv=None):
     """Define and immediately parse command line arguments."""
     parser = argparse.ArgumentParser(
-        description="Reformat {{ name }} samplesheet file and check its contents.",
-        epilog="Example usage: python check_samplesheet.py samplesheet.csv samplesheet.valid.csv",
+        description="Validate and transform a tabular samplesheet.",
+        epilog="Example: python check_samplesheet.py samplesheet.csv samplesheet.valid.csv",
     )
-    parser.add_argument("file_in", metavar="FILE_IN", type=Path, help="Input sample sheet.")
-    parser.add_argument("file_out", metavar="FILE_OUT", type=Path, help="Output file.")
+    parser.add_argument(
+        "file_in",
+        metavar="FILE_IN",
+        type=Path,
+        help="Tabular input samplesheet in CSV or TSV format.",
+    )
+    parser.add_argument(
+        "file_out",
+        metavar="FILE_OUT",
+        type=Path,
+        help="Transformed output samplesheet in CSV format.",
+    )
     parser.add_argument(
         "-l",
         "--log-level",
@@ -147,12 +240,12 @@ def parse_args(args=None):
         choices=("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"),
         default="WARNING",
     )
-    return parser.parse_args(args)
+    return parser.parse_args(argv)
 
 
-def main(args=None):
+def main(argv=None):
     """Coordinate argument parsing and program execution."""
-    args = parse_args(args)
+    args = parse_args(argv)
     logging.basicConfig(level=args.log_level, format="[%(levelname)s] %(message)s")
     if not args.file_in.is_file():
         logger.error(f"The given input file {args.file_in} was not found!")


### PR DESCRIPTION
With this PR I propose to make the following changes as briefly mentioned on Slack.

* `csv.Sniffer` should allow most tabular inputs but writes CSV as nf-core pipelines expect
* refactor validations into checker class
* relax accepted sequence file formats, as mentioned, this is easily changed by modifying

    ```py
    VALID_FORMATS = (
        ".fq",
        ".fastq",
        ".fq.gz",
        ".fastq.gz",
    )
    ```

    in the `RowChecker` class. I like uncompressed formats for local pipelines with many small steps where de-/compression takes up the majority of time.

I will adjust documentation and tests when you have told me exactly what the desired behavior is.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
