### PR TITLE
fix issue with Circular import of ModuleLint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Template
 
+* Solve circular import when importing `nf_core.modules.lint`
 * Disable cache in `nf_core.utils.fetch_wf_config` while performing `test_wf_use_local_configs`.
 * Modify software version channel handling to support multiple software version emissions (e.g. from mulled containers), and multiple software versions.
 * Update `dumpsoftwareversion` module to correctly report versions with trailing zeros.

--- a/nf_core/lint/__init__.py
+++ b/nf_core/lint/__init__.py
@@ -20,8 +20,8 @@ import yaml
 
 import nf_core.utils
 import nf_core.lint_utils
+import nf_core.modules.lint
 from nf_core.lint_utils import console
-from nf_core.modules.lint import ModuleLint
 
 log = logging.getLogger(__name__)
 
@@ -44,7 +44,9 @@ def run_linting(
 
     # Verify that the requested tests exist
     if key:
-        all_tests = set(PipelineLint._get_all_lint_tests(release_mode)).union(set(ModuleLint._get_all_lint_tests()))
+        all_tests = set(PipelineLint._get_all_lint_tests(release_mode)).union(
+            set(nf_core.modules.lint.ModuleLint._get_all_lint_tests())
+        )
         bad_keys = [k for k in key if k not in all_tests]
         if len(bad_keys) > 0:
             raise AssertionError(
@@ -66,7 +68,7 @@ def run_linting(
     lint_obj._list_files()
 
     # Create the modules lint object
-    module_lint_obj = ModuleLint(pipeline_dir)
+    module_lint_obj = nf_core.modules.lint.ModuleLint(pipeline_dir)
 
     # Verify that the pipeline is correctly configured
     try:
@@ -77,7 +79,7 @@ def run_linting(
     # Run only the tests we want
     if key:
         # Select only the module lint tests
-        module_lint_tests = list(set(key).intersection(set(ModuleLint._get_all_lint_tests())))
+        module_lint_tests = list(set(key).intersection(set(nf_core.modules.lint.ModuleLint._get_all_lint_tests())))
     else:
         # If no key is supplied, run the default modules tests
         module_lint_tests = ("module_changes", "module_version")


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

Dear all,

while I was working on another issue, I found that I can't call tests only on `tests/test_modules.py` since a circular import prevents me to call those tests, as described by @grst in #1270. I think I solved by changing the import in `nf_core/lint/__init__.py` and by calling `ModuleLint` using full module path. This let you to import `nf_core.modules.lint` from a Python terminal and to call the individual tests on modules with:
```bash
pytest --color=yes tests/test_modules.py --verbose
```
Hope this helps.

----
This could close #1270 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
