### PR TITLE
Add openjdk and versions to conda env

### DIFF
--- a/nf_core/gitpod/gitpod.Dockerfile
+++ b/nf_core/gitpod/gitpod.Dockerfile
@@ -15,9 +15,18 @@ USER gitpod
 
 # Install nextflow, nf-core, Mamba, and pytest-workflow
 RUN conda update -n base -c defaults conda && \
-    conda install nextflow nf-core pytest-workflow mamba pip black yamllint -n base -c conda-forge -c bioconda && \
-    nextflow self-update && \
     conda config --add channels defaults && \
     conda config --add channels bioconda && \
     conda config --add channels conda-forge && \
+    conda install \
+        openjdk=11.0.13 \
+        nextflow=21.10.6 \
+        nf-core=2.2 \
+        pytest-workflow=1.6.0 \
+        mamba=0.22.1 \
+        pip=22.0.4 \
+        black=22.1.0 \
+        yamllint=1.26.3 \
+        -n base && \
+    nextflow self-update && \
     conda clean --all -f -y


### PR DESCRIPTION
Fixes #1428 

- Adds openjdk explicitly to conda env
- Adds software versions to allow docker image rebuild trigger

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
