### PR TITLE
Build Gitpod container on push to dev

### DIFF
--- a/.github/workflows/build_gitpod.yml
+++ b/.github/workflows/build_gitpod.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'dev'
     paths:
       - 'nf_core/gitpod/gitpod.Dockerfile'
       - '.github/workflows/build_gitpod.yml'


### PR DESCRIPTION
Builds Gitpod container on push to dev.
Propagates Gitpod image changes on push to dev so the changes can be available early.


## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
