### PR TITLE
Output schema documentation as Markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
     * `input:` / `output:` not being specified in module
     * Allow for containers from other biocontainers resource as defined [here](https://github.com/nf-core/modules/blob/cde237e7cec07798e5754b72aeca44efe89fc6db/modules/cat/fastq/main.nf#L7-L8)
 * Fixed traceback when using `stageAs` syntax as defined [here](https://github.com/nf-core/modules/blob/cde237e7cec07798e5754b72aeca44efe89fc6db/modules/cat/fastq/main.nf#L11)
+* Added `nf-core schema docs` command to output pipline parameter documentation in Markdown format for inclusion in GitHub and other documentation systems ([#741](https://github.com/nf-core/tools/issues/741))
 
 ## [v2.2 - Lead Liger](https://github.com/nf-core/tools/releases/tag/2.2) - [2021-12-14]
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -720,11 +720,9 @@ def docs(schema_path, markdown, force, columns):
     try:
         schema_obj.get_schema_path(schema_path)
         schema_obj.load_schema()
-        try:
-            schema_obj.print_documentation(markdown, force, columns.split(","))
-        except AssertionError as e:
-            log.warning(e)
+        schema_obj.print_documentation(markdown, force, columns.split(","))
     except AssertionError as e:
+        log.error(e)
         sys.exit(1)
 
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -698,6 +698,26 @@ def lint(schema_path):
         sys.exit(1)
 
 
+@schema.command(help_priority=4)
+@click.argument("schema_path", type=click.Path(exists=True), required=True, metavar="<pipeline schema>")
+@click.option("--markdown", type=str, metavar="<filename>", help="File to write documentation to in Markdown format")
+@click.option("--columns", type=str, metavar="<columns_list>", help="Columns to include in the parameter tables", default="parameter,description,type,default,required,hidden")
+def docs(schema_path, markdown, columns):
+    """
+    Outputs parameter documentation for a pipeline schema. 
+    """
+    schema_obj = nf_core.schema.PipelineSchema()
+    try:
+        schema_obj.get_schema_path(schema_path)
+        schema_obj.load_schema()
+        try:
+            schema_obj.print_documentation(markdown, columns)
+        except AssertionError as e:
+            log.warning(e)
+    except AssertionError as e:
+        sys.exit(1)
+
+
 @nf_core_cli.command("bump-version", help_priority=9)
 @click.argument("new_version", required=True, metavar="<new version>")
 @click.option("-d", "--dir", type=click.Path(exists=True), default=".", help="Pipeline directory. Defaults to CWD")

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -701,10 +701,16 @@ def lint(schema_path):
 @schema.command(help_priority=4)
 @click.argument("schema_path", type=click.Path(exists=True), required=True, metavar="<pipeline schema>")
 @click.option("--markdown", type=str, metavar="<filename>", help="File to write documentation to in Markdown format")
-@click.option("--columns", type=str, metavar="<columns_list>", help="CSV list of columns to include in the parameter tables (parameter,description,type,default,required,hidden)", default="parameter,description,type,default,required,hidden")    
+@click.option(
+    "--columns",
+    type=str,
+    metavar="<columns_list>",
+    help="CSV list of columns to include in the parameter tables (parameter,description,type,default,required,hidden)",
+    default="parameter,description,type,default,required,hidden",
+)
 def docs(schema_path, markdown, columns):
     """
-    Outputs parameter documentation for a pipeline schema. 
+    Outputs parameter documentation for a pipeline schema.
     """
     schema_obj = nf_core.schema.PipelineSchema()
     try:

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -701,7 +701,7 @@ def lint(schema_path):
 @schema.command(help_priority=4)
 @click.argument("schema_path", type=click.Path(exists=True), required=True, metavar="<pipeline schema>")
 @click.option("--markdown", type=str, metavar="<filename>", help="File to write documentation to in Markdown format")
-@click.option("--columns", type=str, metavar="<columns_list>", help="Columns to include in the parameter tables", default="parameter,description,type,default,required,hidden")
+@click.option("--columns", type=str, metavar="<columns_list>", help="CSV list of columns to include in the parameter tables (parameter,description,type,default,required,hidden)", default="parameter,description,type,default,required,hidden")    
 def docs(schema_path, markdown, columns):
     """
     Outputs parameter documentation for a pipeline schema. 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -700,8 +700,9 @@ def lint(schema_path):
 
 @schema.command(help_priority=4)
 @click.argument("schema_path", type=click.Path(exists=True), required=True, metavar="<pipeline schema>")
+@click.option("-o", "--output", type=str, metavar="<filename>", help="Output filename. Defaults to standard out.")
 @click.option(
-    "-m", "--markdown", type=str, metavar="<filename>", help="File to write documentation to in Markdown format"
+    "-x", "--format", type=click.Choice(["markdown", "html"]), default="markdown", help="Format to output docs in."
 )
 @click.option("-f", "--force", is_flag=True, default=False, help="Overwrite existing files")
 @click.option(
@@ -712,7 +713,7 @@ def lint(schema_path):
     help="CSV list of columns to include in the parameter tables (parameter,description,type,default,required,hidden)",
     default="parameter,description,type,default,required,hidden",
 )
-def docs(schema_path, markdown, force, columns):
+def docs(schema_path, output, format, force, columns):
     """
     Outputs parameter documentation for a pipeline schema.
     """
@@ -720,7 +721,7 @@ def docs(schema_path, markdown, force, columns):
     try:
         schema_obj.get_schema_path(schema_path)
         schema_obj.load_schema()
-        schema_obj.print_documentation(markdown, force, columns.split(","))
+        schema_obj.print_documentation(output, format, force, columns.split(","))
     except AssertionError as e:
         log.error(e)
         sys.exit(1)

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -734,7 +734,7 @@ def lint(schema_path):
 
 
 @schema.command()
-@click.argument("schema_path", type=click.Path(exists=True), required=True, metavar="<pipeline schema>")
+@click.argument("schema_path", type=click.Path(exists=True), required=False, metavar="<pipeline schema>")
 @click.option("-o", "--output", type=str, metavar="<filename>", help="Output filename. Defaults to standard out.")
 @click.option(
     "-x", "--format", type=click.Choice(["markdown", "html"]), default="markdown", help="Format to output docs in."
@@ -754,6 +754,12 @@ def docs(schema_path, output, format, force, columns):
     """
     schema_obj = nf_core.schema.PipelineSchema()
     try:
+        # Assume we're in a pipeline dir root if schema path not set
+        if schema_path is None:
+            schema_path = "nextflow_schema.json"
+            assert os.path.exists(
+                schema_path
+            ), "Could not find 'nextflow_schema.json' in current directory. Please specify a path."
         schema_obj.get_schema_path(schema_path)
         schema_obj.load_schema()
         schema_obj.print_documentation(output, format, force, columns.split(","))

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -700,15 +700,19 @@ def lint(schema_path):
 
 @schema.command(help_priority=4)
 @click.argument("schema_path", type=click.Path(exists=True), required=True, metavar="<pipeline schema>")
-@click.option("--markdown", type=str, metavar="<filename>", help="File to write documentation to in Markdown format")
 @click.option(
+    "-m", "--markdown", type=str, metavar="<filename>", help="File to write documentation to in Markdown format"
+)
+@click.option("-f", "--force", is_flag=True, default=False, help="Overwrite existing files")
+@click.option(
+    "-c",
     "--columns",
     type=str,
     metavar="<columns_list>",
     help="CSV list of columns to include in the parameter tables (parameter,description,type,default,required,hidden)",
     default="parameter,description,type,default,required,hidden",
 )
-def docs(schema_path, markdown, columns):
+def docs(schema_path, markdown, force, columns):
     """
     Outputs parameter documentation for a pipeline schema.
     """
@@ -717,7 +721,7 @@ def docs(schema_path, markdown, columns):
         schema_obj.get_schema_path(schema_path)
         schema_obj.load_schema()
         try:
-            schema_obj.print_documentation(markdown, columns)
+            schema_obj.print_documentation(markdown, force, columns.split(","))
         except AssertionError as e:
             log.warning(e)
     except AssertionError as e:

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -427,7 +427,7 @@ class PipelineSchema(object):
         else:
             self.print_documentation_markdown(sys.stdout, columns)
         
-    def print_documentation_markdown(self, file, columns_csv):
+    def print_documentation_markdown(self, file, columns_csv='parameter,description,type,default,required,hidden'):
         """
         Prints documentation for the schema in Markdown format to the given file-like object.
         """

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -433,22 +433,24 @@ class PipelineSchema(object):
         """
         columns = columns_csv.split(",")
         out = lambda s: print(s, end="", file=file)
-        out(f"# {self.schema['title']}\n")
+        out(f"# {self.schema['title']}\n\n")
         out(f"{self.schema['description']}\n")
         for d_key, definition in self.schema.get("definitions", {}).items():
             out(f"\n## {definition.get('title', {})}")
-            out(f"\n{definition.get('description', '')}")
+            out(f"\n\n{definition.get('description', '')}")
             out("\n\n")
-            out("".join([f"| {column.title()} " for column in columns]))
+            out("".join([f"|{column.title()}" for column in columns]))
             out("\n")
             out("".join([f"|-----------" for columns in columns]))
             out("\n")
             for p_key, param in definition.get("properties", {}).items():
                 for column in columns:
                     if column == "parameter":
-                        out(f"| {p_key} ")
+                        out(f"|`{p_key}`")
+                    elif column == "type":
+                        out(f"|`{param.get('type', '')}`")
                     else:
-                        out(f"| {param.get(column, '')} ")
+                        out(f"|{param.get(column, '')}")
                 out("\n")
 
     def make_skeleton_schema(self):

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -420,36 +420,36 @@ class PipelineSchema(object):
         """
         Prints documentation for the schema.
         """
-        if (markdown):
-            with open(markdown, 'w') as file:
+        if markdown:
+            with open(markdown, "w") as file:
                 self.print_documentation_markdown(file, columns)
                 print(f"Documentation written to {markdown}")
         else:
             self.print_documentation_markdown(sys.stdout, columns)
-        
-    def print_documentation_markdown(self, file, columns_csv='parameter,description,type,default,required,hidden'):
+
+    def print_documentation_markdown(self, file, columns_csv="parameter,description,type,default,required,hidden"):
         """
         Prints documentation for the schema in Markdown format to the given file-like object.
         """
-        columns = columns_csv.split(',')
-        out = lambda s: print(s, end='', file=file)
+        columns = columns_csv.split(",")
+        out = lambda s: print(s, end="", file=file)
         out(f"# {self.schema['title']}\n")
         out(f"{self.schema['description']}\n")
         for d_key, definition in self.schema.get("definitions", {}).items():
             out(f"\n## {definition.get('title', {})}")
             out(f"\n{definition.get('description', '')}")
-            out('\n\n')
-            out(''.join([f"| {column.title()} " for column in columns]))
-            out('\n')
-            out(''.join([f"|-----------" for columns in columns]))
-            out('\n')
+            out("\n\n")
+            out("".join([f"| {column.title()} " for column in columns]))
+            out("\n")
+            out("".join([f"|-----------" for columns in columns]))
+            out("\n")
             for p_key, param in definition.get("properties", {}).items():
                 for column in columns:
-                    if (column == "parameter"):
+                    if column == "parameter":
                         out(f"| {p_key} ")
                     else:
                         out(f"| {param.get(column, '')} ")
-                out('\n')            
+                out("\n")
 
     def make_skeleton_schema(self):
         """Make a new pipeline schema from the template"""

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -417,7 +417,7 @@ class PipelineSchema(object):
         output_fn=None,
         format="markdown",
         force=False,
-        columns=["parameter", "description", "type,", "efault", "required", "hidden"],
+        columns=["parameter", "description", "type,", "default", "required", "hidden"],
     ):
         """
         Prints documentation for the schema.
@@ -456,6 +456,10 @@ class PipelineSchema(object):
                 for column in columns:
                     if column == "parameter":
                         out += f"| `{p_key}` "
+                    elif column == "description":
+                        out += f"| {param.get('description', '')} "
+                        if param.get("help_text", "") != "":
+                            out += f"<details><summary>Help</summary><small>{param['help_text']}</small></details>"
                     elif column == "type":
                         out += f"| `{param.get('type', '')}` "
                     else:

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -416,6 +416,41 @@ class PipelineSchema(object):
                 desc_attr, self.schema["description"]
             )
 
+    def print_documentation(self, markdown, columns):
+        """
+        Prints documentation for the schema.
+        """
+        if (markdown):
+            with open(markdown, 'w') as file:
+                self.print_documentation_markdown(file, columns)
+                print(f"Documentation written to {markdown}")
+        else:
+            self.print_documentation_markdown(sys.stdout, columns)
+        
+    def print_documentation_markdown(self, file, columns_csv):
+        """
+        Prints documentation for the schema in Markdown format to the given file-like object.
+        """
+        columns = columns_csv.split(',')
+        out = lambda s: print(s, end='', file=file)
+        out(f"# {self.schema['title']}\n")
+        out(f"{self.schema['description']}\n")
+        for d_key, definition in self.schema.get("definitions", {}).items():
+            out(f"\n## {definition.get('title', {})}")
+            out(f"\n{definition.get('description', '')}")
+            out('\n\n')
+            out(''.join([f"| {column.title()} " for column in columns]))
+            out('\n')
+            out(''.join([f"|-----------" for columns in columns]))
+            out('\n')
+            for p_key, param in definition.get("properties", {}).items():
+                for column in columns:
+                    if (column == "parameter"):
+                        out(f"| {p_key} ")
+                    else:
+                        out(f"| {param.get(column, '')} ")
+                out('\n')            
+
     def make_skeleton_schema(self):
         """Make a new pipeline schema from the template"""
         self.schema_from_scratch = True

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -445,6 +445,7 @@ class PipelineSchema(object):
         """
         out = f"# {self.schema['title']}\n\n"
         out += f"{self.schema['description']}\n"
+        # Grouped parameters
         for definition in self.schema.get("definitions", {}).values():
             out += f"\n## {definition.get('title', {})}\n\n"
             out += f"{definition.get('description', '')}\n\n"
@@ -465,7 +466,30 @@ class PipelineSchema(object):
                     else:
                         out += f"| {param.get(column, '')} "
                 out += "|\n"
-        return out
+
+        # Top-level ungrouped parameters
+        if len(self.schema.get("properties", {})) > 0:
+            out += f"\n## Other parameters\n\n"
+            out += "".join([f"| {column.title()} " for column in columns])
+            out += "|\n"
+            out += "".join([f"|-----------" for columns in columns])
+            out += "|\n"
+
+            for p_key, param in self.schema.get("properties", {}).items():
+                for column in columns:
+                    if column == "parameter":
+                        out += f"| `{p_key}` "
+                    elif column == "description":
+                        out += f"| {param.get('description', '')} "
+                        if param.get("help_text", "") != "":
+                            out += f"<details><summary>Help</summary><small>{param['help_text']}</small></details>"
+                    elif column == "type":
+                        out += f"| `{param.get('type', '')}` "
+                    else:
+                        out += f"| {param.get(column, '')} "
+                out += "|\n"
+
+            return out
 
     def markdown_to_html(self, markdown_str):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ click
 GitPython
 jinja2
 jsonschema>=3.0
+markdown>=3.3
 packaging
 prompt_toolkit>=3.0.3
 pyyaml

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -95,6 +95,20 @@ class TestSchema(unittest.TestCase):
         self.schema_obj.schema_filename = self.template_schema
         self.schema_obj.load_schema()
 
+    def test_schema_docs(self):
+        """Try to generate Markdown docs for a schema from a file"""
+        self.schema_obj.schema_filename = self.template_schema
+        self.schema_obj.load_schema()
+        import io
+        f = io.StringIO('')
+        self.schema_obj.print_documentation_markdown(f)
+        docs = f.getvalue()
+        assert self.schema_obj.schema['title'] in docs
+        assert self.schema_obj.schema['description'] in docs
+        for d_key, definition in self.schema_obj.schema.get("definitions", {}).items():
+            assert definition['title'] in docs
+            assert definition['description'] in docs
+            
     @with_temporary_file
     def test_save_schema(self, tmp_file):
         """Try to save a schema"""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -100,15 +100,16 @@ class TestSchema(unittest.TestCase):
         self.schema_obj.schema_filename = self.template_schema
         self.schema_obj.load_schema()
         import io
-        f = io.StringIO('')
+
+        f = io.StringIO("")
         self.schema_obj.print_documentation_markdown(f)
         docs = f.getvalue()
-        assert self.schema_obj.schema['title'] in docs
-        assert self.schema_obj.schema['description'] in docs
+        assert self.schema_obj.schema["title"] in docs
+        assert self.schema_obj.schema["description"] in docs
         for d_key, definition in self.schema_obj.schema.get("definitions", {}).items():
-            assert definition['title'] in docs
-            assert definition['description'] in docs
-            
+            assert definition["title"] in docs
+            assert definition["description"] in docs
+
     @with_temporary_file
     def test_save_schema(self, tmp_file):
         """Try to save a schema"""


### PR DESCRIPTION
Per discussion in [Slack](https://nfcore.slack.com/archives/CUC8PPDL2/p1641920634004300) and partially addressing #741, I added a `nf-core schema docs` command which takes any nextflow_schema.json and generates Markdown documentation for it. 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated

## Example Output (eager pipeline)

# nf-core/eager pipeline parameters

A fully reproducible and state-of-the-art ancient DNA analysis pipeline

## Input/output options

Define where the pipeline should find input data, and additional metadata.

|Parameter|Description|Type|Default|Required|Hidden
|-----------|-----------|-----------|-----------|-----------|-----------
|`input`|Either paths or URLs to FASTQ/BAM data (must be surrounded with quotes). For paired end data, the path must use '{1,2}' notation to specify read pairs. Alternatively, a path to a TSV file (ending .tsv) containing file paths and sequencing/sample metadata. Allows for merging of multiple lanes/libraries/samples. Please see documentation for template.|`string`|||
|`udg_type`|Specifies whether you have UDG treated libraries. Set to 'half' for partial treatment, or 'full' for UDG. If not set, libraries are assumed to have no UDG treatment ('none'). Not required for TSV input.|`string`|none||
|`single_stranded`|Specifies that libraries are single stranded. Always affects MALTExtract but will be ignored by pileupCaller with TSV input. Not required for TSV input.|`boolean`|||
|`single_end`|Specifies that the input is single end reads. Not required for TSV input.|`boolean`|||
|`colour_chemistry`|Specifies which Illumina sequencing chemistry was used. Used to inform whether to poly-G trim if turned on (see below). Not required for TSV input. Options: 2, 4.|`integer`|4||
|`bam`|Specifies that the input is in BAM format. Not required for TSV input.|`boolean`|||
