### PR TITLE
modules list local - handle DSL1 pipelines

### DIFF
--- a/nf_core/modules/module_utils.py
+++ b/nf_core/modules/module_utils.py
@@ -131,6 +131,9 @@ def create_modules_json(pipeline_dir):
     modules_json = {"name": pipeline_name.strip("'"), "homePage": pipeline_url.strip("'"), "repos": dict()}
     modules_dir = f"{pipeline_dir}/modules"
 
+    if not os.path.exists(modules_dir):
+        raise UserWarning(f"Can't find a ./modules directory. Is this a DSL2 pipeline?")
+
     # Extract all modules repos in the pipeline directory
     repo_names = [
         f"{user_name}/{repo_name}"


### PR DESCRIPTION
Handle a missing `modules` directory when running `nf-core modules list local` in a DSL1 pipeline. Give a nice error message instead of a big stack trace.

## PR checklist

 - [ ] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
