### PR TITLE
First stab at nicely formatted cli help output using Rich.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,12 @@
 ## General
 
 * Updated `nf-core download` to work with latest DSL2 syntax for containers ([#1379](https://github.com/nf-core/tools/issues/1379))
-* [#1384](https://github.com/nf-core/tools/pull/1384) Adds Gitpod environment and Dockerfile.
+* Added a Gitpod environment and Dockerfile ([#1384](https://github.com/nf-core/tools/pull/1384))
     * Adds conda, Nextflow, nf-core, pytest-workflow, mamba, and pip to base Gitpod Docker image.
     * Adds GH action to build and push Gitpod Docker image.
     * Adds Gitpod environment to template.
     * Adds Gitpod environment to tools with auto build of nf-core tool.
+* Shiny new command-line help formatting ([#1403](https://github.com/nf-core/tools/pull/1403))
 
 ### Modules
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -89,6 +89,7 @@ def rich_format_help(obj, ctx, formatter):
         highlights = [
             r"(?P<switch>\-\w)(?!\S)",
             r"(?P<option>\-\-[\w\-]+)(?!\S)",
+            r"(?P<metavar>\<[^\>]+\>)",
             r"(?P<usage>Usage: )",
         ]
 
@@ -99,6 +100,7 @@ def rich_format_help(obj, ctx, formatter):
             {
                 "option": "bold cyan",
                 "switch": "bold green",
+                "metavar": "bold magenta",
                 "usage": "yellow",
             }
         ),
@@ -138,7 +140,7 @@ def rich_format_help(obj, ctx, formatter):
         # Column for a metavar, if we have one
         metavar = ""
         if param.metavar:
-            metavar = Text(f" {param.metavar}", style="bold yellow")
+            metavar = Text(f" {param.metavar}", style="bold magenta")
 
         # Help text
         help_record = param.get_help_record(ctx)

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -11,6 +11,8 @@ import rich.traceback
 from rich import print
 from rich.text import Text
 from rich.highlighter import RegexHighlighter
+from rich.align import Align
+from rich.padding import Padding
 from rich.panel import Panel
 from rich.table import Table
 from rich.theme import Theme
@@ -104,7 +106,22 @@ def rich_format_help(obj, ctx, formatter):
     )
 
     # Print usage
-    console.print(highlighter(" " + obj.get_usage(ctx) + "\n"), style="bold")
+    console.print(Padding(highlighter(obj.get_usage(ctx)), (0, 1, 1, 1)), style="bold")
+
+    # Print command / group help if we have some
+    if obj.help:
+        # Get the first line, remove single linebreaks
+        first_line = obj.help.split("\n\n")[0].replace("\n", " ")
+        helptext = Text(first_line)
+
+        # Get remaining lines, remove single line breaks and format as dim
+        remaining_lines = obj.help.split("\n\n")[1:]
+        if len(remaining_lines) > 0:
+            remaining_lines = "\n" + "\n".join([x.replace("\n", " ") for x in remaining_lines])
+            helptext.append(remaining_lines, style="dim")
+
+        # Print with a max width and some padding
+        console.print(Padding(Align(helptext, width=100, pad=False), (0, 1, 1, 1)))
 
     # Print the option flags
     options_table = Table(highlight=True, box=None, show_header=False)

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -100,7 +100,7 @@ def rich_format_help(obj, ctx, formatter):
             {
                 "option": "bold cyan",
                 "switch": "bold green",
-                "metavar": "bold magenta",
+                "metavar": "bold yellow",
                 "usage": "yellow",
             }
         ),
@@ -140,7 +140,7 @@ def rich_format_help(obj, ctx, formatter):
         # Column for a metavar, if we have one
         metavar = ""
         if param.metavar:
-            metavar = Text(f" {param.metavar}", style="bold magenta")
+            metavar = Text(f" {param.metavar}", style="bold yellow")
 
         # Help text
         help_record = param.get_help_record(ctx)


### PR DESCRIPTION
Took code from rich-cli written by @willmcgugan and played around with until it worked for us.

It's so pretty 🤩 

* Help strings are no longer truncated if they're a bit on the long side
* Text now stuff wraps onto multiple lines for narrow terminals and long help texts
* I've set it to use a maximum width of 100 chars, instead of the full terminal width. Personal preference.
* ~We have a custom [`@click.version_option()`](https://click.palletsprojects.com/en/8.0.x/api/?highlight=version_option#click.version_option) which doesn't seem to make it into the help, I don't know how to fix this.~

<table>
<tr>
<th>Before</th>
<th>Afer</th>
</tr>
<tr>
<td>
<img width="619" alt="image" src="https://user-images.githubusercontent.com/465550/153222512-2f890e62-4cbb-42b8-bad6-e59d8f299238.png">
</td>
<td>
<img width="811" alt="image" src="https://user-images.githubusercontent.com/465550/153230101-d1fe02cb-b1bf-4424-823f-ab8a539e937a.png">

</td>
</tr>
<tr>
<td>
<img width="647" alt="image" src="https://user-images.githubusercontent.com/465550/153222777-f4b7fb35-4b47-4236-9077-c1b7beed6c78.png">
</td>
<td>
<img width="811" alt="image" src="https://user-images.githubusercontent.com/465550/153231155-86b66fd5-7611-4db0-ba78-b030dd063544.png">
</td>
</tr>

## PR checklist

 - [ ] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
