### PR TITLE
GH Actions workflow YAML tweaks.

### DIFF
--- a/nf_core/pipeline-template/.github/workflows/branch.yml
+++ b/nf_core/pipeline-template/.github/workflows/branch.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check PRs
         if: github.repository == '{{ name }}'
         run: |
-          "{ [[ {% raw %}${{github.event.pull_request.head.repo.full_name }}{% endraw %} == {{ name }} ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]"
+          { [[ {% raw %}${{github.event.pull_request.head.repo.full_name }}{% endraw %} == {{ name }} ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
 
       # If the above check failed, post a comment on the PR explaining the failure {%- raw %}
       # NOTE - this doesn't currently work if the PR is coming from a fork, due to limitations in GitHub actions secrets
@@ -41,5 +41,4 @@ jobs:
 
             Thanks again for your contribution!
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          allow-repeats: false
-# {%- endraw %}
+          allow-repeats: false {%- endraw %}

--- a/nf_core/pipeline-template/.github/workflows/ci.yml
+++ b/nf_core/pipeline-template/.github/workflows/ci.yml
@@ -47,6 +47,4 @@ jobs:
         # For example: adding multiple test runs with different parameters
         # Remember that you can parallelise this by using strategy.matrix
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results
-
-# {%- endraw %}
+          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results {%- endraw %}

--- a/nf_core/pipeline-template/.github/workflows/linting.yml
+++ b/nf_core/pipeline-template/.github/workflows/linting.yml
@@ -77,6 +77,4 @@ jobs:
           path: |
             lint_log.txt
             lint_results.md
-            PR_number.txt
-
-# {%- endraw %}
+            PR_number.txt {%- endraw %}

--- a/nf_core/pipeline-template/.github/workflows/linting_comment.yml
+++ b/nf_core/pipeline-template/.github/workflows/linting_comment.yml
@@ -25,5 +25,4 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ steps.pr_number.outputs.pr_number }}
-          path: linting-logs/lint_results.md
-# {%- endraw %}
+          path: linting-logs/lint_results.md {%- endraw %}


### PR DESCRIPTION
Reported by @d4straub - in https://github.com/nf-core/ampliseq/pull/417 the `branch.yml` workflow is complaining that the PR is against `master`. It is a valid PR against `master` so the bash logic is broken, presumably from [this change](https://github.com/nf-core/ampliseq/pull/413/files#diff-a1d832efe16369fb6549ffea0b71cfaf8da1bf641ff6be470ad40d2303f45577) in the workflow where I added quotes in the template.

Additionally, the floating `#` markers that have appeared at the end of the workflow files have confused a lot of people. @Emiller88 tried to address these in https://github.com/nf-core/tools/pull/1500 but here I have an alternative fix, where I just move the `{% endraw %}` statements off comment lines and on to the tail of the last statement to get rid of floating comment marker. Should be functionally the same for Jinja and as they're now inside a string it's valid YAML again so Prettier should be happy in the template.



<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
