### PR TITLE
Allow conditional process execution from configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
     * `input:` / `output:` not being specified in module
     * Allow for containers from other biocontainers resource as defined [here](https://github.com/nf-core/modules/blob/cde237e7cec07798e5754b72aeca44efe89fc6db/modules/cat/fastq/main.nf#L7-L8)
 * Fixed traceback when using `stageAs` syntax as defined [here](https://github.com/nf-core/modules/blob/cde237e7cec07798e5754b72aeca44efe89fc6db/modules/cat/fastq/main.nf#L11)
+* Allow conditional process execution from the configuration file ([#1393](https://github.com/nf-core/tools/pull/1393))
 
 ## [v2.2 - Lead Liger](https://github.com/nf-core/tools/releases/tag/2.2) - [2021-12-14]
 

--- a/nf_core/module-template/modules/main.nf
+++ b/nf_core/module-template/modules/main.nf
@@ -5,7 +5,7 @@
 // TODO nf-core: A module file SHOULD only define input and output files as command-line parameters.
 //               All other parameters MUST be provided using the "task.ext" directive, see here:
 //               https://www.nextflow.io/docs/latest/process.html#ext
-//               where "task.ext" is a string. 
+//               where "task.ext" is a string.
 //               Any parameters that need to be evaluated in the context of a particular sample
 //               e.g. single-end/paired-end data MUST also be defined and evaluated appropriately.
 // TODO nf-core: Software that can be piped together SHOULD be added to separate module files
@@ -18,7 +18,7 @@
 process {{ tool_name_underscore|upper }} {
     tag {{ '"$meta.id"' if has_meta else "'$bam'" }}
     label '{{ process_label }}'
-    
+
     // TODO nf-core: List required Conda package(s).
     //               Software MUST be pinned to channel (i.e. "bioconda"), version (i.e. "1.10").
     //               For Conda, the build (i.e. "h9402c20_2") must be EXCLUDED to support installation on different operating systems.
@@ -42,6 +42,9 @@ process {{ tool_name_underscore|upper }} {
     {{ 'tuple val(meta), path("*.bam")' if has_meta else 'path "*.bam"' }}, emit: bam
     // TODO nf-core: List additional required output channels/values here
     path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
 
     script:
     def args = task.ext.args ?: ''


### PR DESCRIPTION
Addition:
Allow modules to use `when:` block by moving it to configuration.

```
when:
task.ext.when == null || task.ext.when
```

Allows modules to flexibly use the `when:` from the configuration file. 
Allows conditional process execution on settings not available in the `workflow` block. 

Configuration is set using `process.ext.when` allowing one to use process selectors and other configuration benefits to 
apply a when condition to a group of processes or test process specific values.

Execution conditions
```groovy
process {
    withName: 'FOO' {
        ext.args = 'module1,module2'
        // Example settings
        ext.when = null                           // Process executes - no conditional defined. 
        ext.when = true                          // Process executes - e.g. override for existing configuration
        ext.when = !params.skip_module // Process executes if set, or if null 
        ext.when = ext.args.tokenize(',').contains('module1')  // Process does not execute - evaluated in configuration context.
        ext.when = { task.ext.args.tokenize(',').contains('module1') }  // Process does not execute - evaluated in task context.
    }
}
```

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
