### PR TITLE
Throw error when an unexpected parameter is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Post linting comment even when `linting.yml` fails
 * Update `CONTRIBUTION.md` bullets to remove points related to `scrape_software_versions.py`
 * Update AWS test to set Nextflow version to 21.10.3
+* When validating pipeline parameters, throw error instead of warning when an unexpected parameter is detected
 
 ### General
 

--- a/nf_core/pipeline-template/lib/NfcoreSchema.groovy
+++ b/nf_core/pipeline-template/lib/NfcoreSchema.groovy
@@ -168,13 +168,14 @@ class NfcoreSchema {
         if (unexpectedParams.size() > 0) {
             Map colors = NfcoreTemplate.logColours(params.monochrome_logs)
             println ''
-            def warn_msg = 'Found unexpected parameters:'
+            def error_msg = 'Found unexpected parameters:'
             for (unexpectedParam in unexpectedParams) {
-                warn_msg = warn_msg + "\n* --${unexpectedParam}: ${params[unexpectedParam].toString()}"
+                error_msg = error_msg + "\n* --${unexpectedParam}: ${params[unexpectedParam].toString()}"
             }
-            log.warn warn_msg
-            log.info "- ${colors.dim}Ignore this warning: params.schema_ignore_params = \"${unexpectedParams.join(',')}\" ${colors.reset}"
+            log.error error_msg
+            log.info "- ${colors.dim}Ignore this error: params.schema_ignore_params = \"${unexpectedParams.join(',')}\" ${colors.reset}"
             println ''
+            has_error = true
         }
 
         if (has_error) {


### PR DESCRIPTION
This PR updates the `NfcoreSchema` class so that an error (instead of warning) is thrown when unexpected parameters are found. This is the behaviour I would expect from a software, i.e. that it terminates if undefined parameters are detected. The warning is of course helpful, but sometimes a mispelled parameter can leave a silent error, which might not attract attention to the log. I can't really see any cases where it is beneficial to allow the user to supply undefined parameters? Let me know what you think. 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [] If you've fixed a bug or added code that should be tested, add tests!
 - [] Documentation in `docs` is updated
