### PR TITLE
Updated `nf-core create` to tolerate failures and retry when fetching pipeline logos from the website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Prevent module linting KeyError edge case ([#1321](https://github.com/nf-core/tools/issues/1321))
 * Bump-versions: Don't trim the trailing newline on files, causes editorconfig linting to fail ([#1265](https://github.com/nf-core/tools/issues/1265))
 * Handle exception in `nf-core list` when a broken git repo is found ([#1273](https://github.com/nf-core/tools/issues/1273))
+* Updated `nf-core create` to tolerate failures and retry when fetching pipeline logos from the website ([#1369](https://github.com/nf-core/tools/issues/1369))
 
 ### Modules
 


### PR DESCRIPTION
When we do a pipeline sync, many pipelines try to fetch logos at the same time. In previous syncs this has taken the website down and then a load of template syncs fail.

Also sometimes the website just borks for some other reason.

This PR adds code to check that the response from the website was sane:

- Catches raised `ConnectionError` errors from timeouts etc
- Pushes the default timeout period way up, to 3 minutes
- Checks to see if the website returned a HTML `200` code (all is well)
- After it saves the file, check that it looks like a PNG file
- If any of the above go wrong, try again
    - Wait a random number of seconds for each attempt, increasing the duration for each wait
    - Random number tries to un-synchronise the hits to the website during a release of tools

Hopefully fixes #1369

Tested locally and it didn't seem to break stuff anyway. Difficult to really know if it'll work without deliberately breaking the website.

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
