### PR TITLE
Add yamllint config to template

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,5 @@
+extends: default
+
+rules:
+    document-start: disable
+    line-length: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add retry strategy for AWS megatests after releasing [nf-core/tower-action v2.2](https://github.com/nf-core/tower-action/releases/tag/v2.2)
 * Update igenomes path to the `BWAIndex` to fetch the whole `version0.6.0` folder instead of only the `genome.fa` file
 * Remove pinned Node version in the GitHub Actions workflows, to fix errors with `markdownlint`
+* Add `.yamllint.yml` to avoid line length and document start errors ([#1407](https://github.com/nf-core/tools/issues/1407))
 
 ## General
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
     * Adds Gitpod environment to tools with auto build of nf-core tool.
 * Shiny new command-line help formatting ([#1403](https://github.com/nf-core/tools/pull/1403))
 * Call the command line help with `-h` as well as `--help` (was formerly just the latter) ([#1404](https://github.com/nf-core/tools/pull/1404))
+* Add `.yamllint.yml` config file to avoid line length and document start errors in the tools repo itself.
 
 ### Modules
 

--- a/nf_core/pipeline-template/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/nf_core/pipeline-template/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,3 @@
-
 name: Bug report
 description: Report something that is broken or incorrect
 labels: bug

--- a/nf_core/pipeline-template/.github/workflows/linting.yml
+++ b/nf_core/pipeline-template/.github/workflows/linting.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install yaml-lint
         run: npm install -g yaml-lint
       - name: Run yaml-lint
-        run: yamllint $(find ${GITHUB_WORKSPACE} -type f -name "*.yml" -o -name "*.yaml") -c ${GITHUB_WORKSPACE}/.markdownlint.yml
+        run: yamllint $(find ${GITHUB_WORKSPACE} -type f -name "*.yml" -o -name "*.yaml") -c ${GITHUB_WORKSPACE}/.yamllint.yml
 
       # If the above check failed, post a comment on the PR explaining the failure
       - name: Post PR comment
@@ -81,7 +81,7 @@ jobs:
             * Install `yaml-lint`
                 * [Install `npm`](https://www.npmjs.com/get-npm) then [install `yaml-lint`](https://www.npmjs.com/package/yaml-lint) (`npm install -g yaml-lint`)
             * Fix the markdown errors
-                * Run the test locally: `yamllint $(find . -type f -name "*.yml" -o -name "*.yaml")`
+                * Run the test locally: `yamllint $(find . -type f -name "*.yml" -o -name "*.yaml") -c ./.yamllint.yml`
                 * Fix any reported errors in your YAML files
 
             Once you push these changes the test should pass, and you can hide this comment :+1:

--- a/nf_core/pipeline-template/.github/workflows/linting.yml
+++ b/nf_core/pipeline-template/.github/workflows/linting.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install yaml-lint
         run: npm install -g yaml-lint
       - name: Run yaml-lint
-        run: yamllint $(find ${GITHUB_WORKSPACE} -type f -name "*.yml" -o -name "*.yaml")
+        run: yamllint $(find ${GITHUB_WORKSPACE} -type f -name "*.yml" -o -name "*.yaml") -c ${GITHUB_WORKSPACE}/.markdownlint.yml
 
       # If the above check failed, post a comment on the PR explaining the failure
       - name: Post PR comment

--- a/nf_core/pipeline-template/.yamllint.yml
+++ b/nf_core/pipeline-template/.yamllint.yml
@@ -1,0 +1,5 @@
+extends: default
+
+rules:
+    document-start: disable
+    line-length: disable


### PR DESCRIPTION
Adds a `.yamllint.yml` config to avoid `line too long` and `missing document start "---"` errors.

Closes #1407 

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 