### PR TITLE
Check modules fail, but for pipelines only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Modules
 
+* Linting a pipeline now fails instead of warning if a local copy of a module does not match the remote ([#1313](https://github.com/nf-core/tools/issues/1313))
+
 ## [v2.2 - Lead Liger](https://github.com/nf-core/tools/releases/tag/2.2) - [2021-12-14]
 
 ### Template
@@ -59,7 +61,6 @@
 * Check if README is from modules repo
 * Update module template to DSL2 v2.0 (remove `functions.nf` from modules template and updating `main.nf` ([#1289](https://github.com/nf-core/tools/pull/))
 * Substitute get process/module name custom functions in module `main.nf` using template replacement ([#1284](https://github.com/nf-core/tools/issues/1284))
-* Linting now fails instead of warning if a local copy of a module does not match the remote ([#1313](https://github.com/nf-core/tools/issues/1313))
 * Check test YML file for md5sums corresponding to empty files ([#1302](https://github.com/nf-core/tools/issues/1302))
 * Exit with an error if empty files are found when generating the test YAML file ([#1302](https://github.com/nf-core/tools/issues/1302))
 

--- a/nf_core/modules/lint/__init__.py
+++ b/nf_core/modules/lint/__init__.py
@@ -93,10 +93,12 @@ class ModuleLint(ModuleCommand):
         if self.repo_type == "pipeline":
             # Add as first test to load git_sha before module_changes
             self.lint_tests.insert(0, "module_version")
+            # Only check if modules have been changed in pipelines
+            self.lint_tests.append("module_changes")
 
     @staticmethod
     def _get_all_lint_tests():
-        return ["main_nf", "meta_yml", "module_changes", "module_todos", "module_deprecations"]
+        return ["main_nf", "meta_yml", "module_todos", "module_deprecations"]
 
     def lint(self, module=None, key=(), all_modules=False, print_results=True, show_passed=False, local=False):
         """

--- a/nf_core/modules/lint/module_changes.py
+++ b/nf_core/modules/lint/module_changes.py
@@ -15,6 +15,8 @@ def module_changes(module_lint_object, module):
     and compares them to the local copies
 
     If the module has a 'git_sha', the file content is checked against this sha
+
+    Only runs when linting a pipeline, not the modules repository
     """
     files_to_check = ["main.nf", "meta.yml"]
 
@@ -49,7 +51,7 @@ def module_changes(module_lint_object, module):
                 remote_copy = r.content.decode("utf-8")
 
                 if local_copy != remote_copy:
-                    module.warned.append(
+                    module.failed.append(
                         (
                             "check_local_copy",
                             "Local copy of module does not match remote",


### PR DESCRIPTION
Revert #1364 which reverted #1357

Brings back a failure instead of a warning if a module doesn't match the remote copy in nf-core/modules. _However_, now this particular lint test is only run when linting a pipeline, not when linting the modules repo.

Should mean that people can now propose changes to modules.. 🙄 

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
