### PR TITLE
Don't allow a .nf-core.yaml file (should be .yml)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This patch release to removes the Graphviz dependency from default pipeline temp
 - Bumped the minimum version of `rich` from `v10` to `v10.7.0`
 - Add an empty line to `modules.json`, `params.json` and `nextflow-schema.json` when dumping them to avoid prettier errors.
 - Add actions workflow to respond to `@nf-core-bot fix linting` comments on nf-core/tools PRs
+- Linting: Don't allow a `.nf-core.yaml` file, should be `.yml` ([#1515](https://github.com/nf-core/tools/pull/1515)).
 
 ### Modules
 

--- a/nf_core/lint/files_exist.py
+++ b/nf_core/lint/files_exist.py
@@ -76,6 +76,7 @@ def files_exist(self):
 
         Singularity
         parameters.settings.json
+        .nf-core.yaml  # NB: Should be yml, not yaml
         bin/markdown_to_html.r
         conf/aws.config
         .github/workflows/push_dockerhub.yml
@@ -90,6 +91,15 @@ def files_exist(self):
     .. code-block:: bash
 
         .travis.yml
+
+    .. tip:: You can configure the ``nf-core lint`` tests to ignore any of these checks by setting
+            the ``files_exist`` key as follows in your ``.nf-core.yml`` config file. For example:
+
+            .. code-block:: yaml
+
+            lint:
+                files_exist:
+                    - assets/multiqc_config.yml
     """
 
     passed = []
@@ -160,6 +170,7 @@ def files_exist(self):
     files_fail_ifexists = [
         "Singularity",
         "parameters.settings.json",
+        ".nf-core.yaml",  # yml not yaml
         os.path.join("bin", "markdown_to_html.r"),
         os.path.join("conf", "aws.config"),
         os.path.join(".github", "workflows", "push_dockerhub.yml"),

--- a/nf_core/lint/files_unchanged.py
+++ b/nf_core/lint/files_unchanged.py
@@ -47,12 +47,13 @@ def files_unchanged(self):
         .gitignore
 
     .. tip:: You can configure the ``nf-core lint`` tests to ignore any of these checks by setting
-             the ``files_unchanged`` key as follows in your linting config file. For example:
+             the ``files_unchanged`` key as follows in your ``.nf-core.yml`` config file. For example:
 
              .. code-block:: yaml
 
-                files_unchanged:
-                  - .github/workflows/branch.yml
+                lint:
+                    files_unchanged:
+                        - .github/workflows/branch.yml
 
     """
 


### PR DESCRIPTION
Disallow `.yaml` file extension for the nf-core config file. We definitely don't want two versions of this file, and the template has `.yml`.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
