### PR TITLE
Create README.md when a dummy module is created

### DIFF
--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -19,6 +19,8 @@ def create_modules_repo_dummy():
     os.makedirs(os.path.join(root_dir, "tests", "config"))
     with open(os.path.join(root_dir, "tests", "config", "pytest_modules.yml"), "w") as fh:
         fh.writelines(["test:", "\n  - modules/test/**", "\n  - tests/modules/test/**"])
+    with open(os.path.join(root_dir, "README.md"), "w") as fh:
+        fh.writelines(["# ![nf-core/modules](docs/images/nfcore-modules_logo.png)", "\n"])
 
     module_create = nf_core.modules.ModuleCreate(root_dir, "star/align", "@author", "process_medium", False, False)
     module_create.create()


### PR DESCRIPTION
After PR  #1322 tests were failing since `create_modules_repo_dummy()` was not creating a README.md in the module tree. 

## PR checklist

 - [x] This comment contains a description of changes (with reason)

