### PR TITLE
Updated URL for pipeline lint test docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Prevent module linting KeyError edge case ([#1321](https://github.com/nf-core/tools/issues/1321))
 * Bump-versions: Don't trim the trailing newline on files, causes editorconfig linting to fail ([#1265](https://github.com/nf-core/tools/issues/1265))
 * Handle exception in `nf-core list` when a broken git repo is found ([#1273](https://github.com/nf-core/tools/issues/1273))
+* Updated URL for pipeline lint test docs ([#1348](https://github.com/nf-core/tools/issues/1348))
 
 ### Modules
 

--- a/nf_core/lint/__init__.py
+++ b/nf_core/lint/__init__.py
@@ -12,15 +12,14 @@ import datetime
 import git
 import json
 import logging
-import os
 import re
 import rich
 import rich.progress
-import yaml
 
 import nf_core.utils
 import nf_core.lint_utils
 import nf_core.modules.lint
+from nf_core import __version__
 from nf_core.lint_utils import console
 
 log = logging.getLogger(__name__)
@@ -331,7 +330,14 @@ class PipelineLint(nf_core.utils.Pipeline):
             string for the terminal with appropriate ASCII colours.
             """
             for eid, msg in test_results:
-                table.add_row(Markdown("[{0}](https://nf-co.re/tools-docs/lint_tests/{0}.html): {1}".format(eid, msg)))
+                tools_version = __version__
+                if "dev" in __version__:
+                    tools_version = "latest"
+                table.add_row(
+                    Markdown(
+                        f"[{eid}](https://nf-co.re/tools/docs/{tools_version}/pipeline_lint_tests/{eid}.html): {msg}"
+                    )
+                )
             return table
 
         def _s(some_list):


### PR DESCRIPTION
When you run pipeline linting you can ctrl+click the test name and it takes you to the website. This updates to the newer URL format and also pins the version of tools that you're currently running.

Fixes #1348

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
