### PR TITLE
Remove flag --repo-type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 ## General
 
 * Updated `nf-core download` to work with latest DSL2 syntax for containers ([#1379](https://github.com/nf-core/tools/issues/1379))
-* Made `nf-core modules create` detect repository type with explicit `.nf-core.yml` or `--repo-type`, instead of random readme stuff ([#1391](https://github.com/nf-core/tools/pull/1391))
+* Made `nf-core modules create` detect repository type with explicit `.nf-core.yml` instead of random readme stuff ([#1391](https://github.com/nf-core/tools/pull/1391))
 * Added a Gitpod environment and Dockerfile ([#1384](https://github.com/nf-core/tools/pull/1384))
     * Adds conda, Nextflow, nf-core, pytest-workflow, mamba, and pip to base Gitpod Docker image.
     * Adds GH action to build and push Gitpod Docker image.

--- a/README.md
+++ b/README.md
@@ -1127,8 +1127,6 @@ set to either `pipeline` or `modules`.
 The command will automatically look through parent directories for this file to set the root path, so that you can run the command in a subdirectory.
 It will start in the current working directory, or whatever is specified with `--dir <directory>`.
 
-If you do not have a `.nf-core.yml` file you can specify the repository type with the `--repo-type` flag.
-
 The `nf-core modules create` command will prompt you with the relevant questions in order to create all of the necessary module files.
 
 ```console

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -526,8 +526,7 @@ def remove(ctx, dir, tool):
 @click.option("-f", "--force", is_flag=True, default=False, help="Overwrite any files if they already exist")
 @click.option("-c", "--conda-name", type=str, default=None, help="Name of the conda package to use")
 @click.option("-p", "--conda-package-version", type=str, default=None, help="Version of conda package to use")
-@click.option("-r", "--repo-type", type=click.Choice(["pipeline", "modules"]), default=None, help="Type of repository")
-def create_module(ctx, tool, dir, author, label, meta, no_meta, force, conda_name, conda_package_version, repo_type):
+def create_module(ctx, tool, dir, author, label, meta, no_meta, force, conda_name, conda_package_version):
     """
     Create a new DSL2 module from the nf-core template.
 
@@ -549,7 +548,7 @@ def create_module(ctx, tool, dir, author, label, meta, no_meta, force, conda_nam
     # Run function
     try:
         module_create = nf_core.modules.ModuleCreate(
-            dir, tool, author, label, has_meta, force, conda_name, conda_package_version, repo_type
+            dir, tool, author, label, has_meta, force, conda_name, conda_package_version
         )
         module_create.create()
     except UserWarning as e:


### PR DESCRIPTION
Since we now have a nice interactive prompt if the `repository_type` is not found in the `.nf-core.yml` config file (#1437), I figure a flag to override the repo type is not really needed and will just cause more problems if anything.

So best way of closing #1433 is to just strip `--repo-type` entirely.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
