### PR TITLE
Add Gitpod environment to nf-core tools

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,19 @@
+FROM gitpod/workspace-full
+
+USER root
+
+# Install Conda
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && \
+    rm Miniconda3-latest-Linux-x86_64.sh
+
+ENV PATH="/opt/conda/bin:$PATH"
+
+RUN chown -R gitpod:gitpod /opt/conda
+
+USER gitpod
+
+# Install nextflow, nf-core, Mamba, and pytest-workflow
+RUN conda install nextflow nf-core pytest-workflow mamba -n base -c conda-forge -c bioconda && \
+    nextflow self-update && \
+    conda clean --all -f -y

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,18 @@
+image:
+  file: .gitpod.Dockerfile
+github:
+  prebuilds:
+    # enable for the default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: false
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: false
+    # add a check to pull requests (defaults to true)
+    addCheck: prevent-merge-on-error
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: false
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: false


### PR DESCRIPTION
Adds a gitpod environment with 

- Nextflow
- nf-core tools
- pytest-workflow
- Docker
- Conda
- Mamba

Singularity might be possible through the docker image: https://github.com/kaczmarj/singularity-in-docker

[My fork](https://gitpod.io/#https://github.com/mahesh-panchal/tools) has prebuilds enabled. 
Check if it meets your needs @drpatelh . We can then enable prebuilds on the nf-core repo.

I've not added extensions, but check the extensions tab if there's something you think might be useful. 