### PR TITLE
WIP: MultiQC table of all parameters

### DIFF
--- a/nf_core/pipeline-template/assets/multiqc_config.yaml
+++ b/nf_core/pipeline-template/assets/multiqc_config.yaml
@@ -3,9 +3,7 @@ report_comment: >
     analysis pipeline. For information about how to interpret these results, please see the
     <a href="https://nf-co.re/{{ short_name }}" target="_blank">documentation</a>.
 report_section_order:
-    software_versions:
+    nf-core-{{short_name}}_run_details:
         order: -1000
-    {{ name.lower().replace('/', '-') }}-summary:
-        order: -1001
 
 export_plots: true

--- a/nf_core/pipeline-template/lib/WorkflowPipeline.groovy
+++ b/nf_core/pipeline-template/lib/WorkflowPipeline.groovy
@@ -33,8 +33,8 @@ class Workflow{{ short_name[0]|upper }}{{ short_name[1:] }} {
             }
         }
 
-        String yaml_file_text  = "id: '${workflow.manifest.name.replace('/','-')}-summary'\n"
-        yaml_file_text        += "description: ' - this information is collected when the pipeline is started.'\n"
+        String yaml_file_text  = "parent_id: '${workflow.manifest.name.replace('/','-')}_run_details'\n"
+        yaml_file_text        += "id: '${workflow.manifest.name.replace('/','-')}_run_summary'\n"
         yaml_file_text        += "section_name: '${workflow.manifest.name} Workflow Summary'\n"
         yaml_file_text        += "section_href: 'https://github.com/${workflow.manifest.name}'\n"
         yaml_file_text        += "plot_type: 'html'\n"

--- a/nf_core/pipeline-template/modules/nf-core/modules/custom/dumpsoftwareversions/templates/dumpsoftwareversions.py
+++ b/nf_core/pipeline-template/modules/nf-core/modules/custom/dumpsoftwareversions/templates/dumpsoftwareversions.py
@@ -72,11 +72,13 @@ versions_by_module["Workflow"] = {
 }
 
 versions_mqc = {
-    "id": "software_versions",
-    "section_name": "${workflow.manifest.name} Software Versions",
+    "parent_id": "${workflow.manifest.name.replace('/','-')}_run_details",
+    "parent_name": "${workflow.manifest.name} Run Details",
+    "section_id": "sofware_versions",
+    "section_name": "Software Versions",
     "section_href": "https://github.com/${workflow.manifest.name}",
     "plot_type": "html",
-    "description": "are collected at run time from the software output.",
+    "description": "These software version numbers are collected directly from each tool, at run time.",
     "data": _make_versions_html(versions_by_module),
 }
 

--- a/nf_core/pipeline-template/workflows/pipeline.nf
+++ b/nf_core/pipeline-template/workflows/pipeline.nf
@@ -4,7 +4,7 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-def summary_params = NfcoreSchema.paramsSummaryMap(workflow, params)
+def (summary_params, params_mqc_file) = NfcoreSchema.paramsSummaryMap(workflow, params)
 
 // Validate input parameters
 Workflow{{ short_name[0]|upper }}{{ short_name[1:] }}.initialise(params, log)
