### PR TITLE
Use `-h` as a help flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     * Adds Gitpod environment to template.
     * Adds Gitpod environment to tools with auto build of nf-core tool.
 * Shiny new command-line help formatting ([#1403](https://github.com/nf-core/tools/pull/1403))
+* Call the command line help with `-h` as well as `--help` (was formerly just the latter) ([#1404](https://github.com/nf-core/tools/pull/1404))
 
 ### Modules
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -136,8 +136,13 @@ def rich_format_help(obj, ctx, formatter):
 
         # Short and long form
         if len(param.opts) == 2:
-            opt1 = highlighter(param.opts[1])
-            opt2 = highlighter(param.opts[0])
+            # Always have the --long form first
+            if "--" in param.opts[0]:
+                opt1 = highlighter(param.opts[0])
+                opt2 = highlighter(param.opts[1])
+            else:
+                opt1 = highlighter(param.opts[1])
+                opt2 = highlighter(param.opts[0])
         # Just one form
         else:
             opt1 = highlighter(param.opts[0])
@@ -228,7 +233,7 @@ class RichCommand(click.Command):
         rich_format_help(self, ctx, formatter)
 
 
-@click.group(cls=CustomHelpOrder)
+@click.group(cls=CustomHelpOrder, context_settings=dict(help_option_names=["-h", "--help"]))
 @click.version_option(nf_core.__version__)
 @click.option("-v", "--verbose", is_flag=True, default=False, help="Print verbose output to the console.")
 @click.option("-l", "--log-file", help="Save a verbose log to a file.", metavar="<filename>")
@@ -299,10 +304,10 @@ def list(keywords, sort, json, show_archived):
     "-a", "--save-all", is_flag=True, default=False, help="Save all parameters, even if unchanged from default"
 )
 @click.option(
-    "-h", "--show-hidden", is_flag=True, default=False, help="Show hidden params which don't normally need changing"
+    "-x", "--show-hidden", is_flag=True, default=False, help="Show hidden params which don't normally need changing"
 )
 @click.option(
-    "--url", type=str, default="https://nf-co.re/launch", help="Customise the builder URL (for development work)"
+    "-u", "--url", type=str, default="https://nf-co.re/launch", help="Customise the builder URL (for development work)"
 )
 def launch(pipeline, id, revision, command_only, params_in, params_out, save_all, show_hidden, url):
     """


### PR DESCRIPTION
Keep @Midnighter happy ;)

This is in addition to the previous `--help`.

One piece of collateral damage: `nf-core launch` had a short form `-h` flag for `--hidden`. I've changed this to `-x`.

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
