### PR TITLE
Escaped test run output before logging it, to avoid a rich `MarkupError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Modules
 
+- Escaped test run output before logging it, to avoid a rich ` MarkupError`
+
 ## [v2.3.2 - Mercury Vulture Fixed Formatting](https://github.com/nf-core/tools/releases/tag/2.3.2) - [2022-03-24]
 
 Very minor patch release to fix the full size AWS tests and re-run the template sync, which partially failed due to GitHub pull-requests being down at the time of release.

--- a/nf_core/modules/test_yml_builder.py
+++ b/nf_core/modules/test_yml_builder.py
@@ -330,12 +330,13 @@ class ModulesTestYmlBuilder(object):
                     "It looks like Nextflow is not installed. It is required for most nf-core functions."
                 )
         except subprocess.CalledProcessError as e:
-            raise UserWarning(f"Error running test workflow (exit code {e.returncode})\n[red]{e.output.decode()}")
+            output = rich.markup.escape(e.output.decode())
+            raise UserWarning(f"Error running test workflow (exit code {e.returncode})\n[red]{output}")
         except Exception as e:
             raise UserWarning(f"Error running test workflow: {e}")
         else:
             log.info("Test workflow finished!")
-            log.debug(nfconfig_raw)
+            log.debug(rich.markup.escape(nfconfig_raw))
 
         return tmp_dir, tmp_dir_repeat
 


### PR DESCRIPTION
Reported by @sateeshperi and @henningonsbring via https://github.com/nf-core/modules/pull/1460

Errors in the test data gave this unhelpful Python traceback error:

```
MarkupError: closing tag '[/nf-core/test-datasets/modules/data/genomics/sarscov2/genome/db/metamaps.tar.gz]' at position 589 doesn't match any open tag
```

This was due to the underlying nf-core/tools code logging the output from the test command to the terminal. This happened to include square brackets, which the Rich library was interpreting as formatting markup.

Properly escaping that text before logging it _should_ fix the issue and properly log the error to the terminal.

Untested, as I can't easily replicate the testing error.

<details>

<summary>Full original log output</summary>

```
nextflow run tests/modules/metamaps/mapdirectly -entry test_metamaps_mapdirectly -c tests/config/nextflow.config --outdir /tmp/tmpxbjzlp64 -work-dir /tmp/tmpenszt8k7                                            
Picked up JAVA_TOOL_OPTIONS:  -Xmx3435m

