### PR TITLE
Make yamllint config recognisable by the yml lint github action

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -27,7 +27,7 @@ jobs:
                 * Install `yamllint` following [this](https://yamllint.readthedocs.io/en/stable/quickstart.html#installing-yamllint)
                 instructions or alternative install it in your [conda environment](https://anaconda.org/conda-forge/yamllint)
             * Fix the markdown errors
-                * Run the test locally: `yamllint $(find . -type f -name "*.yml" -o -name "*.yaml") -c ${GITHUB_WORKSPACE}/.yamllint.yml`
+                * Run the test locally: `yamllint $(find . -type f -name "*.yml" -o -name "*.yaml") -c ./.yamllint.yml`
                 * Fix any reported errors in your YAML files
 
             Once you push these changes the test should pass, and you can hide this comment :+1:

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -4,12 +4,13 @@ jobs:
   YAML:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v2
-      - name: Install yaml-lint
-        run: npm install -g yaml-lint
-      - name: Run yaml-lint
-        run: yamllint $(find ${GITHUB_WORKSPACE} -type f -name "*.yml" -o -name "*.yaml") -c ${GITHUB_WORKSPACE}/.yamllint.yml
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: 'Yamllint'
+        uses: karancode/yamllint-github-action@master
+        with:
+          yamllint_file_or_dir: '.'
+          yamllint_config_filepath: '.yamllint.yml'
 
       # If the above check failed, post a comment on the PR explaining the failure
       - name: Post PR comment
@@ -22,10 +23,11 @@ jobs:
             To keep the code consistent with lots of contributors, we run automated code consistency checks.
             To fix this CI test, please run:
 
-            * Install `yaml-lint`
-                * [Install `npm`](https://www.npmjs.com/get-npm) then [install `yaml-lint`](https://www.npmjs.com/package/yaml-lint) (`npm install -g yaml-lint`)
+            * Install `yamllint`
+                * Install `yamllint` following [this](https://yamllint.readthedocs.io/en/stable/quickstart.html#installing-yamllint)
+                instructions or alternative install it in your [conda environment](https://anaconda.org/conda-forge/yamllint)
             * Fix the markdown errors
-                * Run the test locally: `yamllint $(find . -type f -name "*.yml" -o -name "*.yaml") -c ./.yamllint.yml`
+                * Run the test locally: `yamllint $(find . -type f -name "*.yml" -o -name "*.yaml") -c ${GITHUB_WORKSPACE}/.yamllint.yml`
                 * Fix any reported errors in your YAML files
 
             Once you push these changes the test should pass, and you can hide this comment :+1:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -4,3 +4,4 @@ ignore: |
 rules:
     document-start: disable
     line-length: disable
+    truthy: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Shiny new command-line help formatting ([#1403](https://github.com/nf-core/tools/pull/1403))
 * Call the command line help with `-h` as well as `--help` (was formerly just the latter) ([#1404](https://github.com/nf-core/tools/pull/1404))
 * Add `.yamllint.yml` config file to avoid line length and document start errors in the tools repo itself.
+* Switch to `yamllint-github-action`to be able to configure yaml lint exceptions ([#1404](https://github.com/nf-core/tools/issues/1413))
 
 ### Modules
 

--- a/nf_core/pipeline-template/.github/workflows/linting.yml
+++ b/nf_core/pipeline-template/.github/workflows/linting.yml
@@ -60,12 +60,13 @@ jobs:
   YAML:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v2
-      - name: Install yaml-lint
-        run: npm install -g yaml-lint
-      - name: Run yaml-lint
-        run: yamllint $(find ${GITHUB_WORKSPACE} -type f -name "*.yml" -o -name "*.yaml") -c ${GITHUB_WORKSPACE}/.yamllint.yml
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: 'Yamllint'
+        uses: karancode/yamllint-github-action@master
+        with:
+          yamllint_file_or_dir: '.'
+          yamllint_config_filepath: '.yamllint.yml'
 
       # If the above check failed, post a comment on the PR explaining the failure
       - name: Post PR comment
@@ -78,10 +79,11 @@ jobs:
             To keep the code consistent with lots of contributors, we run automated code consistency checks.
             To fix this CI test, please run:
 
-            * Install `yaml-lint`
-                * [Install `npm`](https://www.npmjs.com/get-npm) then [install `yaml-lint`](https://www.npmjs.com/package/yaml-lint) (`npm install -g yaml-lint`)
+            * Install `yamllint`
+                * Install `yamllint` following [this](https://yamllint.readthedocs.io/en/stable/quickstart.html#installing-yamllint)
+                instructions or alternative install it in your [conda environment](https://anaconda.org/conda-forge/yamllint)
             * Fix the markdown errors
-                * Run the test locally: `yamllint $(find . -type f -name "*.yml" -o -name "*.yaml") -c ./.yamllint.yml`
+                * Run the test locally: `yamllint $(find . -type f -name "*.yml" -o -name "*.yaml") -c ${GITHUB_WORKSPACE}/.yamllint.yml`
                 * Fix any reported errors in your YAML files
 
             Once you push these changes the test should pass, and you can hide this comment :+1:

--- a/nf_core/pipeline-template/.github/workflows/linting.yml
+++ b/nf_core/pipeline-template/.github/workflows/linting.yml
@@ -83,7 +83,7 @@ jobs:
                 * Install `yamllint` following [this](https://yamllint.readthedocs.io/en/stable/quickstart.html#installing-yamllint)
                 instructions or alternative install it in your [conda environment](https://anaconda.org/conda-forge/yamllint)
             * Fix the markdown errors
-                * Run the test locally: `yamllint $(find . -type f -name "*.yml" -o -name "*.yaml") -c ${GITHUB_WORKSPACE}/.yamllint.yml`
+                * Run the test locally: `yamllint $(find . -type f -name "*.yml" -o -name "*.yaml") -c ./.yamllint.yml`
                 * Fix any reported errors in your YAML files
 
             Once you push these changes the test should pass, and you can hide this comment :+1:

--- a/nf_core/pipeline-template/.yamllint.yml
+++ b/nf_core/pipeline-template/.yamllint.yml
@@ -3,3 +3,4 @@ extends: default
 rules:
     document-start: disable
     line-length: disable
+    truthy: disable


### PR DESCRIPTION
Use [this](https://github.com/marketplace/actions/yamllint-github-action) github action to enable the recognition of the `yamllint.yml` and avoid undesired errors.

Closes #1404

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 