### PR TITLE
Remove nextflow_config from AWS test CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Template
 
 - Fix bug in pipeline readme logo URL
+- Removed retry strategy for AWS tests CI, as Nextflow now handles spot instance retries itself
 
 ### General
 

--- a/nf_core/pipeline-template/.github/workflows/awsfulltest.yml
+++ b/nf_core/pipeline-template/.github/workflows/awsfulltest.yml
@@ -28,6 +28,3 @@ jobs:
               "outdir": "s3://{% raw %}${{ secrets.AWS_S3_BUCKET }}{% endraw %}/{{ short_name }}/{% raw %}results-${{ github.sha }}{% endraw %}"
             }
           profiles: test_full,aws_tower
-          nextflow_config: |
-            process.errorStrategy = 'retry'
-            process.maxRetries = 3

--- a/nf_core/pipeline-template/.github/workflows/awstest.yml
+++ b/nf_core/pipeline-template/.github/workflows/awstest.yml
@@ -23,6 +23,3 @@ jobs:
               "outdir": "s3://{% raw %}${{ secrets.AWS_S3_BUCKET }}{% endraw %}/{{ short_name }}/{% raw %}results-test-${{ github.sha }}{% endraw %}"
             }
           profiles: test,aws_tower
-          nextflow_config: |
-            process.errorStrategy = 'retry'
-            process.maxRetries = 3


### PR DESCRIPTION
Tower.nf is now running Nextflow 22.03.0.edge by default, which includes a new strategy to handle retrying jobs killed due to AWS spot policies. This was the reason for these lines of config, so they can now be removed.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
