### PR TITLE
revert to single dag graph format allowance when linting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
+email_template.html
 docs/api/_build
 testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## [v2.3.2 - Mercury Vulture Fixed Formatting](https://github.com/nf-core/tools/releases/tag/2.3.2) - [2022-03-24]
 
-Very minor patch release to fix the full size AWS tests and re-run the template sync, which partially failed due to GitHub pull-requests being down at the time of release.
+This patch release to removes the Graphviz dependency from default pipeline template.
+
+Also included are patches to fix the full size AWS tests and re-run the template sync, which partially failed due to GitHub pull-requests being down at the time of release.
 
 ### Template
 
+- Set the default DAG graphic output to HTML to have a default that does not depend on Graphviz being installed on the host system.
 - Updated the AWS GitHub actions to let nf-core/tower-action use it's defaults for pipeline and git sha ([#1488](https://github.com/nf-core/tools/pull/1488))
 - Add prettier editor extension to `gitpod.yml` in template ([#1485](https://github.com/nf-core/tools/pull/1485))
 - Remove traces of markdownlint in the template ([#1486](https://github.com/nf-core/tools/pull/1486)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## v2.4dev
 
-This patch release to removes the Graphviz dependency from default pipeline template by setting the defaul DAG format to HTML. To keep the previous behaviour, the "dag.file" file extension needs to be changed to ".svg" in the nextflow.config.
-
 ### Template
 
 - Set the default DAG graphic output to HTML to have a default that does not depend on Graphviz being installed on the host system ([#1512](https://github.com/nf-core/tools/pull/1512)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.4dev
 
-This patch release to removes the Graphviz dependency from default pipeline template by setting the defaul DAG format to HTML. To keep the pevious behaviour, the "dag.file" file extension needs to be changed to ".svg" in the nextflow.config.
+This patch release to removes the Graphviz dependency from default pipeline template by setting the defaul DAG format to HTML. To keep the previous behaviour, the "dag.file" file extension needs to be changed to ".svg" in the nextflow.config.
 
 ### Template
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## v2.4dev
 
-This patch release to removes the Graphviz dependency from default pipeline template.
+This patch release to removes the Graphviz dependency from default pipeline template by setting the defaul DAG format to HTML. To keep the pevious behaviour, the "dag.file" file extension needs to be changed to ".svg" in the nextflow.config.
 
 ### Template
 
-- Set the default DAG graphic output to HTML to have a default that does not depend on Graphviz being installed on the host system.
+- Set the default DAG graphic output to HTML to have a default that does not depend on Graphviz being installed on the host system ([#1512](https://github.com/nf-core/tools/pull/1512)).
 - Fix bug in pipeline readme logo URL
 - Fix Prettier formatting bug in completion email HTML template ([#1509](https://github.com/nf-core/tools/issues/1509))
 - Removed retry strategy for AWS tests CI, as Nextflow now handles spot instance retries itself

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
 # nf-core/tools: Changelog
 
-## [v2.3.2 - Mercury Vulture Fixed Formatting](https://github.com/nf-core/tools/releases/tag/2.3.2) - [2022-03-24]
+## dev
 
 This patch release to removes the Graphviz dependency from default pipeline template.
 
-Also included are patches to fix the full size AWS tests and re-run the template sync, which partially failed due to GitHub pull-requests being down at the time of release.
+- Set the default DAG graphic output to HTML to have a default that does not depend on Graphviz being installed on the host system.
+
+## [v2.3.2 - Mercury Vulture Fixed Formatting](https://github.com/nf-core/tools/releases/tag/2.3.2) - [2022-03-24]
+
+Very minor patch release to fix the full size AWS tests and re-run the template sync, which partially failed due to GitHub pull-requests being down at the time of release.
 
 ### Template
 
-- Set the default DAG graphic output to HTML to have a default that does not depend on Graphviz being installed on the host system.
 - Updated the AWS GitHub actions to let nf-core/tower-action use it's defaults for pipeline and git sha ([#1488](https://github.com/nf-core/tools/pull/1488))
 - Add prettier editor extension to `gitpod.yml` in template ([#1485](https://github.com/nf-core/tools/pull/1485))
 - Remove traces of markdownlint in the template ([#1486](https://github.com/nf-core/tools/pull/1486)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,25 @@
 # nf-core/tools: Changelog
 
-## dev
+## v2.4dev
 
 This patch release to removes the Graphviz dependency from default pipeline template.
 
+### Template
+
 - Set the default DAG graphic output to HTML to have a default that does not depend on Graphviz being installed on the host system.
+- Fix bug in pipeline readme logo URL
+- Fix Prettier formatting bug in completion email HTML template ([#1509](https://github.com/nf-core/tools/issues/1509))
+- Removed retry strategy for AWS tests CI, as Nextflow now handles spot instance retries itself
+- Add `.prettierignore` file to stop Prettier linting tests from running over test files
+
+### General
+
+- Bumped the minimum version of `rich` from `v10` to `v10.7.0`
+- Add an empty line to `modules.json`, `params.json` and `nextflow-schema.json` when dumping them to avoid prettier errors.
+
+### Modules
+
+- Escaped test run output before logging it, to avoid a rich ` MarkupError`
 
 ## [v2.3.2 - Mercury Vulture Fixed Formatting](https://github.com/nf-core/tools/releases/tag/2.3.2) - [2022-03-24]
 

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -39,8 +39,8 @@ class PipelineCreate(object):
         self.name = f"nf-core/{self.short_name}"
         self.name_noslash = self.name.replace("/", "-")
         self.name_docker = self.name.replace("nf-core", "nfcore")
-        self.logo_light = f"{self.name}_logo_light.png"
-        self.logo_dark = f"{self.name}_logo_dark.png"
+        self.logo_light = f"{self.name_noslash}_logo_light.png"
+        self.logo_dark = f"{self.name_noslash}_logo_dark.png"
         self.description = description
         self.author = author
         self.version = version

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -692,6 +692,7 @@ class Launch(object):
             if self.use_params_file:
                 with open(self.params_out, "w") as fp:
                     json.dump(self.schema_obj.input_params, fp, indent=4)
+                    fp.write("\n")
                 self.nextflow_cmd += ' {} "{}"'.format("-params-file", os.path.relpath(self.params_out))
 
             # Call nextflow with a list of command line flags

--- a/nf_core/lint/nextflow_config.py
+++ b/nf_core/lint/nextflow_config.py
@@ -229,7 +229,7 @@ def nextflow_config(self):
 
     # Check that the DAG filename ends in ``.svg``
     if "dag.file" in self.nf_config:
-        dag_file_suffix = os.path.splitext(self.nf_config["dag.file"].strip("'\""))
+        _, dag_file_suffix = os.path.splitext(self.nf_config["dag.file"].strip("'\""))
         allowed_dag_file_suffixes = [".dot", ".html", ".pdf", ".png", ".svg", ".gexf"]
         if dag_file_suffix in allowed_dag_file_suffixes:
             passed.append(f"Config ``dag.file`` ended with ``.{dag_file_suffix}``")

--- a/nf_core/lint/nextflow_config.py
+++ b/nf_core/lint/nextflow_config.py
@@ -234,7 +234,9 @@ def nextflow_config(self):
         if dag_file_suffix in allowed_dag_file_suffixes:
             passed.append(f"Config ``dag.file`` ended with ``.{dag_file_suffix}``")
         else:
-            failed.append(f"Config ``dag.file`` ended with ``.{dag_file_suffix}`` but needs to be one of {allowed_dag_file_suffixes!r}")
+            failed.append(
+                f"Config ``dag.file`` ended with ``.{dag_file_suffix}`` but needs to be one of {allowed_dag_file_suffixes!r}"
+            )
 
     # Check that the minimum nextflowVersion is set properly
     if "manifest.nextflowVersion" in self.nf_config:

--- a/nf_core/lint/nextflow_config.py
+++ b/nf_core/lint/nextflow_config.py
@@ -229,14 +229,11 @@ def nextflow_config(self):
 
     # Check that the DAG filename ends in ``.svg``
     if "dag.file" in self.nf_config:
-        _, dag_file_suffix = os.path.splitext(self.nf_config["dag.file"].strip("'\""))
-        allowed_dag_file_suffixes = [".dot", ".html", ".pdf", ".png", ".svg", ".gexf"]
-        if dag_file_suffix in allowed_dag_file_suffixes:
-            passed.append(f"Config ``dag.file`` ended with ``.{dag_file_suffix}``")
+        default_dag_format = ".html"
+        if self.nf_config["dag.file"].strip("'\"").endswith(default_dag_format):
+            passed.append(f"Config ``dag.file`` ended with ``{default_dag_format}``")
         else:
-            failed.append(
-                f"Config ``dag.file`` ended with ``.{dag_file_suffix}`` but needs to be one of {allowed_dag_file_suffixes!r}"
-            )
+            failed.append(f"Config ``dag.file`` did not end with ``{default_dag_format}``")
 
     # Check that the minimum nextflowVersion is set properly
     if "manifest.nextflowVersion" in self.nf_config:

--- a/nf_core/lint/nextflow_config.py
+++ b/nf_core/lint/nextflow_config.py
@@ -229,10 +229,12 @@ def nextflow_config(self):
 
     # Check that the DAG filename ends in ``.svg``
     if "dag.file" in self.nf_config:
-        if self.nf_config["dag.file"].strip("'\"").endswith(".svg"):
-            passed.append("Config ``dag.file`` ended with ``.svg``")
+        dag_file_suffix = os.path.splitext(self.nf_config["dag.file"].strip("'\""))
+        allowed_dag_file_suffixes = [".dot", ".html", ".pdf", ".png", ".svg", ".gexf"]
+        if dag_file_suffix in allowed_dag_file_suffixes:
+            passed.append(f"Config ``dag.file`` ended with ``.{dag_file_suffix}``")
         else:
-            failed.append("Config ``dag.file`` did not end with ``.svg``")
+            failed.append(f"Config ``dag.file`` ended with ``.{dag_file_suffix}`` but needs to be one of {allowed_dag_file_suffixes!r}")
 
     # Check that the minimum nextflowVersion is set properly
     if "manifest.nextflowVersion" in self.nf_config:

--- a/nf_core/modules/module_utils.py
+++ b/nf_core/modules/module_utils.py
@@ -188,6 +188,7 @@ def create_modules_json(pipeline_dir):
     modules_json_path = os.path.join(pipeline_dir, "modules.json")
     with open(modules_json_path, "w") as fh:
         json.dump(modules_json, fh, indent=4)
+        fh.write("\n")
 
 
 def find_correct_commit_sha(module_name, module_path, modules_repo):

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -301,6 +301,7 @@ class ModuleCommand:
         modules_json_path = os.path.join(self.dir, "modules.json")
         with open(modules_json_path, "w") as fh:
             json.dump(modules_json, fh, indent=4)
+            fh.write("\n")
 
     def load_lint_config(self):
         """Parse a pipeline lint config file.

--- a/nf_core/modules/test_yml_builder.py
+++ b/nf_core/modules/test_yml_builder.py
@@ -330,12 +330,13 @@ class ModulesTestYmlBuilder(object):
                     "It looks like Nextflow is not installed. It is required for most nf-core functions."
                 )
         except subprocess.CalledProcessError as e:
-            raise UserWarning(f"Error running test workflow (exit code {e.returncode})\n[red]{e.output.decode()}")
+            output = rich.markup.escape(e.output.decode())
+            raise UserWarning(f"Error running test workflow (exit code {e.returncode})\n[red]{output}")
         except Exception as e:
             raise UserWarning(f"Error running test workflow: {e}")
         else:
             log.info("Test workflow finished!")
-            log.debug(nfconfig_raw)
+            log.debug(rich.markup.escape(nfconfig_raw))
 
         return tmp_dir, tmp_dir_repeat
 

--- a/nf_core/pipeline-template/.github/workflows/awsfulltest.yml
+++ b/nf_core/pipeline-template/.github/workflows/awsfulltest.yml
@@ -28,6 +28,3 @@ jobs:
               "outdir": "s3://{% raw %}${{ secrets.AWS_S3_BUCKET }}{% endraw %}/{{ short_name }}/{% raw %}results-${{ github.sha }}{% endraw %}"
             }
           profiles: test_full,aws_tower
-          nextflow_config: |
-            process.errorStrategy = 'retry'
-            process.maxRetries = 3

--- a/nf_core/pipeline-template/.github/workflows/awstest.yml
+++ b/nf_core/pipeline-template/.github/workflows/awstest.yml
@@ -23,6 +23,3 @@ jobs:
               "outdir": "s3://{% raw %}${{ secrets.AWS_S3_BUCKET }}{% endraw %}/{{ short_name }}/{% raw %}results-test-${{ github.sha }}{% endraw %}"
             }
           profiles: test,aws_tower
-          nextflow_config: |
-            process.errorStrategy = 'retry'
-            process.maxRetries = 3

--- a/nf_core/pipeline-template/.github/workflows/branch.yml
+++ b/nf_core/pipeline-template/.github/workflows/branch.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check PRs
         if: github.repository == '{{ name }}'
         run: |
-          "{ [[ {% raw %}${{github.event.pull_request.head.repo.full_name }}{% endraw %} == {{ name }} ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]"
+          { [[ {% raw %}${{github.event.pull_request.head.repo.full_name }}{% endraw %} == {{ name }} ]] && [[ $GITHUB_HEAD_REF = "dev" ]]; } || [[ $GITHUB_HEAD_REF == "patch" ]]
 
       # If the above check failed, post a comment on the PR explaining the failure {%- raw %}
       # NOTE - this doesn't currently work if the PR is coming from a fork, due to limitations in GitHub actions secrets
@@ -41,5 +41,4 @@ jobs:
 
             Thanks again for your contribution!
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          allow-repeats: false
-# {%- endraw %}
+          allow-repeats: false {%- endraw %}

--- a/nf_core/pipeline-template/.github/workflows/ci.yml
+++ b/nf_core/pipeline-template/.github/workflows/ci.yml
@@ -47,6 +47,4 @@ jobs:
         # For example: adding multiple test runs with different parameters
         # Remember that you can parallelise this by using strategy.matrix
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results
-
-# {%- endraw %}
+          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results {%- endraw %}

--- a/nf_core/pipeline-template/.github/workflows/linting.yml
+++ b/nf_core/pipeline-template/.github/workflows/linting.yml
@@ -77,6 +77,4 @@ jobs:
           path: |
             lint_log.txt
             lint_results.md
-            PR_number.txt
-
-# {%- endraw %}
+            PR_number.txt {%- endraw %}

--- a/nf_core/pipeline-template/.github/workflows/linting_comment.yml
+++ b/nf_core/pipeline-template/.github/workflows/linting_comment.yml
@@ -25,5 +25,4 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ steps.pr_number.outputs.pr_number }}
-          path: linting-logs/lint_results.md
-# {%- endraw %}
+          path: linting-logs/lint_results.md {%- endraw %}

--- a/nf_core/pipeline-template/.prettierignore
+++ b/nf_core/pipeline-template/.prettierignore
@@ -1,0 +1,9 @@
+email_template.html
+.nextflow*
+work/
+data/
+results/
+.DS_Store
+testing/
+testing*
+*.pyc

--- a/nf_core/pipeline-template/assets/email_template.html
+++ b/nf_core/pipeline-template/assets/email_template.html
@@ -1,111 +1,53 @@
 <html>
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <!-- prettier-ignore -->
-    <meta name="description" content="{{ name }}: {{ description }}" />
-    <title>{{ name }} Pipeline Report</title>
-  </head>
-  <body>
-    <div style="font-family: Helvetica, Arial, sans-serif; padding: 30px; max-width: 800px; margin: 0 auto">
-      <img src="cid:nfcorepipelinelogo" />
+  <meta name="description" content="{{ name }}: {{ description }}">
+  <title>{{ name }} Pipeline Report</title>
+</head>
+<body>
+<div style="font-family: Helvetica, Arial, sans-serif; padding: 30px; max-width: 800px; margin: 0 auto;">
 
-      <h1>{{ name }} v${version}</h1>
-      <h2>Run Name: $runName</h2>
+<img src="cid:nfcorepipelinelogo">
 
-      <% if (!success){ out << """
-      <div
-        style="
-          color: #a94442;
-          background-color: #f2dede;
-          border-color: #ebccd1;
-          padding: 15px;
-          margin-bottom: 20px;
-          border: 1px solid transparent;
-          border-radius: 4px;
-        "
-      >
-        <h4 style="margin-top: 0; color: inherit">{{ name }} execution completed unsuccessfully!</h4>
+<h1>{{ name }} v${version}</h1>
+<h2>Run Name: $runName</h2>
+
+<% if (!success){
+    out << """
+    <div style="color: #a94442; background-color: #f2dede; border-color: #ebccd1; padding: 15px; margin-bottom: 20px; border: 1px solid transparent; border-radius: 4px;">
+        <h4 style="margin-top:0; color: inherit;">{{ name }} execution completed unsuccessfully!</h4>
         <p>The exit status of the task that caused the workflow execution to fail was: <code>$exitStatus</code>.</p>
         <p>The full error message was:</p>
-        <pre style="white-space: pre-wrap; overflow: visible; margin-bottom: 0">${errorReport}</pre>
-      </div>
-      """ } else { out << """
-      <div
-        style="
-          color: #3c763d;
-          background-color: #dff0d8;
-          border-color: #d6e9c6;
-          padding: 15px;
-          margin-bottom: 20px;
-          border: 1px solid transparent;
-          border-radius: 4px;
-        "
-      >
-        {{ name }} execution completed successfully!
-      </div>
-      """ } %>
-
-      <p>The workflow was completed at <strong>$dateComplete</strong> (duration: <strong>$duration</strong>)</p>
-      <p>The command used to launch the workflow was as follows:</p>
-      <pre
-        style="
-          white-space: pre-wrap;
-          overflow: visible;
-          background-color: #ededed;
-          padding: 15px;
-          border-radius: 4px;
-          margin-bottom: 30px;
-        "
-      >
-$commandLine</pre
-      >
-
-      <h3>Pipeline Configuration:</h3>
-      <table
-        style="
-          width: 100%;
-          max-width: 100%;
-          border-spacing: 0;
-          border-collapse: collapse;
-          border: 0;
-          margin-bottom: 30px;
-        "
-      >
-        <tbody style="border-bottom: 1px solid #ddd">
-          <% out << summary.collect{ k,v -> "
-          <tr>
-            <th
-              style="
-                text-align: left;
-                padding: 8px 0;
-                line-height: 1.42857143;
-                vertical-align: top;
-                border-top: 1px solid #ddd;
-              "
-            >
-              $k
-            </th>
-            <td
-              style="
-                text-align: left;
-                padding: 8px;
-                line-height: 1.42857143;
-                vertical-align: top;
-                border-top: 1px solid #ddd;
-              "
-            >
-              <pre style="white-space: pre-wrap; overflow: visible">$v</pre>
-            </td>
-          </tr>
-          " }.join("\n") %>
-        </tbody>
-      </table>
-
-      <p>{{ name }}</p>
-      <p><a href="https://github.com/{{ name }}">https://github.com/{{ name }}</a></p>
+        <pre style="white-space: pre-wrap; overflow: visible; margin-bottom: 0;">${errorReport}</pre>
     </div>
-  </body>
+    """
+} else {
+    out << """
+    <div style="color: #3c763d; background-color: #dff0d8; border-color: #d6e9c6; padding: 15px; margin-bottom: 20px; border: 1px solid transparent; border-radius: 4px;">
+        {{ name }} execution completed successfully!
+    </div>
+    """
+}
+%>
+
+<p>The workflow was completed at <strong>$dateComplete</strong> (duration: <strong>$duration</strong>)</p>
+<p>The command used to launch the workflow was as follows:</p>
+<pre style="white-space: pre-wrap; overflow: visible; background-color: #ededed; padding: 15px; border-radius: 4px; margin-bottom:30px;">$commandLine</pre>
+
+<h3>Pipeline Configuration:</h3>
+<table style="width:100%; max-width:100%; border-spacing: 0; border-collapse: collapse; border:0; margin-bottom: 30px;">
+    <tbody style="border-bottom: 1px solid #ddd;">
+        <% out << summary.collect{ k,v -> "<tr><th style='text-align:left; padding: 8px 0; line-height: 1.42857143; vertical-align: top; border-top: 1px solid #ddd;'>$k</th><td style='text-align:left; padding: 8px; line-height: 1.42857143; vertical-align: top; border-top: 1px solid #ddd;'><pre style='white-space: pre-wrap; overflow: visible;'>$v</pre></td></tr>" }.join("\n") %>
+    </tbody>
+</table>
+
+<p>{{ name }}</p>
+<p><a href="https://github.com/{{ name }}">https://github.com/{{ name }}</a></p>
+
+</div>
+
+</body>
 </html>

--- a/nf_core/pipeline-template/bin/check_samplesheet.py
+++ b/nf_core/pipeline-template/bin/check_samplesheet.py
@@ -98,7 +98,7 @@ class RowChecker:
         if row[self._first_col] and row[self._second_col]:
             row[self._single_col] = False
             assert (
-                Path(row[self._first_col]).suffixes == Path(row[self._second_col]).suffixes
+                Path(row[self._first_col]).suffixes[-2:] == Path(row[self._second_col]).suffixes[-2:]
             ), "FASTQ pairs must have the same file extensions."
         else:
             row[self._single_col] = True

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -159,7 +159,7 @@ trace {
 }
 dag {
     enabled = true
-    file    = "${params.tracedir}/pipeline_dag_${trace_timestamp}.svg"
+    file    = "${params.tracedir}/pipeline_dag_${trace_timestamp}.html"
 }
 
 manifest {

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -171,6 +171,7 @@ class PipelineSchema(object):
         log.info("Writing schema with {} params: '{}'".format(num_params, self.schema_filename))
         with open(self.schema_filename, "w") as fh:
             json.dump(self.schema, fh, indent=4)
+            fh.write("\n")
 
     def load_input_params(self, params_path):
         """Load a given a path to a parameters file (JSON/YAML)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ questionary>=1.8.0
 requests
 requests_cache
 rich-click>=1.0.0
-rich>=10.0.0
+rich>=10.7.0
 tabulate

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-version = "2.3.2"
+version = "2.4dev"
 
 with open("README.md") as f:
     readme = f.read()


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

#1512 introduced code to allow all nf-core supported DAG graph formats in the default linting. This was not desired and thus removed in this PR.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
