### PR TITLE
Modules lint: Check for md5sums of empty files

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * Update module template to DSL2 v2.0 (remove `functions.nf` from modules template and updating `main.nf` ([#1289](https://github.com/nf-core/tools/pull/))
 * Substitute get process/module name custom functions in module `main.nf` using template replacement ([#1284](https://github.com/nf-core/tools/issues/1284))
 * Check test YML file for md5sums corresponding to empty files ([#1302](https://github.com/nf-core/tools/issues/1302))
+* Exit with an error if empty files are found when generating the test YAML file ([#1302](https://github.com/nf-core/tools/issues/1302))
 
 ## [v2.1 - Zinc Zebra](https://github.com/nf-core/tools/releases/tag/2.1) - [2021-07-27]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * Check if README is from modules repo
 * Update module template to DSL2 v2.0 (remove `functions.nf` from modules template and updating `main.nf` ([#1289](https://github.com/nf-core/tools/pull/))
 * Substitute get process/module name custom functions in module `main.nf` using template replacement ([#1284](https://github.com/nf-core/tools/issues/1284))
+* Check test YML file for md5sums corresponding to empty files ([#1302](https://github.com/nf-core/tools/issues/1302))
 
 ## [v2.1 - Zinc Zebra](https://github.com/nf-core/tools/releases/tag/2.1) - [2021-07-27]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * New YAML issue templates for tools bug reports and feature requests, with a much richer interface ([#1165](https://github.com/nf-core/tools/pull/1165))
 * Handle synax errors in Nextflow config nicely when running `nf-core schema build` ([#1267](https://github.com/nf-core/tools/pull/1267))
 * Remove base `Dockerfile` used for DSL1 pipeline container builds
+* Run tests with Python 3.10
 
 ### Modules
 

--- a/nf_core/modules/lint/module_tests.py
+++ b/nf_core/modules/lint/module_tests.py
@@ -52,11 +52,31 @@ def module_tests(module_lint_object, module):
                     if not tag in [module.module_name, module.module_name.split("/")[0]]:
                         all_tags_correct = False
 
+                # Look for md5sums of empty files
+                for tfile in test.get("files", []):
+                    if tfile.get("md5sum") == "d41d8cd98f00b204e9800998ecf8427e":
+                        module.warned.append(
+                            (
+                                "test_yml_md5sum",
+                                "md5sum for empty file found: d41d8cd98f00b204e9800998ecf8427e",
+                                module.test_yml,
+                            )
+                        )
+                    if tfile.get("md5sum") == "7029066c27ac6f5ef18d660d5741979a":
+                        module.warned.append(
+                            (
+                                "test_yml_md5sum",
+                                "md5sum for compressed empty file found: 7029066c27ac6f5ef18d660d5741979a",
+                                module.test_yml,
+                            )
+                        )
+
             if all_tags_correct:
                 module.passed.append(("test_yml_tags", "tags adhere to guidelines", module.test_yml))
             else:
                 module.failed.append(("test_yml_tags", "tags do not adhere to guidelines", module.test_yml))
 
+        # Test that the file exists
         module.passed.append(("test_yml_exists", "Test `test.yml` exists", module.test_yml))
     except FileNotFoundError:
         module.failed.append(("test_yml_exists", "Test `test.yml` does not exist", module.test_yml))

--- a/nf_core/modules/test_yml_builder.py
+++ b/nf_core/modules/test_yml_builder.py
@@ -197,8 +197,9 @@ class ModulesTestYmlBuilder(object):
         if os.path.getsize(fname) == 0:
             return True
         try:
-            with gzip.open(fname, "rb") as fh:
-                if fh.read() == b"":
+            with open(fname, "rb") as fh:
+                g_f = gzip.GzipFile(fileobj=fh, mode="rb")
+                if g_f.read() == b"":
                     return True
         except gzip.BadGzipFile:
             pass

--- a/nf_core/modules/test_yml_builder.py
+++ b/nf_core/modules/test_yml_builder.py
@@ -205,7 +205,11 @@ class ModulesTestYmlBuilder(object):
                 elem_md5 = self._md5(elem)
                 # Switch out the results directory path with the expected 'output' directory
                 elem = elem.replace(results_dir, "output")
-                test_files.append({"path": elem, "md5sum": elem_md5})
+                test_file = {"path": elem}
+                # Only add the md5 if it's not for an empty file / compressed empty file
+                if elem_md5 != "d41d8cd98f00b204e9800998ecf8427e" and elem_md5 != "7029066c27ac6f5ef18d660d5741979a":
+                    test_file["md5sum"] = elem_md5
+                test_files.append(test_file)
 
         test_files = sorted(test_files, key=operator.itemgetter("path"))
 

--- a/nf_core/modules/test_yml_builder.py
+++ b/nf_core/modules/test_yml_builder.py
@@ -201,7 +201,15 @@ class ModulesTestYmlBuilder(object):
                 g_f = gzip.GzipFile(fileobj=fh, mode="rb")
                 if g_f.read() == b"":
                     return True
-        except gzip.BadGzipFile:
+        except Exception as e:
+            # Python 3.8+
+            if hasattr(gzip, "BadGzipFile"):
+                if isinstance(e, gzip.BadGzipFile):
+                    pass
+            # Python 3.7
+            else:
+                if isinstance(e, OSError):
+                    pass
             pass
         return False
 

--- a/nf_core/modules/test_yml_builder.py
+++ b/nf_core/modules/test_yml_builder.py
@@ -192,9 +192,12 @@ class ModulesTestYmlBuilder(object):
         """Check if the file is empty, or compressed empty"""
         if os.path.getsize(fname) == 0:
             return True
-        with gzip.open(fname, "rb") as fh:
-            if fh.read() == b"":
-                return True
+        try:
+            with gzip.open(fname, "rb") as fh:
+                if fh.read() == b"":
+                    return True
+        except gzip.BadGzipFile:
+            pass
         return False
 
     def _md5(self, fname):

--- a/nf_core/modules/test_yml_builder.py
+++ b/nf_core/modules/test_yml_builder.py
@@ -207,10 +207,10 @@ class ModulesTestYmlBuilder(object):
                 if isinstance(e, gzip.BadGzipFile):
                     pass
             # Python 3.7
+            elif isinstance(e, OSError):
+                pass
             else:
-                if isinstance(e, OSError):
-                    pass
-            pass
+                raise e
         return False
 
     def _md5(self, fname):


### PR DESCRIPTION
Brace yourselves for lots of new modules linting errors.. 😱 

Can think about changing this from a warn to a fail once the offending md5sums are all removed. I'd prefer that as I don't think that there's a good reason to have the md5sum in this case (?) but don't want to suddenly introduce so many failures.

Addresses #1302

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
