### PR TITLE
don't updatate sha if the module is not updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Bumped the minimum version of `rich` from `v10` to `v10.7.0`
 - Add an empty line to `modules.json`, `params.json` and `nextflow-schema.json` when dumping them to avoid prettier errors.
+- Fix bug in modules.json when a module is not updated ([#1518](https://github.com/nf-core/tools/pull/1518))
 
 ### Modules
 

--- a/nf_core/modules/update.py
+++ b/nf_core/modules/update.py
@@ -428,12 +428,6 @@ class ModuleUpdate(ModuleCommand):
             if not dry_run:
                 self.update_modules_json(modules_json, modules_repo.name, module, version)
 
-            # Don't save to a file, just iteratively update the variable
-            else:
-                modules_json = self.update_modules_json(
-                    modules_json, modules_repo.name, module, version, write_file=False
-                )
-
         if self.save_diff_fn:
             # Compare the new modules.json and build a diff
             modules_json_diff = difflib.unified_diff(


### PR DESCRIPTION
Closes #1514

The version of all modules was updated in the variable modules_json even though the module was not updated. The information from this variable was dumped to modules.json when another module was updated.

I deleted the line updating modules_json when the module is not updated.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
