### PR TITLE
Update template with some DSL2 v2.0 bits detected during fetchngs ver 1.5 release 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 * New YAML issue templates for pipeline bug reports and feature requests, with a much richer interface ([#1165](https://github.com/nf-core/tools/pull/1165))
 * Update AWS test GitHub Actions to use v2 of [nf-core/tower-action](https://github.com/nf-core/tower-action)
 * Post linting comment even when `linting.yml` fails
+* Update `CONTRIBUTION.md` bullets to remove points related to `scrape_software_versions.py`
+* Update AWS test to set Nextflow version to 21.10.3
 
 ### General
 

--- a/nf_core/pipeline-template/.github/CONTRIBUTING.md
+++ b/nf_core/pipeline-template/.github/CONTRIBUTING.md
@@ -68,16 +68,13 @@ If you wish to contribute a new step, please use the following coding standards:
 1. Define the corresponding input channel into your new process from the expected previous process channel
 2. Write the process block (see below).
 3. Define the output channel if needed (see below).
-4. Add any new flags/options to `nextflow.config` with a default (see below).
-5. Add any new flags/options to `nextflow_schema.json` with help text (with `nf-core schema build`).
-6. Add any new flags/options to the help message (for integer/text parameters, print to help the corresponding `nextflow.config` parameter).
-7. Add sanity checks for all relevant parameters.
-8. Add any new software to the `scrape_software_versions.py` script in `bin/` and the version command to the `scrape_software_versions` process in `main.nf`.
-9. Do local tests that the new code works properly and as expected.
-10. Add a new test command in `.github/workflow/ci.yml`.
-11. If applicable add a [MultiQC](https://https://multiqc.info/) module.
-12. Update MultiQC config `assets/multiqc_config.yaml` so relevant suffixes, name clean up, General Statistics Table column order, and module figures are in the right order.
-13. Optional: Add any descriptions of MultiQC report sections and output files to `docs/output.md`.
+4. Add any new parameters to `nextflow.config` with a default (see below).
+5. Add any new parameters to `nextflow_schema.json` with help text (via the `nf-core schema build` tool).
+6. Add sanity checks and validation for all relevant parameters.
+7. Perform local tests to validate that the new code works as expected.
+8. If applicable, add a new test command in `.github/workflow/ci.yml`.
+9. Update MultiQC config `assets/multiqc_config.yaml` so relevant suffixes, file name clean up and module plots are in the appropriate order. If applicable, add a [MultiQC](https://https://multiqc.info/) module.
+10. Add a description of the output files and if relevant any appropriate images from the MultiQC report to `docs/output.md`.
 
 ### Default values
 
@@ -101,27 +98,6 @@ Please use the following naming schemes, to make it easy to understand what is g
 ### Nextflow version bumping
 
 If you are using a new feature from core Nextflow, you may bump the minimum required version of nextflow in the pipeline with: `nf-core bump-version --nextflow . [min-nf-version]`
-
-### Software version reporting
-
-If you add a new tool to the pipeline, please ensure you add the information of the tool to the `get_software_version` process.
-
-Add to the script block of the process, something like the following:
-
-```bash
-<YOUR_TOOL> --version &> v_<YOUR_TOOL>.txt 2>&1 || true
-```
-
-or
-
-```bash
-<YOUR_TOOL> --help | head -n 1 &> v_<YOUR_TOOL>.txt 2>&1 || true
-```
-
-You then need to edit the script `bin/scrape_software_versions.py` to:
-
-1. Add a Python regex for your tool's `--version` output (as in stored in the `v_<YOUR_TOOL>.txt` file), to ensure the version is reported as a `v` and the version number e.g. `v2.1.1`
-2. Add a HTML entry to the `OrderedDict` for formatting in MultiQC.
 
 ### Images and figures
 

--- a/nf_core/pipeline-template/.github/workflows/awsfulltest.yml
+++ b/nf_core/pipeline-template/.github/workflows/awsfulltest.yml
@@ -31,4 +31,4 @@ jobs:
               "outdir": "s3://{% raw %}${{ secrets.AWS_S3_BUCKET }}{% endraw %}/{{ short_name }}/{% raw %}results-${{ github.sha }}{% endraw %}"
             }
           profiles: test_full,aws_tower
-
+          pre_run_script: 'export NXF_VER=21.10.3'

--- a/nf_core/pipeline-template/.github/workflows/awstest.yml
+++ b/nf_core/pipeline-template/.github/workflows/awstest.yml
@@ -25,4 +25,4 @@ jobs:
               "outdir": "s3://{% raw %}${{ secrets.AWS_S3_BUCKET }}{% endraw %}/{{ short_name }}/{% raw %}results-${{ github.sha }}{% endraw %}"
             }
           profiles: test,aws_tower
-
+          pre_run_script: 'export NXF_VER=21.10.3'


### PR DESCRIPTION
We detected some missing points during have been detected during the release of fetchngs version 1.5, see [here](https://github.com/nf-core/fetchngs/pull/59). Namely:

* Update `CONTRIBUTION.md` bullets to remove points related to `scrape_software_versions.py`
* Update AWS test to set Nextflow version to 21.10.3

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
