### PR TITLE
Install tools in the GitPod Docker from the repo itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * Convert nf-core/tools API / lint test documentation to MyST ([#1245](https://github.com/nf-core/tools/pull/1245))
 * Build documentation for the `nf-core modules lint` tests ([#1250](https://github.com/nf-core/tools/pull/1250))
+* Install tools inside GitPod Docker using the repo itself and not from Conda.
 
 ### Modules
 

--- a/nf_core/gitpod/gitpod.Dockerfile
+++ b/nf_core/gitpod/gitpod.Dockerfile
@@ -21,7 +21,6 @@ RUN conda update -n base -c defaults conda && \
     conda install \
         openjdk=11.0.13 \
         nextflow=21.10.6 \
-        nf-core=2.2 \
         pytest-workflow=1.6.0 \
         mamba=0.22.1 \
         pip=22.0.4 \
@@ -30,3 +29,10 @@ RUN conda update -n base -c defaults conda && \
         -n base && \
     nextflow self-update && \
     conda clean --all -f -y
+
+# Add the nf-core source files to the image
+COPY . /usr/src/nf_core
+WORKDIR /usr/src/nf_core
+
+# Install nf-core
+RUN python -m pip install .


### PR DESCRIPTION
As discussed on Slack copy the repo content in the Docker image and avoid the installation of tools from conda

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
