### PR TITLE
Warn instead of fail if module is different from remote

### DIFF
--- a/nf_core/modules/lint/module_changes.py
+++ b/nf_core/modules/lint/module_changes.py
@@ -49,7 +49,7 @@ def module_changes(module_lint_object, module):
                 remote_copy = r.content.decode("utf-8")
 
                 if local_copy != remote_copy:
-                    module.failed.append(
+                    module.warned.append(
                         (
                             "check_local_copy",
                             "Local copy of module does not match remote",


### PR DESCRIPTION
Reverts https://github.com/nf-core/tools/pull/1357 because modules will be changed on PRs to nf-core/modules and hence always result in linting failures.

Couldn't see a `CHANGELOG` entry so just the 1 word to change. Nothing else to see here.