### PR TITLE
Join dir to readme to determine repository type

### DIFF
--- a/nf_core/modules/module_utils.py
+++ b/nf_core/modules/module_utils.py
@@ -344,8 +344,8 @@ def get_repo_type(dir):
         raise LookupError("Could not find directory: {}".format(dir))
 
     # Determine repository type
-    if os.path.exists("README.md"):
-        with open("README.md") as fh:
+    if os.path.exists(os.path.join(dir, "README.md")):
+        with open(os.path.join(dir, "README.md")) as fh:
             if fh.readline().rstrip().startswith("# ![nf-core/modules]"):
                 return "modules"
             else:


### PR DESCRIPTION
When `--dir` option was provided to `nf-core lint` it was throwing an exception. Fixed by joining `dir` when checking for the `README.md` 

Closes #1328 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 