### PR TITLE
Update nf-core tools version to 2.3

### DIFF
--- a/nf_core/gitpod/gitpod.Dockerfile
+++ b/nf_core/gitpod/gitpod.Dockerfile
@@ -21,7 +21,7 @@ RUN conda update -n base -c defaults conda && \
     conda install \
         openjdk=11.0.13 \
         nextflow=21.10.6 \
-        nf-core=2.2 \
+        nf-core=2.3 \
         pytest-workflow=1.6.0 \
         mamba=0.22.1 \
         pip=22.0.4 \


### PR DESCRIPTION
Update's the Gitpod container nf-core tools version to 2.3

Should this be merged to master or dev? Either triggers the GH build action.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
