### PR TITLE
Add a last newline to modules.json to avoid prettier error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Modules
 
+- Add an empty line at the end of the `modules.json` when dumping it to avoid prettier error.
+
 ## [v2.3.2 - Mercury Vulture Fixed Formatting](https://github.com/nf-core/tools/releases/tag/2.3.2) - [2022-03-24]
 
 Very minor patch release to fix the full size AWS tests and re-run the template sync, which partially failed due to GitHub pull-requests being down at the time of release.

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -301,6 +301,7 @@ class ModuleCommand:
         modules_json_path = os.path.join(self.dir, "modules.json")
         with open(modules_json_path, "w") as fh:
             json.dump(modules_json, fh, indent=4)
+            fh.write("\n")
 
     def load_lint_config(self):
         """Parse a pipeline lint config file.


### PR DESCRIPTION
After updating a module or installing it and dumping the `modules.json` the last line of the file was lost and prettier complained. This is something already reported for JSON python dump, see [here](https://codeyarns.com/tech/2017-02-22-python-json-dump-misses-last-newline.html). This PR should fix it. 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated

