### PR TITLE
Fix setup

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
 include README.md
 recursive-include nf_core *
+include requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include LICENSE
 include README.md
-recursive-include nf_core *
+graft nf_core/module-template
+graft nf_core/pipeline-template
 include requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
+[build-system]
+build-backend = 'setuptools.build_meta'
+requires = [
+  'setuptools>=40.6.0',
+  'wheel'
+]
+
 [tool.black]
 line-length = 120
 target_version = ['py36','py37','py38']

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
     license="MIT",
     entry_points={"console_scripts": ["nf-core=nf_core.__main__:run_nf_core"]},
     install_requires=required,
-    setup_requires=["twine>=1.11.0", "setuptools>=38.6."],
     packages=find_packages(exclude=("docs")),
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Builds are currently failing because tools are installed as `pip install -e .`.

I would suggest a number of further changes to make this package follow Python best practices.

* Move package code to a `src` directory
* Introduce a `setup.cfg`
* Declare dependencies in `setup.cfg` rather than `requirements.txt` (that's for applications not library packages)
* Possibly use tox for test and build isolation (but certainly never use `pip install -e .`)
* Could use git tags for versioning rather than hardcoding it.

Happy to discuss these suggestions on Slack, of course.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
