### PR TITLE
revert to single dag.file file format for linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## v2.4dev
 
-This patch release to removes the Graphviz dependency from default pipeline template by setting the defaul DAG format to HTML. To keep the previous behaviour, the "dag.file" file extension needs to be changed to ".svg" in the nextflow.config.
-
 ### Template
 
 - Set the default DAG graphic output to HTML to have a default that does not depend on Graphviz being installed on the host system ([#1512](https://github.com/nf-core/tools/pull/1512)).

--- a/nf_core/lint/nextflow_config.py
+++ b/nf_core/lint/nextflow_config.py
@@ -229,14 +229,11 @@ def nextflow_config(self):
 
     # Check that the DAG filename ends in ``.svg``
     if "dag.file" in self.nf_config:
-        _, dag_file_suffix = os.path.splitext(self.nf_config["dag.file"].strip("'\""))
-        allowed_dag_file_suffixes = [".dot", ".html", ".pdf", ".png", ".svg", ".gexf"]
-        if dag_file_suffix in allowed_dag_file_suffixes:
-            passed.append(f"Config ``dag.file`` ended with ``.{dag_file_suffix}``")
+        default_dag_format = ".html"
+        if self.nf_config["dag.file"].strip("'\"").endswith(default_dag_format):
+            passed.append(f"Config ``dag.file`` ended with ``{default_dag_format}``")
         else:
-            failed.append(
-                f"Config ``dag.file`` ended with ``.{dag_file_suffix}`` but needs to be one of {allowed_dag_file_suffixes!r}"
-            )
+            failed.append(f"Config ``dag.file`` did not end with ``{default_dag_format}``")
 
     # Check that the minimum nextflowVersion is set properly
     if "manifest.nextflowVersion" in self.nf_config:


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

https://github.com/nf-core/tools/pull/1512 introduced code to allow all nf-core supported DAG graph formats in the default linting. This was not desired and thus removed in this PR.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
