### PR TITLE
Print include statement when modules install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@
 - Fix Prettier formatting bug in completion email HTML template ([#1509](https://github.com/nf-core/tools/issues/1509))
 - Removed retry strategy for AWS tests CI, as Nextflow now handles spot instance retries itself
 - Add `.prettierignore` file to stop Prettier linting tests from running over test files
-- Print include statement to terminal when `modules install` ([#1520](https://github.com/nf-core/tools/pull/1520))
 
 ### General
 
 - Bumped the minimum version of `rich` from `v10` to `v10.7.0`
 - Add an empty line to `modules.json`, `params.json` and `nextflow-schema.json` when dumping them to avoid prettier errors.
+- Print include statement to terminal when `modules install` ([#1520](https://github.com/nf-core/tools/pull/1520))
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix Prettier formatting bug in completion email HTML template ([#1509](https://github.com/nf-core/tools/issues/1509))
 - Removed retry strategy for AWS tests CI, as Nextflow now handles spot instance retries itself
 - Add `.prettierignore` file to stop Prettier linting tests from running over test files
+- Print include statement to terminal when `modules install` ([#1520](https://github.com/nf-core/tools/pull/1520))
 
 ### General
 

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -131,11 +131,7 @@ class ModuleInstall(ModuleCommand):
             return False
 
         # Print include statement
-        if module == "stringtie/stringtie":
-            # Only with stringtie the process name is STRINGTIE instead of STRINGTIE_STRINGTIE
-            module_name = module.upper().split("/")[0]
-        else:
-            module_name = "_".join(module.upper().split("/"))
+        module_name = "_".join(module.upper().split("/"))
         log.info(f"Include statement: include {{ {module_name} }} from '.{os.path.join(*install_folder, module)}/main’")
 
         # Update module.json with newly installed module

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -130,6 +130,14 @@ class ModuleInstall(ModuleCommand):
         if not self.download_module_file(module, version, self.modules_repo, install_folder):
             return False
 
+        # Print include statement
+        if module == "stringtie/stringtie":
+            # Only with stringtie the process name is STRINGTIE instead of STRINGTIE_STRINGTIE
+            module_name = module.upper().split("/")[0]
+        else:
+            module_name = "_".join(module.upper().split("/"))
+        log.info(f"Include statement: include {{ {module_name} }} from '.{os.path.join(*install_folder, module)}/main’")
+
         # Update module.json with newly installed module
         self.update_modules_json(modules_json, self.modules_repo.name, module, version)
         return True


### PR DESCRIPTION
Closes #1420

When using `nf-core modules install` print the include statements to terminal for easy copy to destination files.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
