### PR TITLE
Fix: Get file extensions correctly in validate_pair

### DIFF
--- a/nf_core/pipeline-template/bin/check_samplesheet.py
+++ b/nf_core/pipeline-template/bin/check_samplesheet.py
@@ -98,7 +98,7 @@ class RowChecker:
         if row[self._first_col] and row[self._second_col]:
             row[self._single_col] = False
             assert (
-                Path(row[self._first_col]).suffixes == Path(row[self._second_col]).suffixes
+                Path(row[self._first_col]).suffixes[-2:] == Path(row[self._second_col]).suffixes[-2:]
             ), "FASTQ pairs must have the same file extensions."
         else:
             row[self._single_col] = True


### PR DESCRIPTION
Noticed that when there are more dots in the FASTQ file name, the Path(file).suffixes returns all elements split by dot, which ends in list mismatch, therefore throwing an error. I think we should limit it to the last two items (according to VALID_FORMATS) for the extension check. Hope this PR helps to solve the problem.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
