### PR TITLE
Add last line to json files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@
 ### General
 
 - Bumped the minimum version of `rich` from `v10` to `v10.7.0`
+- Add an empty line to `modules.json`, `params.json` and `nextflow-schema.json` when dumping them to avoid prettier errors.
 
 ### Modules
 
-- Add an empty line at the end of the `modules.json` when dumping it to avoid prettier error.
 
 ## [v2.3.2 - Mercury Vulture Fixed Formatting](https://github.com/nf-core/tools/releases/tag/2.3.2) - [2022-03-24]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 
 ### Modules
 
-
 ## [v2.3.2 - Mercury Vulture Fixed Formatting](https://github.com/nf-core/tools/releases/tag/2.3.2) - [2022-03-24]
 
 Very minor patch release to fix the full size AWS tests and re-run the template sync, which partially failed due to GitHub pull-requests being down at the time of release.

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -692,6 +692,7 @@ class Launch(object):
             if self.use_params_file:
                 with open(self.params_out, "w") as fp:
                     json.dump(self.schema_obj.input_params, fp, indent=4)
+                    fp.write("\n")
                 self.nextflow_cmd += ' {} "{}"'.format("-params-file", os.path.relpath(self.params_out))
 
             # Call nextflow with a list of command line flags

--- a/nf_core/modules/module_utils.py
+++ b/nf_core/modules/module_utils.py
@@ -188,6 +188,7 @@ def create_modules_json(pipeline_dir):
     modules_json_path = os.path.join(pipeline_dir, "modules.json")
     with open(modules_json_path, "w") as fh:
         json.dump(modules_json, fh, indent=4)
+        fh.write("\n")
 
 
 def find_correct_commit_sha(module_name, module_path, modules_repo):

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -171,6 +171,7 @@ class PipelineSchema(object):
         log.info("Writing schema with {} params: '{}'".format(num_params, self.schema_filename))
         with open(self.schema_filename, "w") as fh:
             json.dump(self.schema, fh, indent=4)
+            fh.write("\n")
 
     def load_input_params(self, params_path):
         """Load a given a path to a parameters file (JSON/YAML)


### PR DESCRIPTION
Following @ewels comment on https://github.com/nf-core/tools/pull/1501, all the problematic instances where a `JSON` file was created without a last line were fix (prettier errors otherwise)
Files fixed are:
- `modules.json` (when file is created when `nf-core lint` identifies that is missing)
- `params.json` (`nf-core launch`)
- `nextflow-schema.json` (`nf-core schema build`)

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
