### PR TITLE
Remove get process and software name functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Added `--diff` flag to `nf-core modules update` which shows the diff between the installed files and the versions
 * Update `nf-core modules create` help texts which were not changed with the introduction of the `--dir` flag
 * Check if README is from modules repo
+* Substitute get process/module name custom functions in module `main.nf` using template replacement ([#1284](https://github.com/nf-core/tools/issues/1284))
 
 ## [v2.1 - Zinc Zebra](https://github.com/nf-core/tools/releases/tag/2.1) - [2021-07-27]
 

--- a/nf_core/module-template/modules/main.nf
+++ b/nf_core/module-template/modules/main.nf
@@ -80,7 +80,7 @@ process {{ tool_name_underscore|upper }} {
 
     cat <<-END_VERSIONS > versions.yml
     {{ tool_name_underscore|upper }}:
-        {{ tool }}: \$( samtools --version 2>&1 | sed 's/^.*samtools //; s/Using.*\$//' )
+        {{ tool }}: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//' )
     END_VERSIONS
     """
 }

--- a/nf_core/module-template/modules/main.nf
+++ b/nf_core/module-template/modules/main.nf
@@ -79,8 +79,8 @@ process {{ tool_name_underscore|upper }} {
         $bam
 
     cat <<-END_VERSIONS > versions.yml
-    ${getProcessName(task.process)}:
-        ${getSoftwareName(task.process)}: \$( samtools --version 2>&1 | sed 's/^.*samtools //; s/Using.*\$//' )
+    {{ tool_name_underscore|upper }}:
+        {{ tool }}: \$( samtools --version 2>&1 | sed 's/^.*samtools //; s/Using.*\$//' )
     END_VERSIONS
     """
 }


### PR DESCRIPTION
Remove custom functions `getProcessName` and `getSoftwareName` and instead use the template to directly populate the process name and the software name within the `versions.yml` code.

Closes #1284

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
