### PR TITLE
Replaces suffix with completely customisable prefix variable

### DIFF
--- a/nf_core/module-template/modules/main.nf
+++ b/nf_core/module-template/modules/main.nf
@@ -46,7 +46,7 @@ process {{ tool_name_underscore|upper }} {
     script:
     def args = task.ext.args ?: ''
     {% if has_meta -%}
-    def prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def prefix = task.ext.prefix ?: "${meta.id}"
     {%- endif %}
     // TODO nf-core: Where possible, a command MUST be provided to obtain the version number of the software e.g. 1.10
     //               If the software is unable to output a version number on the command-line then it can be manually specified

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -108,7 +108,7 @@ def check_script_section(self, lines):
 
     # check for prefix (only if module has a meta map as input)
     if self.has_meta:
-        if re.search("\s*prefix\s*=\s*options.suffix", script):
+        if re.search("\s*prefix\s*=\s*task.args.prefix", script):
             self.passed.append(("main_nf_meta_prefix", "'prefix' specified in script section", self.main_nf))
         else:
             self.failed.append(("main_nf_meta_prefix", "'prefix' unspecified in script section", self.main_nf))

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -108,7 +108,7 @@ def check_script_section(self, lines):
 
     # check for prefix (only if module has a meta map as input)
     if self.has_meta:
-        if re.search("\s*prefix\s*=\s*task.args.prefix", script):
+        if re.search("\s*prefix\s*=\s*task.ext.prefix", script):
             self.passed.append(("main_nf_meta_prefix", "'prefix' specified in script section", self.main_nf))
         else:
             self.failed.append(("main_nf_meta_prefix", "'prefix' unspecified in script section", self.main_nf))

--- a/nf_core/pipeline-template/conf/modules.config
+++ b/nf_core/pipeline-template/conf/modules.config
@@ -6,7 +6,7 @@
         ext.args            = Additional arguments appended to command in module.
         ext.args2           = Second set of arguments appended to command in module (multi-tool modules).
         ext.args3           = Third set of arguments appended to command in module (multi-tool modules).
-        ext.suffix          = File name suffix for output files.
+        ext.prefix          = File name prefix for output files.
 ----------------------------------------------------------------------------------------
 */
 

--- a/nf_core/pipeline-template/modules.json
+++ b/nf_core/pipeline-template/modules.json
@@ -7,7 +7,7 @@
                 "git_sha": "20d8250d9f39ddb05dfb437603aaf99b5c0b2b41"
             },
             "fastqc": {
-                "git_sha": "20d8250d9f39ddb05dfb437603aaf99b5c0b2b41"
+                "git_sha": "9d0cad583b9a71a6509b754fdf589cbfbed08961"
             },
             "multiqc": {
                 "git_sha": "20d8250d9f39ddb05dfb437603aaf99b5c0b2b41"

--- a/nf_core/pipeline-template/modules/nf-core/modules/fastqc/main.nf
+++ b/nf_core/pipeline-template/modules/nf-core/modules/fastqc/main.nf
@@ -18,7 +18,7 @@ process FASTQC {
     script:
     def args = task.ext.args ?: ''
     // Add soft-links to original FastQs for consistent naming in pipeline
-    def prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def prefix = task.ext.prefix ?: "${meta.id}"
     if (meta.single_end) {
         """
         [ ! -f  ${prefix}.fastq.gz ] && ln -s $reads ${prefix}.fastq.gz


### PR DESCRIPTION
**DO NOT MERGE UNTIL AFTER ELIXIR WORKSHOP**

This replaces the slightly restrictive `$suffix` to a completely flexible `$prefix` parameter for naming output files - as made possible by DSL2 v2 syntax. 

This corresponds to what will change in the modules repository:

- https://github.com/drpatelh/nf-core-modules/commit/01d0b699359232835aac5c79af68c6267bdf05c5
- https://github.com/drpatelh/nf-core-modules/commit/90a41f843273b350bf216b41c7d2c47fefc60960

I think I caught everything (did a search with vscode for `suffix`)

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