╭───────────────────────────────────────────────────────────────────────────────── Traceback (most recent call last) ──────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                                                                      │
│ /opt/conda/bin/nf-core:8 in <module>                                                                                                                                                                 │
│                                                                                                                                                                                                      │
│   7 │   sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])                                                                                                                             │
│ ❱ 8 │   sys.exit(run_nf_core())                                                                                                                                                                      │
│   9                                                                                                                                                                                                  │
│ /opt/conda/lib/python3.9/site-packages/nf_core/__main__.py:90 in run_nf_core                                                                                                                         │
│                                                                                                                                                                                                      │
│    89 │   # Lanch the click cli                                                                                                                                                                      │
│ ❱  90 │   nf_core_cli()                                                                                                                                                                              │
│    91                                                                                                                                                                                                │
│                                                                                                                                                                                                      │
│ /opt/conda/lib/python3.9/site-packages/click/core.py:1128 in __call__                                                                                                                                │
│                                                                                                                                                                                                      │
│   1127 │   │   """Alias for :meth:`main`."""                                                                                                                                                         │
│ ❱ 1128 │   │   return self.main(*args, **kwargs)                                                                                                                                                     │
│   1129                                                                                                                                                                                               │
│                                                                                                                                                                                                      │
│ /opt/conda/lib/python3.9/site-packages/rich_click/rich_click.py:594 in main                                                                                                                          │
│                                                                                                                                                                                                      │
│   593 │   │   try:                                                                                                                                                                                   │
│ ❱ 594 │   │   │   return super().main(*args, standalone_mode=False, **kwargs)                                                                                                                        │
│   595 │   │   except click.ClickException as e:                                                                                                                                                      │
│                                                                                                                                                                                                      │
│ /opt/conda/lib/python3.9/site-packages/click/core.py:1053 in main                                                                                                                                    │
│                                                                                                                                                                                                      │
│   1052 │   │   │   │   with self.make_context(prog_name, args, **extra) as ctx:                                                                                                                      │
│ ❱ 1053 │   │   │   │   │   rv = self.invoke(ctx)                                                                                                                                                     │
│   1054 │   │   │   │   │   if not standalone_mode:                                                                                                                                                   │
│                                                                                                                                                                                                      │
│ /opt/conda/lib/python3.9/site-packages/click/core.py:1659 in invoke                                                                                                                                  │
│                                                                                                                                                                                                      │
│   1658 │   │   │   │   with sub_ctx:                                                                                                                                                                 │
│ ❱ 1659 │   │   │   │   │   return _process_result(sub_ctx.command.invoke(sub_ctx))                                                                                                                   │
│   1660                                                                                                                                                                                               │
│                                                                                                                                                                                                      │
│ /opt/conda/lib/python3.9/site-packages/click/core.py:1659 in invoke                                                                                                                                  │
│                                                                                                                                                                                                      │
│   1658 │   │   │   │   with sub_ctx:                                                                                                                                                                 │
│ ❱ 1659 │   │   │   │   │   return _process_result(sub_ctx.command.invoke(sub_ctx))                                                                                                                   │
│   1660                                                                                                                                                                                               │
│                                                                                                                                                                                                      │
│ /opt/conda/lib/python3.9/site-packages/click/core.py:1395 in invoke                                                                                                                                  │
│                                                                                                                                                                                                      │
│   1394 │   │   if self.callback is not None:                                                                                                                                                         │
│ ❱ 1395 │   │   │   return ctx.invoke(self.callback, **ctx.params)                                                                                                                                    │
│   1396                                                                                                                                                                                               │
│                                                                                                                                                                                                      │
│ /opt/conda/lib/python3.9/site-packages/click/core.py:754 in invoke                                                                                                                                   │
│                                                                                                                                                                                                      │
│    753 │   │   │   with ctx:                                                                                                                                                                         │
│ ❱  754 │   │   │   │   return __callback(*args, **kwargs)                                                                                                                                            │
│    755                                                                                                                                                                                               │
│                                                                                                                                                                                                      │
│ /opt/conda/lib/python3.9/site-packages/click/decorators.py:26 in new_func                                                                                                                            │
│                                                                                                                                                                                                      │
│    25 │   def new_func(*args, **kwargs):  # type: ignore                                                                                                                                             │
│ ❱  26 │   │   return f(get_current_context(), *args, **kwargs)                                                                                                                                       │
│    27                                                                                                                                                                                                │
│                                                                                                                                                                                                      │
│ /opt/conda/lib/python3.9/site-packages/nf_core/__main__.py:585 in create_test_yml                                                                                                                    │
│                                                                                                                                                                                                      │
│   584 │   except UserWarning as e:                                                                                                                                                                   │
│ ❱ 585 │   │   log.critical(e)                                                                                                                                                                        │
│   586 │   │   sys.exit(1)                                                                                                                                                                            │
│                                                                                                                                                                                                      │
│ /opt/conda/lib/python3.9/logging/__init__.py:1493 in critical                                                                                                                                        │
│                                                                                                                                                                                                      │
│   1492 │   │   if self.isEnabledFor(CRITICAL):                                                                                                                                                       │
│ ❱ 1493 │   │   │   self._log(CRITICAL, msg, args, **kwargs)                                                                                                                                          │
│   1494                                                                                                                                                                                               │
│                                                                                                                                                                                                      │
│ /opt/conda/lib/python3.9/logging/__init__.py:1589 in _log                                                                                                                                            │
│                                                                                                                                                                                                      │
│   1588 │   │   │   │   │   │   │   │    exc_info, func, extra, sinfo)                                                                                                                                │
│ ❱ 1589 │   │   self.handle(record)                                                                                                                                                                   │
│   1590                                                                                                                                                                                               │
│                                                                                                                                                                                                      │
│ /opt/conda/lib/python3.9/logging/__init__.py:1599 in handle                                                                                                                                          │
│                                                                                                                                                                                                      │
│   1598 │   │   if (not self.disabled) and self.filter(record):                                                                                                                                       │
│ �� 1599 │   │   │   self.callHandlers(record)                                                                                                                                                         │
│   1600                                                                                                                                                                                               │
│                                                                                                                                                                                                      │
│ /opt/conda/lib/python3.9/logging/__init__.py:1661 in callHandlers                                                                                                                                    │
│                                                                                                                                                                                                      │
│   1660 │   │   │   │   if record.levelno >= hdlr.level:                                                                                                                                              │
│ ❱ 1661 │   │   │   │   │   hdlr.handle(record)                                                                                                                                                       │
│   1662 │   │   │   if not c.propagate:                                                                                                                                                               │
│                                                                                                                                                                                                      │
│ /opt/conda/lib/python3.9/logging/__init__.py:952 in handle                                                                                                                                           │
│                                                                                                                                                                                                      │
│    951 │   │   │   try:                                                                                                                                                                              │
│ ❱  952 │   │   │   │   self.emit(record)                                                                                                                                                             │
│    953 │   │   │   finally:                                                                                                                                                                          │
│                                                                                                                                                                                                      │
│ /opt/conda/lib/python3.9/site-packages/rich/logging.py:157 in emit                                                                                                                                   │
│                                                                                                                                                                                                      │
│   156 │   │                                                                                                                                                                                          │
│ ❱ 157 │   │   message_renderable = self.render_message(record, message)                                                                                                                              │
│   158 │   │   log_renderable = self.render(                                                                                                                                                          │
│                                                                                                                                                                                                      │
│ /opt/conda/lib/python3.9/site-packages/rich/logging.py:176 in render_message                                                                                                                         │
│                                                                                                                                                                                                      │
│   175 │   │   use_markup = getattr(record, "markup", self.markup)                                                                                                                                    │
│ ❱ 176 │   │   message_text = Text.from_markup(message) if use_markup else Text(message)                                                                                                              │
│   177                                                                                                                                                                                                │
│                                                                                                                                                                                                      │
│ /opt/conda/lib/python3.9/site-packages/rich/text.py:270 in from_markup                                                                                                                               │
│                                                                                                                                                                                                      │
│    269 │   │                                                                                                                                                                                         │
│ ❱  270 │   │   rendered_text = render(text, style, emoji=emoji, emoji_variant=emoji_variant)                                                                                                         │
│    271 │   │   rendered_text.justify = justify                                                                                                                                                       │
│                                                                                                                                                                                                      │
│ /opt/conda/lib/python3.9/site-packages/rich/markup.py:160 in render                                                                                                                                  │
│                                                                                                                                                                                                      │
│   159 │   │   │   │   │   except KeyError:                                                                                                                                                           │
│ ❱ 160 │   │   │   │   │   │   raise MarkupError(                                                                                                                                                     │
│   161 │   │   │   │   │   │   │   f"closing tag '{tag.markup}' at position {position} doesn't                                                                                                        │
│       match any open tag"                                                                                                                                                                            │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
MarkupError: closing tag '[/nf-core/test-datasets/modules/data/genomics/sarscov2/genome/db/metamaps.tar.gz]' at position 589 doesn't match any open tag
```

</details>

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