@@ -95,6 +95,7 @@ workflow {{ short_name|upper }} {
     ch_multiqc_files = ch_multiqc_files.mix(ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
     ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
     ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]}.ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(Channel.from(file(params_mqc_file)))
 
     MULTIQC (
         ch_multiqc_files.collect()


### PR DESCRIPTION
Following on from a discussion with @jfy133 about his PR: https://github.com/nf-core/modules/pull/1161

I thought that it should be possible / cleaner to create a MultiQC file with a table of all parameters in the pipeline `
lib` code that already handles pipeline paramters. I whipped up this quick proof of concept around that for discusssion.

Only _after_ writing the code did I realise that we already have a very very similar YAML output showing parameters that vary from the defaults 🤦🏻 This was held in another file and I only saw the output when I ran the full test pipeline. We probably want to merge these two sections I guess. Or at least have a think about whether we want both.

Example MultiQC report: [multiqc_report.html.zip](https://github.com/nf-core/tools/files/7971921/multiqc_report.html.zip)

Example JSON output: [pipeline_params7314521067081776068_mqc.json.zip](https://github.com/nf-core/tools/files/7971953/pipeline_params7314521067081776068_mqc.json.zip)

<details>

<summary>JSON file contents</summary>

```json
{
  "parent_name": "nf-core/test Run Details",
  "headers": {
    "default": {
      "format": "{}",
      "description": "Default value in the pipeline",
      "scale": false,
      "title": "Default"
    },
    "value": {
      "format": "{}",
      "description": "Defined value in the pipeline run",
      "scale": false,
      "title": "Value"
    }
  },
  "data": {
    "custom_config_base": {
      "default": "<code>https://raw.githubusercontent.com/nf-core/configs/master</code>",
      "value": "<code>https://raw.githubusercontent.com/nf-core/configs/master</code>"
    },
    "multiqc_title": {
      "default": "<code>null</code>",
      "value": "<code>null</code>"
    },
    "plaintext_email": {
      "default": "<code>null</code>",
      "value": "<code>false</code>"
    },
    "monochrome_logs": {
      "default": "<code>null</code>",
      "value": "<code>false</code>"
    },
    "max_cpus": {
      "default": "<code>16</code>",
      "value": "<code>2</code>"
    },
    "multiqc_config": {
      "default": "<code>null</code>",
      "value": "<code>null</code>"
    },
    "fasta": {
      "default": "<code>null</code>",
      "value": "<code>s3://ngi-igenomes/igenomes/Saccharomyces_cerevisiae/Ensembl/R64-1-1/Sequence/WholeGenomeFasta/genome.fa</code>"
    },
    "custom_config_version": {
      "default": "<code>master</code>",
      "value": "<code>master</code>"
    },
    "max_memory": {
      "default": "<code>128.GB</code>",
      "value": "<code>6.GB</code>"
    },
    "max_multiqc_email_size": {
      "default": "<code>25.MB</code>",
      "value": "<code>25.MB</code>"
    },
    "max_time": {
      "default": "<code>240.h</code>",
      "value": "<code>6.h</code>"
    },
    "email": {
      "default": "<code>null</code>",
      "value": "<code>null</code>"
    },
    "tracedir": {
      "default": "<code>./results/pipeline_info</code>",
      "value": "<code>./results/pipeline_info</code>"
    },
    "config_profile_description": {
      "default": "<code>null</code>",
      "value": "<code>Minimal test dataset to check pipeline function</code>"
    },
    "config_profile_contact": {
      "default": "<code>null</code>",
      "value": "<code>null</code>"
    },
    "validate_params": {
      "default": "<code>true</code>",
      "value": "<code>true</code>"
    },
    "email_on_fail": {
      "default": "<code>null</code>",
      "value": "<code>null</code>"
    },
    "igenomes_ignore": {
      "default": "<code>null</code>",
      "value": "<code>false</code>"
    },
    "outdir": {
      "default": "<code>./results</code>",
      "value": "<code>./results</code>"
    },
    "input": {
      "default": "<code>null</code>",
      "value": "<code>https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/samplesheet/samplesheet_test_illumina_amplicon.csv</code>"
    },
    "genome": {
      "default": "<code>null</code>",
      "value": "<code>R64-1-1</code>"
    },
    "help": {
      "default": "<code>null</code>",
      "value": "<code>false</code>"
    },
    "igenomes_base": {
      "default": "<code>s3://ngi-igenomes/igenomes</code>",
      "value": "<code>s3://ngi-igenomes/igenomes</code>"
    },
    "config_profile_name": {
      "default": "<code>null</code>",
      "value": "<code>Test profile</code>"
    },
    "show_hidden_params": {
      "default": "<code>null</code>",
      "value": "<code>false</code>"
    },
    "enable_conda": {
      "default": "<code>null</code>",
      "value": "<code>false</code>"
    },
    "config_profile_url": {
      "default": "<code>null</code>",
      "value": "<code>null</code>"
    }
  },
  "parent_id": "nf-core-test_run_details",
  "section_name": "Pipeline Parameters",
  "description": "Lists all pipeline parameters used to control how the pipeline was run, including those not modified from the defaults.",
  "id": "nextflow_params",
  "pconfig": {
    "namespace": "Nextflow Pipeline",
    "id": "nextflow_params_table",
    "title": "Nextflow Pipeline Parameters"
  },
  "plot_type": "table"
}

```

</details>

I've been testing with the following:
```bash
nf-core create -n test -d testing -a tester && nextflow run nf-core-test/ -profile test,docker -resume
```

I'd appreciate feedback on:

* Concept and location of code
* Whether to keep as-is, or merge with the existing summary
* Improvements for the table

NB: There is also some small improvements to the existing MultiQC sections that we can keep either way - grouping multiple subsections into a single report section. This is a relatively new feature for MultiQC Custom Content.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
