### PR TITLE
Remove the graphviz dependency from nf-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## [v2.3.2 - Mercury Vulture Fixed Formatting](https://github.com/nf-core/tools/releases/tag/2.3.2) - [2022-03-24]
 
-Very minor patch release to fix the full size AWS tests and re-run the template sync, which partially failed due to GitHub pull-requests being down at the time of release.
+This patch release to removes the Graphviz dependency from default pipeline template.
+
+Also included are patches to fix the full size AWS tests and re-run the template sync, which partially failed due to GitHub pull-requests being down at the time of release.
 
 ### Template
 
+- Set the default DAG graphic output to HTML to have a default that does not depend on Graphviz being installed on the host system.
 - Updated the AWS GitHub actions to let nf-core/tower-action use it's defaults for pipeline and git sha ([#1488](https://github.com/nf-core/tools/pull/1488))
 - Add prettier editor extension to `gitpod.yml` in template ([#1485](https://github.com/nf-core/tools/pull/1485))
 - Remove traces of markdownlint in the template ([#1486](https://github.com/nf-core/tools/pull/1486)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.4dev
 
-This patch release to removes the Graphviz dependency from default pipeline template by setting the defaul DAG format to HTML. To keep the pevious behaviour, the "dag.file" file extension needs to be changed to ".svg" in the nextflow.config.
+This patch release to removes the Graphviz dependency from default pipeline template by setting the defaul DAG format to HTML. To keep the previous behaviour, the "dag.file" file extension needs to be changed to ".svg" in the nextflow.config.
 
 ### Template
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## v2.4dev
 
-This patch release to removes the Graphviz dependency from default pipeline template.
+This patch release to removes the Graphviz dependency from default pipeline template by setting the defaul DAG format to HTML. To keep the pevious behaviour, the "dag.file" file extension needs to be changed to ".svg" in the nextflow.config.
 
 ### Template
 
-- Set the default DAG graphic output to HTML to have a default that does not depend on Graphviz being installed on the host system.
+- Set the default DAG graphic output to HTML to have a default that does not depend on Graphviz being installed on the host system ([#1512](https://github.com/nf-core/tools/pull/1512)).
 - Fix bug in pipeline readme logo URL
 - Fix Prettier formatting bug in completion email HTML template ([#1509](https://github.com/nf-core/tools/issues/1509))
 - Removed retry strategy for AWS tests CI, as Nextflow now handles spot instance retries itself

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
 # nf-core/tools: Changelog
 
-## [v2.3.2 - Mercury Vulture Fixed Formatting](https://github.com/nf-core/tools/releases/tag/2.3.2) - [2022-03-24]
+## dev
 
 This patch release to removes the Graphviz dependency from default pipeline template.
 
-Also included are patches to fix the full size AWS tests and re-run the template sync, which partially failed due to GitHub pull-requests being down at the time of release.
+- Set the default DAG graphic output to HTML to have a default that does not depend on Graphviz being installed on the host system.
+
+## [v2.3.2 - Mercury Vulture Fixed Formatting](https://github.com/nf-core/tools/releases/tag/2.3.2) - [2022-03-24]
+
+Very minor patch release to fix the full size AWS tests and re-run the template sync, which partially failed due to GitHub pull-requests being down at the time of release.
 
 ### Template
 
-- Set the default DAG graphic output to HTML to have a default that does not depend on Graphviz being installed on the host system.
 - Updated the AWS GitHub actions to let nf-core/tower-action use it's defaults for pipeline and git sha ([#1488](https://github.com/nf-core/tools/pull/1488))
 - Add prettier editor extension to `gitpod.yml` in template ([#1485](https://github.com/nf-core/tools/pull/1485))
 - Remove traces of markdownlint in the template ([#1486](https://github.com/nf-core/tools/pull/1486)

--- a/nf_core/lint/nextflow_config.py
+++ b/nf_core/lint/nextflow_config.py
@@ -229,7 +229,7 @@ def nextflow_config(self):
 
     # Check that the DAG filename ends in ``.svg``
     if "dag.file" in self.nf_config:
-        dag_file_suffix = os.path.splitext(self.nf_config["dag.file"].strip("'\""))
+        _, dag_file_suffix = os.path.splitext(self.nf_config["dag.file"].strip("'\""))
         allowed_dag_file_suffixes = [".dot", ".html", ".pdf", ".png", ".svg", ".gexf"]
         if dag_file_suffix in allowed_dag_file_suffixes:
             passed.append(f"Config ``dag.file`` ended with ``.{dag_file_suffix}``")

--- a/nf_core/lint/nextflow_config.py
+++ b/nf_core/lint/nextflow_config.py
@@ -234,7 +234,9 @@ def nextflow_config(self):
         if dag_file_suffix in allowed_dag_file_suffixes:
             passed.append(f"Config ``dag.file`` ended with ``.{dag_file_suffix}``")
         else:
-            failed.append(f"Config ``dag.file`` ended with ``.{dag_file_suffix}`` but needs to be one of {allowed_dag_file_suffixes!r}")
+            failed.append(
+                f"Config ``dag.file`` ended with ``.{dag_file_suffix}`` but needs to be one of {allowed_dag_file_suffixes!r}"
+            )
 
     # Check that the minimum nextflowVersion is set properly
     if "manifest.nextflowVersion" in self.nf_config:

--- a/nf_core/lint/nextflow_config.py
+++ b/nf_core/lint/nextflow_config.py
@@ -229,10 +229,12 @@ def nextflow_config(self):
 
     # Check that the DAG filename ends in ``.svg``
     if "dag.file" in self.nf_config:
-        if self.nf_config["dag.file"].strip("'\"").endswith(".svg"):
-            passed.append("Config ``dag.file`` ended with ``.svg``")
+        dag_file_suffix = os.path.splitext(self.nf_config["dag.file"].strip("'\""))
+        allowed_dag_file_suffixes = [".dot", ".html", ".pdf", ".png", ".svg", ".gexf"]
+        if dag_file_suffix in allowed_dag_file_suffixes:
+            passed.append(f"Config ``dag.file`` ended with ``.{dag_file_suffix}``")
         else:
-            failed.append("Config ``dag.file`` did not end with ``.svg``")
+            failed.append(f"Config ``dag.file`` ended with ``.{dag_file_suffix}`` but needs to be one of {allowed_dag_file_suffixes!r}")
 
     # Check that the minimum nextflowVersion is set properly
     if "manifest.nextflowVersion" in self.nf_config:

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -159,7 +159,7 @@ trace {
 }
 dag {
     enabled = true
-    file    = "${params.tracedir}/pipeline_dag_${trace_timestamp}.svg"
+    file    = "${params.tracedir}/pipeline_dag_${trace_timestamp}.html"
 }
 
 manifest {


### PR DESCRIPTION
The current default DAG image format SVG requires Graphviz. Using the HTML version removes the Graphviz dependency.

It is now common to see the Warning about the missing Graphviz dependency when running nf-core pipelines. In my limited experience it is often the only warning and often not a very useful at that because the DAG is not a main product of the pipeline in most use cases.

To have the DAG image output as HTML should be fine, since most computers who can display a PNG will also have a browser that can render a HTML file.

Because the Graphviz dependency is on the host system rather than in a container, this means the hassle of installation is left with the user. A big part of Nextflow/nf-core is that it abstracts installations away from users. I consider the Graphviz dependency a clear anti-pattern for Nextflow and nf-core.

Because this makes life easier for users, no additional docs are needed.

This PR arouse out of me seeing 

```
WARN: To render the execution DAG in the required format it is required to install Graphviz -- See http://www.graphviz.org/ for more info.
```

in a nextflow log on a LSF cluster and the discussion on [Slack](https://nfcore.slack.com/archives/CE56GDKN0/p1649703103431669) that followed.

An alternative solution might be to use a Graphviz DSL2 module to produce the PNG and remove the dependency on the host system in the most Nextflow way possible.

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
