### PR TITLE
Tweak handling of empty files when generating the test YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@
 * Added `--conda-package-version` flag for specifying version of conda package in `nf-core modules create`. ([#1238](https://github.com/nf-core/tools/issues/1238))
 * Add option of writing diffs to file in `nf-core modules update` using either interactive prompts or the new `--diff-file` flag.
 * Fixed edge case where module names that were substrings of other modules caused both to be installed ([#1380](https://github.com/nf-core/tools/issues/1380))
+* Tweak handling of empty files when generating the test YAML ([#1376](https://github.com/nf-core/tools/issues/1376))
+    * Fail linting if a md5sum for an empty file is found (instead of a warning)
+    * Don't skip the md5 when generating a test file if an empty file is found (so that linting fails and can be manually checked)
 
 ## [v2.2 - Lead Liger](https://github.com/nf-core/tools/releases/tag/2.2) - [2021-12-14]
 

--- a/nf_core/modules/lint/module_tests.py
+++ b/nf_core/modules/lint/module_tests.py
@@ -55,7 +55,7 @@ def module_tests(module_lint_object, module):
                 # Look for md5sums of empty files
                 for tfile in test.get("files", []):
                     if tfile.get("md5sum") == "d41d8cd98f00b204e9800998ecf8427e":
-                        module.warned.append(
+                        module.failed.append(
                             (
                                 "test_yml_md5sum",
                                 "md5sum for empty file found: d41d8cd98f00b204e9800998ecf8427e",
@@ -63,7 +63,7 @@ def module_tests(module_lint_object, module):
                             )
                         )
                     if tfile.get("md5sum") == "7029066c27ac6f5ef18d660d5741979a":
-                        module.warned.append(
+                        module.failed.append(
                             (
                                 "test_yml_md5sum",
                                 "md5sum for compressed empty file found: 7029066c27ac6f5ef18d660d5741979a",

--- a/nf_core/modules/test_yml_builder.py
+++ b/nf_core/modules/test_yml_builder.py
@@ -232,10 +232,12 @@ class ModulesTestYmlBuilder(object):
                 # Check that this isn't an empty file
                 if self.check_if_empty_file(elem):
                     if not is_repeat:
-                        self.errors.append(f"Empty file, skipping md5sum: '{os.path.basename(elem)}'")
-                else:
-                    elem_md5 = self._md5(elem)
-                    test_file["md5sum"] = elem_md5
+                        self.errors.append(f"Empty file found! '{os.path.basename(elem)}'")
+                # Add the md5 anyway, linting should fail later and can be manually removed if needed.
+                #  Originally we skipped this if empty, but then it's too easy to miss the warning.
+                #  Equally, if a file is legitimately empty we don't want to prevent this from working.
+                elem_md5 = self._md5(elem)
+                test_file["md5sum"] = elem_md5
                 # Switch out the results directory path with the expected 'output' directory
                 test_file["path"] = elem.replace(results_dir, "output")
                 test_files.append(test_file)


### PR DESCRIPTION
- Error instead of warning for md5s of empty files
- Don't skip adding the md5 to the test YAML if an empty file is found

⚠️ UNTESTED ⚠️  - would be fab if someone else could give this a spin and check that it works as intended 🙏🏻 

Fixes #1376

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
