### PR TITLE
YAML lint - ignore template files.

### DIFF
--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -1,5 +1,13 @@
 name: Lint YAML
-on: [push, pull_request]
+on:
+  push:
+    # Ignore YAML files in the template, as they contain Jinja2 template strings
+    paths-ignore:
+      - 'nf_core/pipeline-template/**'
+  pull_request:
+    # Ignore YAML files in the template, as they contain Jinja2 template strings
+    paths-ignore:
+      - 'nf_core/pipeline-template/**'
 jobs:
   YAML:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Attempt to fix the CI with YAML linting errors.

YAML files in the template contain Jinja2 template strings which breaks stuff. My best solution for now is to just ignore them.

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
