### PR TITLE
Don't assume that the module repo branch is master if not set

### DIFF
--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -161,6 +161,7 @@ class ModuleCommand:
                     modules_repo.get_modules_file_tree()
                     install_folder = [modules_repo.owner, modules_repo.repo]
                 except LookupError as e:
+                    log.warn(f"Could not get module's file tree for '{repo}': {e}")
                     remove_from_mod_json[repo] = list(modules.keys())
                     continue
 
@@ -169,6 +170,9 @@ class ModuleCommand:
                     if sha is None:
                         if repo not in remove_from_mod_json:
                             remove_from_mod_json[repo] = []
+                        log.warn(
+                            f"Could not find git SHA for module '{module}' in '{repo}' - removing from modules.json"
+                        )
                         remove_from_mod_json[repo].append(module)
                         continue
                     module_dir = os.path.join(self.dir, "modules", *install_folder, module)
@@ -228,8 +232,8 @@ class ModuleCommand:
                     return "" if len(some_list) == 1 else "s"
 
                 log.info(
-                    f"Could not determine 'git_sha' for module{_s(failed_to_find_commit_sha)}: '{', '.join(failed_to_find_commit_sha)}'."
-                    f"\nPlease try to install a newer version of {'this' if len(failed_to_find_commit_sha) == 1 else 'these'}  module{_s(failed_to_find_commit_sha)}."
+                    f"Could not determine 'git_sha' for module{_s(failed_to_find_commit_sha)}: {', '.join(failed_to_find_commit_sha)}."
+                    f"\nPlease try to install a newer version of {'this' if len(failed_to_find_commit_sha) == 1 else 'these'} module{_s(failed_to_find_commit_sha)}."
                 )
 
         self.dump_modules_json(fresh_mod_json)

--- a/nf_core/modules/modules_repo.py
+++ b/nf_core/modules/modules_repo.py
@@ -20,6 +20,10 @@ class ModulesRepo(object):
         self.name = repo
         self.branch = branch
 
+        # Don't bother fetching default branch if we're using nf-core
+        if not self.branch and self.name == "nf-core/modules":
+            self.branch = "master"
+
         # Verify that the repo seems to be correctly configured
         if self.name != "nf-core/modules" or self.branch:
 


### PR DESCRIPTION
Don't set the module repo branch to `master` by default if we're not working with the main nf-core/modules repo.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
