### PR TITLE
Avoid checking pytest_modules file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Fixed typo in `module_utils.py`.
 * Added `--diff` flag to `nf-core modules update` which shows the diff between the installed files and the versions
 * Update `nf-core modules create` help texts which were not changed with the introduction of the `--dir` flag
+* `nf-core modules lint` skips validating the `pytest_modules.yml`
 
 ## [v2.1 - Zinc Zebra](https://github.com/nf-core/tools/releases/tag/2.1) - [2021-07-27]
 

--- a/nf_core/lint/pipeline_todos.py
+++ b/nf_core/lint/pipeline_todos.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python
 
-import logging
-import os
-import io
-import fnmatch
-
-log = logging.getLogger(__name__)
+from nf_core.lint_utils import find_todos
 
 
 def pipeline_todos(self):
@@ -32,39 +27,5 @@ def pipeline_todos(self):
               in a given project directory. This is a very quick and convenient way to get
               started on your pipeline!
     """
-    passed = []
-    warned = []
-    failed = []
-    file_paths = []
-
-    ignore = [".git"]
-    if os.path.isfile(os.path.join(self.wf_path, ".gitignore")):
-        with io.open(os.path.join(self.wf_path, ".gitignore"), "rt", encoding="latin1") as fh:
-            for l in fh:
-                ignore.append(os.path.basename(l.strip().rstrip("/")))
-    for root, dirs, files in os.walk(self.wf_path, topdown=True):
-        # Ignore files
-        for i_base in ignore:
-            i = os.path.join(root, i_base)
-            dirs[:] = [d for d in dirs if not fnmatch.fnmatch(os.path.join(root, d), i)]
-            files[:] = [f for f in files if not fnmatch.fnmatch(os.path.join(root, f), i)]
-        for fname in files:
-            try:
-                with io.open(os.path.join(root, fname), "rt", encoding="latin1") as fh:
-                    for l in fh:
-                        if "TODO nf-core" in l:
-                            l = (
-                                l.replace("<!--", "")
-                                .replace("-->", "")
-                                .replace("# TODO nf-core: ", "")
-                                .replace("// TODO nf-core: ", "")
-                                .replace("TODO nf-core: ", "")
-                                .strip()
-                            )
-                            warned.append("TODO string in `{}`: _{}_".format(fname, l))
-                            file_paths.append(os.path.join(root, fname))
-            except FileNotFoundError:
-                log.debug(f"Could not open file {fname} in pipeline_todos lint test")
-    # HACK file paths are returned to allow usage of this function in modules/lint.py
-    # Needs to be refactored!
-    return {"passed": passed, "warned": warned, "failed": failed, "file_paths": file_paths}
+    results = find_todos(self)
+    return results

--- a/nf_core/modules/lint/__init__.py
+++ b/nf_core/modules/lint/__init__.py
@@ -23,7 +23,6 @@ from rich.markdown import Markdown
 from rich.panel import Panel
 import rich
 from nf_core.utils import rich_force_colors
-from nf_core.lint.pipeline_todos import pipeline_todos
 import sys
 
 import nf_core.utils

--- a/nf_core/modules/lint/module_tests.py
+++ b/nf_core/modules/lint/module_tests.py
@@ -31,14 +31,14 @@ def module_tests(module_lint_object, module):
     try:
         pytest_yml_path = os.path.join(module.base_dir, "tests", "config", "pytest_modules.yml")
         with open(pytest_yml_path, "r") as fh:
-            module.passed.append(("test_pytest_yml", "pytest_modules.yml file is there", pytest_yml_path))
             # FIXME Using anchors breaks this
             # https://github.com/nf-core/modules/pull/933
             # pytest_yml = yaml.safe_load(fh)
-            # if module.module_name in pytest_yml.keys():
-            #     module.passed.append(("test_pytest_yml", "correct entry in pytest_modules.yml", pytest_yml_path))
-            # else:
-            #     module.failed.append(("test_pytest_yml", "missing entry in pytest_modules.yml", pytest_yml_path))
+            pytest_yml = yaml.load(fh, Loader=yaml.BaseLoader)
+            if module.module_name in pytest_yml.keys():
+                module.passed.append(("test_pytest_yml", "correct entry in pytest_modules.yml", pytest_yml_path))
+            else:
+                module.failed.append(("test_pytest_yml", "missing entry in pytest_modules.yml", pytest_yml_path))
     except FileNotFoundError as e:
         module.failed.append(("test_pytest_yml", f"Could not open pytest_modules.yml file", pytest_yml_path))
 

--- a/nf_core/modules/lint/module_tests.py
+++ b/nf_core/modules/lint/module_tests.py
@@ -31,11 +31,14 @@ def module_tests(module_lint_object, module):
     try:
         pytest_yml_path = os.path.join(module.base_dir, "tests", "config", "pytest_modules.yml")
         with open(pytest_yml_path, "r") as fh:
-            pytest_yml = yaml.safe_load(fh)
-            if module.module_name in pytest_yml.keys():
-                module.passed.append(("test_pytest_yml", "correct entry in pytest_modules.yml", pytest_yml_path))
-            else:
-                module.failed.append(("test_pytest_yml", "missing entry in pytest_modules.yml", pytest_yml_path))
+            module.passed.append(("test_pytest_yml", "pytest_modules.yml file is there", pytest_yml_path))
+            # FIXME Using anchors breaks this
+            # https://github.com/nf-core/modules/pull/933
+            # pytest_yml = yaml.safe_load(fh)
+            # if module.module_name in pytest_yml.keys():
+            #     module.passed.append(("test_pytest_yml", "correct entry in pytest_modules.yml", pytest_yml_path))
+            # else:
+            #     module.failed.append(("test_pytest_yml", "missing entry in pytest_modules.yml", pytest_yml_path))
     except FileNotFoundError as e:
         module.failed.append(("test_pytest_yml", f"Could not open pytest_modules.yml file", pytest_yml_path))
 

--- a/nf_core/modules/lint/module_todos.py
+++ b/nf_core/modules/lint/module_todos.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import logging
-from nf_core.lint.pipeline_todos import pipeline_todos
+from nf_core.lint_utils import find_todos
 
 log = logging.getLogger(__name__)
 
@@ -12,6 +12,6 @@ def module_todos(module_lint_object, module):
     for a single module
     """
     module.wf_path = module.module_dir
-    results = pipeline_todos(module)
+    results = find_todos(module)
     for i, warning in enumerate(results["warned"]):
         module.warned.append(("module_todo", warning, results["file_paths"][i]))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 pytest
 pytest-datafiles
 pytest-cov


### PR DESCRIPTION
For the moment due to using anchors for it, the anchors with a '/' break pyyaml

https://github.com/nf-core/modules/pull/933

## PR checklist

 - [ ] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
