### PR TITLE
Module lint: Fail instead of warn if local copy edited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * Check if README is from modules repo
 * Update module template to DSL2 v2.0 (remove `functions.nf` from modules template and updating `main.nf` ([#1289](https://github.com/nf-core/tools/pull/))
 * Substitute get process/module name custom functions in module `main.nf` using template replacement ([#1284](https://github.com/nf-core/tools/issues/1284))
+* Linting now fails instead of warning if a local copy of a module does not match the remote ([#1313](https://github.com/nf-core/tools/issues/1313))
 
 ## [v2.1 - Zinc Zebra](https://github.com/nf-core/tools/releases/tag/2.1) - [2021-07-27]
 

--- a/nf_core/modules/lint/module_changes.py
+++ b/nf_core/modules/lint/module_changes.py
@@ -49,10 +49,10 @@ def module_changes(module_lint_object, module):
                 remote_copy = r.content.decode("utf-8")
 
                 if local_copy != remote_copy:
-                    module.warned.append(
+                    module.failed.append(
                         (
                             "check_local_copy",
-                            "Local copy of module outdated",
+                            "Local copy of module does not match remote",
                             f"{os.path.join(module.module_dir, f)}",
                         )
                     )

--- a/tests/modules/bump_versions.py
+++ b/tests/modules/bump_versions.py
@@ -8,15 +8,15 @@ from nf_core.modules.module_utils import ModuleException
 
 def test_modules_bump_versions_single_module(self):
     """Test updating a single module"""
-    # Change the star/align version to an older version
-    main_nf_path = os.path.join(self.nfcore_modules, "modules", "star", "align", "main.nf")
+    # Change the bpipe/test version to an older version
+    main_nf_path = os.path.join(self.nfcore_modules, "modules", "bpipe", "test", "main.nf")
     with open(main_nf_path, "r") as fh:
         content = fh.read()
     new_content = re.sub(r"bioconda::star=\d.\d.\d\D?", r"bioconda::star=2.6.1d", content)
     with open(main_nf_path, "w") as fh:
         fh.write(new_content)
     version_bumper = nf_core.modules.ModuleVersionBumper(pipeline_dir=self.nfcore_modules)
-    version_bumper.bump_versions(module="star/align")
+    version_bumper.bump_versions(module="bpipe/test")
     assert len(version_bumper.failed) == 0
 
 
@@ -37,13 +37,13 @@ def test_modules_bump_versions_fail(self):
 
 def test_modules_bump_versions_fail_unknown_version(self):
     """Fail because of an unknown version"""
-    # Change the star/align version to an older version
-    main_nf_path = os.path.join(self.nfcore_modules, "modules", "star", "align", "main.nf")
+    # Change the bpipe/test version to an older version
+    main_nf_path = os.path.join(self.nfcore_modules, "modules", "bpipe", "test", "main.nf")
     with open(main_nf_path, "r") as fh:
         content = fh.read()
     new_content = re.sub(r"bioconda::star=\d.\d.\d\D?", r"bioconda::star=xxx", content)
     with open(main_nf_path, "w") as fh:
         fh.write(new_content)
     version_bumper = nf_core.modules.ModuleVersionBumper(pipeline_dir=self.nfcore_modules)
-    version_bumper.bump_versions(module="star/align")
+    version_bumper.bump_versions(module="bpipe/test")
     assert "Conda package had unknown version" in version_bumper.failed[0][0]

--- a/tests/modules/bump_versions.py
+++ b/tests/modules/bump_versions.py
@@ -41,7 +41,7 @@ def test_modules_bump_versions_fail_unknown_version(self):
     main_nf_path = os.path.join(self.nfcore_modules, "modules", "bpipe", "test", "main.nf")
     with open(main_nf_path, "r") as fh:
         content = fh.read()
-    new_content = re.sub(r"bioconda::star=\d.\d.\d\D?", r"bioconda::star=xxx", content)
+    new_content = re.sub(r"bioconda::bpipe=\d.\d.\d\D?", r"bioconda::bpipe=xxx", content)
     with open(main_nf_path, "w") as fh:
         fh.write(new_content)
     version_bumper = nf_core.modules.ModuleVersionBumper(pipeline_dir=self.nfcore_modules)

--- a/tests/modules/create_test_yml.py
+++ b/tests/modules/create_test_yml.py
@@ -41,18 +41,18 @@ def test_modules_create_test_yml_get_md5(self):
 
 def test_modules_create_test_yml_entry_points(self):
     """Test extracting test entry points from a main.nf file"""
-    meta_builder = nf_core.modules.ModulesTestYmlBuilder("star/align", False, "./", False, True)
-    meta_builder.module_test_main = os.path.join(self.nfcore_modules, "tests", "modules", "star", "align", "main.nf")
+    meta_builder = nf_core.modules.ModulesTestYmlBuilder("bpipe/test", False, "./", False, True)
+    meta_builder.module_test_main = os.path.join(self.nfcore_modules, "tests", "modules", "bpipe", "test", "main.nf")
     meta_builder.scrape_workflow_entry_points()
-    assert meta_builder.entry_points[0] == "test_star_align"
+    assert meta_builder.entry_points[0] == "test_bpipe_test"
 
 
 def test_modules_create_test_yml_check_inputs(self):
     """Test the check_inputs() function - raise UserWarning because test.yml exists"""
     cwd = os.getcwd()
     os.chdir(self.nfcore_modules)
-    meta_builder = nf_core.modules.ModulesTestYmlBuilder("star/align", False, "./", False, True)
-    meta_builder.module_test_main = os.path.join(self.nfcore_modules, "tests", "modules", "star", "align", "main.nf")
+    meta_builder = nf_core.modules.ModulesTestYmlBuilder("bpipe/test", False, "./", False, True)
+    meta_builder.module_test_main = os.path.join(self.nfcore_modules, "tests", "modules", "bpipe", "test", "main.nf")
     with pytest.raises(UserWarning) as excinfo:
         meta_builder.check_inputs()
     os.chdir(cwd)

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -22,7 +22,8 @@ def create_modules_repo_dummy():
     with open(os.path.join(root_dir, "README.md"), "w") as fh:
         fh.writelines(["# ![nf-core/modules](docs/images/nfcore-modules_logo.png)", "\n"])
 
-    module_create = nf_core.modules.ModuleCreate(root_dir, "star/align", "@author", "process_medium", False, False)
+    # bpipe is a valid package on bioconda that is very unlikely to ever be added to nf-core/modules
+    module_create = nf_core.modules.ModuleCreate(root_dir, "bpipe/test", "@author", "process_medium", False, False)
     module_create.create()
 
     return root_dir


### PR DESCRIPTION
If the local copy of a module is edited and does not match the remote, throw an error instead of a warning (with a clearer message too).

Fixes #1313

Not sure if there are cases where we don't want this to happen? But I can't think of any.


## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
