### PR TITLE
Add to pipeline template optional loading of institution specific pipeline configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Add yamllint GitHub Action.
 * Add `.yamllint.yml` to avoid line length and document start errors ([#1407](https://github.com/nf-core/tools/issues/1407))
 * Add `--publish_dir_mode` back into the pipeline template ([nf-core/rnaseq#752](https://github.com/nf-core/rnaseq/issues/752#issuecomment-1039451607))
+* Add optional loading of of pipeline-specific institutional configs to `nextflow.config`
 
 ## General
 

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -63,6 +63,15 @@ try {
     System.err.println("WARNING: Could not load nf-core/config profiles: ${params.custom_config_base}/nfcore_custom.config")
 }
 
+// Load {{ name }} custom profiles from different institutions. 
+// Warning: Uncomment only if a pipeline-specific instititutional config already exists on nf-core/configs!
+// try {
+//   includeConfig "${params.custom_config_base}/pipeline/{{ short.name }}.config"
+// } catch (Exception e) {
+//   System.err.println("WARNING: Could not load nf-core/config/{{ short.name }} profiles: ${params.custom_config_base}/pipeline/{{ short.name }}.config")
+// }
+
+
 profiles {
     debug { process.beforeScript = 'echo $HOSTNAME' }
     conda {

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -66,9 +66,9 @@ try {
 // Load {{ name }} custom profiles from different institutions. 
 // Warning: Uncomment only if a pipeline-specific instititutional config already exists on nf-core/configs!
 // try {
-//   includeConfig "${params.custom_config_base}/pipeline/{{ short.name }}.config"
+//   includeConfig "${params.custom_config_base}/pipeline/{{ short_name }}.config"
 // } catch (Exception e) {
-//   System.err.println("WARNING: Could not load nf-core/config/{{ short.name }} profiles: ${params.custom_config_base}/pipeline/{{ short.name }}.config")
+//   System.err.println("WARNING: Could not load nf-core/config/{{ short_name }} profiles: ${params.custom_config_base}/pipeline/{{ short_name }}.config")
 // }
 
 


### PR DESCRIPTION
This is now utilised for a few pipelines (eager, sarek, rnaseq), but may not be full well known this exists.

This PR adds this as a possibility for pipeline devs once such a config exists, but otherwise is commented out to prevent config loading breaking if such a config doesn't exist.