### PR TITLE
Rewrite modules create repo type check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@
 * Removed mention of `--singularity_pull_docker_container` in pipeline `README.md`
 * Replaced equals with ~ in nf-core headers, to stop false positive unresolved conflict errors when committing with VSCode.
 * Add retry strategy for AWS megatests after releasing [nf-core/tower-action v2.2](https://github.com/nf-core/tower-action/releases/tag/v2.2)
+* Added `.nf-core.yml` file with `repository_type: pipeline` for modules commands
 
 ## General
 
 * Updated `nf-core download` to work with latest DSL2 syntax for containers ([#1379](https://github.com/nf-core/tools/issues/1379))
+* Made `nf-core modules create` detect repository type with explicit `.nf-core.yml` or `--repo-type`, instead of random readme stuff ([#1391](https://github.com/nf-core/tools/pull/1391))
 
 ### Modules
 

--- a/README.md
+++ b/README.md
@@ -925,7 +925,7 @@ github.com:
     git_protocol: <ssh or https are valid choices>
 ```
 
-The easiest way to create this configuration file is through *GitHub CLI*: follow
+The easiest way to create this configuration file is through _GitHub CLI_: follow
 its [installation instructions](https://cli.github.com/manual/installation)
 and then call:
 
@@ -1116,11 +1116,17 @@ This command creates a new nf-core module from the nf-core module template.
 This ensures that your module follows the nf-core guidelines.
 The template contains extensive `TODO` messages to walk you through the changes you need to make to the template.
 
-You can create a new module using `nf-core modules create`. This will create the new module in the current working directory. To specify another directory, use `--dir <directory>`.
+You can create a new module using `nf-core modules create`.
 
-If writing a module for the shared [nf-core/modules](https://github.com/nf-core/modules) repository, the `<directory>` argument should be the path to the clone of your fork of the modules repository.
+This command can be used both when writing a module for the shared [nf-core/modules](https://github.com/nf-core/modules) repository,
+and also when creating local modules for a pipeline.
 
-Alternatively, if writing a more niche module that does not make sense to share, `<directory>` should be the path to your pipeline.
+Which type of repository you are working in is detected by the `repository_type` flag in a `.nf-core.yml` file in the root directory,
+set to either `pipeline` or `modules`.
+The command will automatically look through parent directories for this file to set the root path, so that you can run the command in a subdirectory.
+It will start in the current working directory, or whatever is specified with `--dir <directory>`.
+
+If you do not have a `.nf-core.yml` file you can specify the repository type with the `--repo-type` flag.
 
 The `nf-core modules create` command will prompt you with the relevant questions in order to create all of the necessary module files.
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -498,7 +498,8 @@ def remove(ctx, dir, tool):
 @click.option("-n", "--no-meta", is_flag=True, default=False, help="Don't use meta map for sample information")
 @click.option("-f", "--force", is_flag=True, default=False, help="Overwrite any files if they already exist")
 @click.option("-c", "--conda-name", type=str, default=None, help="Name of the conda package to use")
-def create_module(ctx, tool, dir, author, label, meta, no_meta, force, conda_name):
+@click.option("-r", "--repo-type", type=click.Choice(["pipeline", "modules"]), default=None, help="Type of repository")
+def create_module(ctx, tool, dir, author, label, meta, no_meta, force, conda_name, repo_type):
     """
     Create a new DSL2 module from the nf-core template.
 
@@ -519,7 +520,7 @@ def create_module(ctx, tool, dir, author, label, meta, no_meta, force, conda_nam
 
     # Run function
     try:
-        module_create = nf_core.modules.ModuleCreate(dir, tool, author, label, has_meta, force, conda_name)
+        module_create = nf_core.modules.ModuleCreate(dir, tool, author, label, has_meta, force, conda_name, repo_type)
         module_create.create()
     except UserWarning as e:
         log.critical(e)

--- a/nf_core/modules/bump_versions.py
+++ b/nf_core/modules/bump_versions.py
@@ -15,8 +15,6 @@ from rich.table import Table
 from rich.markdown import Markdown
 import rich
 from nf_core.utils import rich_force_colors
-import sys
-import yaml
 
 import nf_core.utils
 import nf_core.modules.module_utils
@@ -55,7 +53,7 @@ class ModuleVersionBumper(ModuleCommand):
         self.show_up_to_date = show_uptodate
 
         # Verify that this is not a pipeline
-        repo_type = nf_core.modules.module_utils.get_repo_type(self.dir)
+        self.dir, repo_type = nf_core.modules.module_utils.get_repo_type(self.dir)
         if not repo_type == "modules":
             raise nf_core.modules.module_utils.ModuleException(
                 "This command only works on the nf-core/modules repository, not on pipelines!"

--- a/nf_core/modules/bump_versions.py
+++ b/nf_core/modules/bump_versions.py
@@ -64,7 +64,7 @@ class ModuleVersionBumper(ModuleCommand):
         # Get list of all modules
         _, nfcore_modules = nf_core.modules.module_utils.get_installed_modules(self.dir)
 
-        # Load the .nf-core-tools.config
+        # Load the .nf-core.yml config
         self.tools_config = nf_core.utils.load_tools_config(self.dir)
 
         # Prompt for module or all

--- a/nf_core/modules/lint/__init__.py
+++ b/nf_core/modules/lint/__init__.py
@@ -71,7 +71,7 @@ class ModuleLint(ModuleCommand):
     def __init__(self, dir):
         self.dir = dir
         try:
-            self.dir, self.repo_type = nf_core.modules.module_utils.get_repo_type(self.dir, self.repo_type)
+            self.dir, self.repo_type = nf_core.modules.module_utils.get_repo_type(self.dir)
         except LookupError as e:
             raise UserWarning(e)
 

--- a/nf_core/modules/lint/__init__.py
+++ b/nf_core/modules/lint/__init__.py
@@ -71,7 +71,7 @@ class ModuleLint(ModuleCommand):
     def __init__(self, dir):
         self.dir = dir
         try:
-            self.repo_type = nf_core.modules.module_utils.get_repo_type(self.dir)
+            self.dir, self.repo_type = nf_core.modules.module_utils.get_repo_type(self.dir, self.repo_type)
         except LookupError as e:
             raise UserWarning(e)
 

--- a/nf_core/modules/module_utils.py
+++ b/nf_core/modules/module_utils.py
@@ -337,24 +337,49 @@ def get_installed_modules(dir, repo_type="modules"):
     return local_modules, nfcore_modules
 
 
-def get_repo_type(dir):
+def get_repo_type(dir, repo_type=None):
     """
     Determine whether this is a pipeline repository or a clone of
     nf-core/modules
     """
     # Verify that the pipeline dir exists
     if dir is None or not os.path.exists(dir):
-        raise LookupError("Could not find directory: {}".format(dir))
+        raise UserWarning(f"Could not find directory: {dir}")
 
-    # Determine repository type
-    if os.path.exists(os.path.join(dir, "README.md")):
-        with open(os.path.join(dir, "README.md")) as fh:
-            if fh.readline().rstrip().startswith("# ![nf-core/modules]"):
-                return "modules"
-            else:
-                return "pipeline"
-    else:
-        raise LookupError("Could not determine repository type of '{}'".format(dir))
+    # Try to find the root directory
+    base_dir = os.path.abspath(dir)
+    config_path_yml = os.path.join(base_dir, ".nf-core.yml")
+    config_path_yaml = os.path.join(base_dir, ".nf-core.yaml")
+    while (
+        not os.path.exists(config_path_yml)
+        and not os.path.exists(config_path_yaml)
+        and base_dir != os.path.dirname(base_dir)
+    ):
+        base_dir = os.path.dirname(base_dir)
+        config_path_yml = os.path.join(base_dir, ".nf-core.yml")
+        config_path_yaml = os.path.join(base_dir, ".nf-core.yaml")
+        # Reset dir if we found the config file (will be an absolute path)
+        if os.path.exists(config_path_yml) or os.path.exists(config_path_yaml):
+            dir = base_dir
+
+    # Figure out the repository type from the .nf-core.yml config file if we can
+    tools_config = nf_core.utils.load_tools_config(dir)
+    if tools_config.get("repository_type") in ["pipeline", "modules"]:
+        if repo_type is not None and repo_type != tools_config["repository_type"]:
+            raise UserWarning(
+                f"'--repo-type {repo_type}' conflicts with [i][red]repository_type[/]: [blue]pipeline[/][/] in '{os.path.relpath(config_path_yml)}'"
+            )
+        return [dir, tools_config["repository_type"]]
+
+    # Could be set on the command line - throw an error if not
+    if not repo_type:
+        raise UserWarning(
+            f"Can't find a '.nf-core.yml' file with 'repository_type' set to 'pipeline' or 'modules': '{dir}'"
+            "\nPlease use the '--repo-type' flag or create '.nf-core.yml'"
+        )
+
+    # It was set on the command line, return what we were given
+    return [dir, repo_type]
 
 
 def verify_pipeline_dir(dir):

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -29,7 +29,7 @@ class ModuleCommand:
         self.module_names = []
         try:
             if self.dir:
-                self.repo_type = nf_core.modules.module_utils.get_repo_type(self.dir)
+                self.dir, self.repo_type = nf_core.modules.module_utils.get_repo_type(self.dir)
             else:
                 self.repo_type = None
         except LookupError as e:

--- a/nf_core/pipeline-template/.nf-core.yml
+++ b/nf_core/pipeline-template/.nf-core.yml
@@ -1,0 +1,1 @@
+repository_type: pipeline

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -19,8 +19,8 @@ def create_modules_repo_dummy(tmp_dir):
     os.makedirs(os.path.join(root_dir, "tests", "config"))
     with open(os.path.join(root_dir, "tests", "config", "pytest_modules.yml"), "w") as fh:
         fh.writelines(["test:", "\n  - modules/test/**", "\n  - tests/modules/test/**"])
-    with open(os.path.join(root_dir, "README.md"), "w") as fh:
-        fh.writelines(["# ![nf-core/modules](docs/images/nfcore-modules_logo.png)", "\n"])
+    with open(os.path.join(root_dir, ".nf-core.yml"), "w") as fh:
+        fh.writelines(["repository_type: modules", "\n"])
 
     # bpipe is a valid package on bioconda that is very unlikely to ever be added to nf-core/modules
     module_create = nf_core.modules.ModuleCreate(root_dir, "bpipe/test", "@author", "process_medium", False, False)
@@ -47,15 +47,10 @@ class TestModules(unittest.TestCase):
         self.mods_install = nf_core.modules.ModuleInstall(self.pipeline_dir, prompt=False, force=True)
         self.mods_install_alt = nf_core.modules.ModuleInstall(self.pipeline_dir, prompt=True, force=True)
 
-        # TODO Remove comments once external repository to have same structure as nf-core/modules
-        # self.mods_install_alt.modules_repo = nf_core.modules.ModulesRepo(repo="ewels/nf-core-modules", branch="master")
-
         # Set up remove objects
         print("Setting up remove objects")
         self.mods_remove = nf_core.modules.ModuleRemove(self.pipeline_dir)
-        self.mods_remove_alt = nf_core.modules.ModuleRemove(self.pipeline_dir)
-        # TODO Remove comments once external repository to have same structure as nf-core/modules
-        # self.mods_remove_alt.modules_repo = nf_core.modules.ModulesRepo(repo="ewels/nf-core-modules", branch="master")
+        self.mods_remove_alt = nf_core.modules.ModuleRemove(self.pipeline_dir
 
         # Set up the nf-core/modules repo dummy
         self.nfcore_modules = create_modules_repo_dummy(self.tmp_dir)

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -50,7 +50,7 @@ class TestModules(unittest.TestCase):
         # Set up remove objects
         print("Setting up remove objects")
         self.mods_remove = nf_core.modules.ModuleRemove(self.pipeline_dir)
-        self.mods_remove_alt = nf_core.modules.ModuleRemove(self.pipeline_dir
+        self.mods_remove_alt = nf_core.modules.ModuleRemove(self.pipeline_dir)
 
         # Set up the nf-core/modules repo dummy
         self.nfcore_modules = create_modules_repo_dummy(self.tmp_dir)


### PR DESCRIPTION
As discussed on Slack, it's a fairly frequent problem for users to struggle with creating modules due to:

* not running in the root repo directory
* the automatic detection of repo type not working (eg. custom repos for modules)
* the automatic detection breaking / not working (eg. when we added a `main.nf` to nf-core/modules)

Here I've introduced more explicit declaration of the repo type:

* Use `.nf-core.yml` file if we can find it, with `repository_type` key
* Traverse parent directories to look for this file, reset target directory if found (so that we can run from a nested directory)
* Add command line `--repo-type` flag to specify repo type if no `.nf-core.yml` file available

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
