### PR TITLE
Issue1294: Fixes to colors in Sphinx theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Handle exception in `nf-core list` when a broken git repo is found ([#1273](https://github.com/nf-core/tools/issues/1273))
 * Updated URL for pipeline lint test docs ([#1348](https://github.com/nf-core/tools/issues/1348))
 * Updated `nf-core create` to tolerate failures and retry when fetching pipeline logos from the website ([#1369](https://github.com/nf-core/tools/issues/1369))
+* Modified the CSS overriding `sphinx_rtd_theme` default colors to fix some glitches in the API documentation ([#1294](https://github.com/nf-core/tools/issues/1294))
 
 ### Modules
 

--- a/docs/api/_src/_static/css/custom.css
+++ b/docs/api/_src/_static/css/custom.css
@@ -21,7 +21,7 @@
 	
 	code, .rst-content code.literal{
 		background-color: rgba(220,220,220,0.4);
-		color: #db9444;
+		color: #C03221;
 		border: none;
 	}
 	.rst-content .note .admonition-title{
@@ -35,9 +35,6 @@
 	.rst-content .method>dt>code {
 		color: #f5f6f7;
 	}
-	.sig-paren{
-		color: #db9444;
-	}
 	.rst-content div[class^=highlight], .rst-content pre.literal-block{
 		border:none;
 	}
@@ -50,19 +47,26 @@
 		background-color: #585b60fc;
 	}
 	.highlight .k, .highlight .nt, .highlight .no{
-		color: #6fb2e8;
+		color: #246EB9;
 	}
 	.highlight .s, .highlight .s1, .highlight .s2{
 		color: #32AD65;
 	}
 	.highlight .nb, .highlight .o{
-		color: #db9444;
+		color: #FFBE0B;
 	}
 	.highlight .c1{
 		color: #88898afc;
 	}
-	.highlight .nv{
-		color: #f9d977;
+	.highlight .nv, .py>span{
+		color: #C03221;
+	}
+	.py .sig-param, .py .sig-paren, .property .pre{
+		color: #EEF0F2;
+	}
+
+	.method > .py .sig-param, .method > .py .sig-paren{
+		color: #32AD65;
 	}
 	.btn.btn-neutral {
 		background-color: #e5e6e7d4 !important;	
@@ -80,8 +84,8 @@
 	}
 
 	
-.rst-content .admonition-todo .admonition-title, .rst-content .admonition-todo .wy-alert-title, .rst-content .attention .admonition-title, .rst-content .attention .wy-alert-title, .rst-content .caution .admonition-title, .rst-content .caution .wy-alert-title, .rst-content .warning .admonition-title, .rst-content .warning .wy-alert-title, .rst-content .wy-alert-warning.admonition .admonition-title, .rst-content .wy-alert-warning.admonition .wy-alert-title, .rst-content .wy-alert-warning.danger .admonition-title, .rst-content .wy-alert-warning.danger .wy-alert-title, .rst-content .wy-alert-warning.error .admonition-title, .rst-content .wy-alert-warning.error .wy-alert-title, .rst-content .wy-alert-warning.hint .admonition-title, .rst-content .wy-alert-warning.hint .wy-alert-title, .rst-content .wy-alert-warning.important .admonition-title, .rst-content .wy-alert-warning.important .wy-alert-title, .rst-content .wy-alert-warning.note .admonition-title, .rst-content .wy-alert-warning.note .wy-alert-title, .rst-content .wy-alert-warning.seealso .admonition-title, .rst-content .wy-alert-warning.seealso .wy-alert-title, .rst-content .wy-alert-warning.tip .admonition-title, .rst-content .wy-alert-warning.tip .wy-alert-title, .rst-content .wy-alert.wy-alert-warning .admonition-title, .wy-alert.wy-alert-warning .rst-content .admonition-title, .wy-alert.wy-alert-warning .wy-alert-title {
-		background-color: #f4a25b;
+.rst-content .admonition-todo .admonition-title, .rst-content .admonition-todo .wy-alert-title, .rst-content .attention .admonition-title, .rst-content .attention .wy-alert-title, .rst-content .caution .admonition-title, .rst-content .caution .wy-alert-title, .rst-content .warning .admonition-title, .rst-content .warning .wy-alert-title, .rst-content .wy-alert-warning.admonition .admonition-title, .rst-content .wy-alert-warning.admonition .wy-alert-title, .rst-content .wy-alert-warning.danger .admonition-title, .rst-content .wy-alert-warning.danger .wy-alert-title, .rst-content .wy-alert-warning.error .admonition-title, .rst-content .wy-alert-warning.error .wy-alert-title, .rst-content .wy-alert-warning.hint .admonition-title, .rst-content .wy-alert-warning.hint .wy-alert-title, .rst-content .seealso .admonition-title, .rst-content .seealso .wy-alert-title, .rst-content .wy-alert-warning.important .admonition-title, .rst-content .wy-alert-warning.important .wy-alert-title, .rst-content .wy-alert-warning.note .admonition-title, .rst-content .wy-alert-warning.note .wy-alert-title, .rst-content .wy-alert-warning.seealso .admonition-title, .rst-content .wy-alert-warning.seealso .wy-alert-title, .rst-content .wy-alert-warning.tip .admonition-title, .rst-content .wy-alert-warning.tip .wy-alert-title, .rst-content .wy-alert.wy-alert-warning .admonition-title, .wy-alert.wy-alert-warning .rst-content .admonition-title, .wy-alert.wy-alert-warning .wy-alert-title {
+		background-color: #246EB9;
 	}
 .rst-content .admonition-todo, .rst-content .attention, .rst-content .caution, .rst-content .warning, .rst-content .wy-alert-warning.admonition, .rst-content .wy-alert-warning.danger, .rst-content .wy-alert-warning.error, .rst-content .wy-alert-warning.hint, .rst-content .wy-alert-warning.important, .rst-content .wy-alert-warning.note, .rst-content .wy-alert-warning.seealso, .rst-content .wy-alert-warning.tip, .wy-alert.wy-alert-warning {
     color: #343434;
@@ -189,7 +193,7 @@
 	border: none;
 	}
 
-    .rst-content .admonition-todo .admonition-title, .rst-content .admonition-todo .wy-alert-title, .rst-content .attention .admonition-title, .rst-content .attention .wy-alert-title, .rst-content .caution .admonition-title, .rst-content .caution .wy-alert-title, .rst-content .warning .admonition-title, .rst-content .warning .wy-alert-title, .rst-content .wy-alert-warning.admonition .admonition-title, .rst-content .wy-alert-warning.admonition .wy-alert-title, .rst-content .wy-alert-warning.danger .admonition-title, .rst-content .wy-alert-warning.danger .wy-alert-title, .rst-content .wy-alert-warning.error .admonition-title, .rst-content .wy-alert-warning.error .wy-alert-title, .rst-content .wy-alert-warning.hint .admonition-title, .rst-content .wy-alert-warning.hint .wy-alert-title, .rst-content .wy-alert-warning.important .admonition-title, .rst-content .wy-alert-warning.important .wy-alert-title, .rst-content .wy-alert-warning.note .admonition-title, .rst-content .wy-alert-warning.note .wy-alert-title, .rst-content .wy-alert-warning.seealso .admonition-title, .rst-content .wy-alert-warning.seealso .wy-alert-title, .rst-content .wy-alert-warning.tip .admonition-title, .rst-content .wy-alert-warning.tip .wy-alert-title, .rst-content .wy-alert.wy-alert-warning .admonition-title, .wy-alert.wy-alert-warning .rst-content .admonition-title, .wy-alert.wy-alert-warning .wy-alert-title {
+    .rst-content .admonition-todo .admonition-title, .rst-content .admonition-todo .wy-alert-title, .rst-content .attention .admonition-title, .rst-content .attention .wy-alert-title, .rst-content .caution .admonition-title, .rst-content .caution .wy-alert-title, .rst-content .warning .admonition-title, .rst-content .warning .wy-alert-title, .rst-content .wy-alert-warning.admonition .admonition-title, .rst-content .wy-alert-warning.admonition .wy-alert-title, .rst-content .wy-alert-warning.danger .admonition-title, .rst-content .wy-alert-warning.danger .wy-alert-title, .rst-content .wy-alert-warning.error .admonition-title, .rst-content .wy-alert-warning.error .wy-alert-title, .rst-content .wy-alert-warning.hint .admonition-title, .rst-content .wy-alert-warning.hint .wy-alert-title, .rst-content .seealso .admonition-title, .rst-content .seealso .wy-alert-title, .rst-content .wy-alert-warning.important .admonition-title, .rst-content .wy-alert-warning.important .wy-alert-title, .rst-content .wy-alert-warning.note .admonition-title, .rst-content .wy-alert-warning.note .wy-alert-title, .rst-content .wy-alert-warning.seealso .admonition-title, .rst-content .wy-alert-warning.seealso .wy-alert-title, .rst-content .wy-alert-warning.tip .admonition-title, .rst-content .wy-alert-warning.tip .wy-alert-title, .rst-content .wy-alert.wy-alert-warning .admonition-title, .wy-alert.wy-alert-warning .rst-content .admonition-title, .wy-alert.wy-alert-warning .wy-alert-title {
 		background-color: #f4a25b;
 	}
     .rst-content .admonition-todo, .rst-content .attention, .rst-content .caution, .rst-content .warning, .rst-content .wy-alert-warning.admonition, .rst-content .wy-alert-warning.danger, .rst-content .wy-alert-warning.error, .rst-content .wy-alert-warning.hint, .rst-content .wy-alert-warning.important, .rst-content .wy-alert-warning.note, .rst-content .wy-alert-warning.seealso, .rst-content .wy-alert-warning.tip, .wy-alert.wy-alert-warning {

--- a/docs/api/_src/_static/css/custom.css
+++ b/docs/api/_src/_static/css/custom.css
@@ -1,4 +1,10 @@
 @media (prefers-color-scheme: light) {
+	a, a:visited {
+		color: #246EB9;
+	}
+	a:hover, a:focus, a:active {
+		color: #C03221;
+	}
 	.wy-nav-side{
 		background-color: #ededed;
 	}
@@ -49,10 +55,10 @@
 	.highlight .k, .highlight .nt, .highlight .no{
 		color: #246EB9;
 	}
-	.highlight .s, .highlight .s1, .highlight .s2{
+	.highlight .s, .highlight .s1, .highlight .s2, .highlight .na{
 		color: #32AD65;
 	}
-	.highlight .nb, .highlight .o{
+	.highlight .nb, .highlight .o, .highlight .cm{
 		color: #FFBE0B;
 	}
 	.highlight .c1{
@@ -111,8 +117,11 @@
 		background-color: #343434;
 		color: #e5e6e7;
 	}
-	a, a:hover, a:focus, a:active {
+	a, a:visited {
 		color: #6fb2e8;
+	}
+	a:hover, a:focus, a:active {
+		color: #db9444;
 	}
 	code, .rst-content code.literal{
 		background-color: rgba(220,220,220,0.1);
@@ -165,10 +174,10 @@
 	.highlight .k, .highlight .nt, .highlight .no{
 		color: #6fb2e8;
 	}
-	.highlight .s, .highlight .s1, .highlight .s2{
+	.highlight .s, .highlight .s1, .highlight .s2,  .highlight .na{
 		color: #32AD65;
 	}
-	.highlight .nb, .highlight .o{
+	.highlight .nb, .highlight .o,  .highlight .cm{
 		color: #db9444;
 	}
 	.highlight .c1{


### PR DESCRIPTION
In order to address #1294, I have slightly modified the secondary colors of the light theme and added a few additional CSS selectors to ensure that there are no elements (like the hyperlinks) without associated styles. Those are styled with the default colors from the user's desktop theme and thus might play well with the theme. 

## Current light secondary color scheme:

![colorsold](https://user-images.githubusercontent.com/6963520/158791480-cf37e959-226e-44c5-bf0c-825d5365506d.png)

## Proposed light secondary color scheme:

![colorsnew](https://user-images.githubusercontent.com/6963520/158791476-6dc64064-655e-45c1-aaea-44975bdb8ad6.png)

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Documentation in `docs` is updated
 
 



