### PR TITLE
add new command modules test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 - Escaped test run output before logging it, to avoid a rich ` MarkupError`
 - Add a new command `nf-core modules mulled` which can generate the name for a multi-tool container image.
+- Add a new command `nf-core modules test` which runs pytests locally.
 
 ## [v2.3.2 - Mercury Vulture Fixed Formatting](https://github.com/nf-core/tools/releases/tag/2.3.2) - [2022-03-24]
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -49,7 +49,7 @@ click.rich_click.COMMAND_GROUPS = {
         },
         {
             "name": "Developing new modules",
-            "commands": ["create", "create-test-yml", "lint", "bump-versions"],
+            "commands": ["create", "create-test-yml", "lint", "bump-versions", "test"],
         },
     ],
 }
@@ -669,6 +669,25 @@ def bump_versions(ctx, tool, dir, all, show_all):
     except nf_core.modules.module_utils.ModuleException as e:
         log.error(e)
         sys.exit(1)
+    except UserWarning as e:
+        log.critical(e)
+        sys.exit(1)
+
+
+# nf-core modules test
+@modules.command("test")
+@click.pass_context
+@click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
+@click.option("-p", "--no-prompts", is_flag=True, default=False, help="Use defaults without prompting")
+def test_module(ctx, tool, no_prompts):
+    """
+    Run module tests locally.
+
+    Given the name of a module, runs the Nextflow test command.
+    """
+    try:
+        meta_builder = nf_core.modules.ModulesTest(tool, no_prompts)
+        meta_builder.run()
     except UserWarning as e:
         log.critical(e)
         sys.exit(1)

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -679,14 +679,15 @@ def bump_versions(ctx, tool, dir, all, show_all):
 @click.pass_context
 @click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
 @click.option("-p", "--no-prompts", is_flag=True, default=False, help="Use defaults without prompting")
-def test_module(ctx, tool, no_prompts):
+@click.option("-a", "--pytest_args", type=str, required=False, multiple=True, help="Additional pytest arguments")
+def test_module(ctx, tool, no_prompts, pytest_args):
     """
     Run module tests locally.
 
     Given the name of a module, runs the Nextflow test command.
     """
     try:
-        meta_builder = nf_core.modules.ModulesTest(tool, no_prompts)
+        meta_builder = nf_core.modules.ModulesTest(tool, no_prompts, pytest_args)
         meta_builder.run()
     except UserWarning as e:
         log.critical(e)

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -708,7 +708,7 @@ def mulled(specifications, build_number):
         )
         sys.exit(1)
 
-        
+
 # nf-core modules test
 @modules.command("test")
 @click.pass_context

--- a/nf_core/modules/__init__.py
+++ b/nf_core/modules/__init__.py
@@ -9,3 +9,4 @@ from .install import ModuleInstall
 from .update import ModuleUpdate
 from .remove import ModuleRemove
 from .info import ModuleInfo
+from .module_test import ModulesTest

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -87,7 +87,9 @@ class ModulesTest(object):
 
         # First, sanity check that the module directory exists
         if not module_dir.is_dir():
-            raise UserWarning(f"Cannot find directory '{module_dir}'. Should be TOOL/SUBTOOL or TOOL. Are you running the tests inside the nf-core/modules main directory?")
+            raise UserWarning(
+                f"Cannot find directory '{module_dir}'. Should be TOOL/SUBTOOL or TOOL. Are you running the tests inside the nf-core/modules main directory?"
+            )
 
     def _set_profile(self):
         """Set $PROFILE env variable.
@@ -117,7 +119,6 @@ class ModulesTest(object):
         """Check if profile is available"""
         profile = os.environ.get("PROFILE")
         try:
-
             # Make sure the profile read from the environment is a valid Nextflow profile.
             valid_nextflow_profiles = ["docker", "singularity", "podman", "shifter", "charliecloud", "conda"]
             if profile in valid_nextflow_profiles:

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -25,6 +25,7 @@ class ModulesTest(object):
         self.module_name = module_name
         self.no_prompts = no_prompts
         self.pytest_args = pytest_args
+        self.module_dir = None
 
     def run(self):
         """Run test steps"""
@@ -49,13 +50,10 @@ class ModulesTest(object):
                 style=nf_core.utils.nfcore_question_style,
             ).ask()
         self.module_dir = os.path.join("modules", *self.module_name.split("/"))
-        self.module_test_main = os.path.join("tests", "modules", *self.module_name.split("/"), "main.nf")
 
         # First, sanity check that the module directory exists
         if not os.path.isdir(self.module_dir):
             raise UserWarning(f"Cannot find directory '{self.module_dir}'. Should be TOOL/SUBTOOL or TOOL")
-        if not os.path.exists(self.module_test_main):
-            raise UserWarning(f"Cannot find module test workflow '{self.module_test_main}'")
 
     def set_profile(self):
         """Set $PROFILE env variable.

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -15,6 +15,7 @@ from .modules_repo import ModulesRepo
 
 log = logging.getLogger(__name__)
 
+
 class ModulesTest(object):
     def __init__(
         self,

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -9,6 +9,7 @@ import os
 import pytest
 import sys
 import rich
+from pathlib import Path
 
 import nf_core.utils
 from .modules_repo import ModulesRepo
@@ -52,7 +53,6 @@ class ModulesTest(object):
         self.module_name = module_name
         self.no_prompts = no_prompts
         self.pytest_args = pytest_args
-        self.module_dir = None
 
     def run(self):
         """Run test steps"""
@@ -80,11 +80,11 @@ class ModulesTest(object):
                 choices=modules_repo.modules_avail_module_names,
                 style=nf_core.utils.nfcore_question_style,
             ).ask()
-        self.module_dir = os.path.join("modules", *self.module_name.split("/"))
+        module_dir = Path("modules") / self.module_name
 
         # First, sanity check that the module directory exists
-        if not os.path.isdir(self.module_dir):
-            raise UserWarning(f"Cannot find directory '{self.module_dir}'. Should be TOOL/SUBTOOL or TOOL")
+        if not module_dir.is_dir():
+            raise UserWarning(f"Cannot find directory '{module_dir}'. Should be TOOL/SUBTOOL or TOOL")
 
     def _set_profile(self):
         """Set $PROFILE env variable.
@@ -117,7 +117,7 @@ class ModulesTest(object):
         console.print("[black]" + "─" * console.width)
 
         # Set pytest arguments
-        command_args = ["--tag", f"{self.module_name}", "--symlink", "--keep-workflow-wd"]
+        command_args = ["--tag", f"{self.module_name}", "--symlink", "--keep-workflow-wd", "--git-aware"]
         command_args += self.pytest_args
 
         # Run pytest

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -117,7 +117,9 @@ class ModulesTest(object):
         """Check if profile is available"""
         profile = os.environ.get("PROFILE")
         try:
-            profile_check = subprocess.check_output(shlex.split(f"{profile} --help"), stderr=subprocess.STDOUT, shell=True)
+            profile_check = subprocess.check_output(
+                shlex.split(f"{profile} --help"), stderr=subprocess.STDOUT, shell=True
+            )
         except subprocess.CalledProcessError as e:
             raise UserWarning(f"Error with profile {profile} (exit code {e.returncode})\n[red]{e.output.decode()}")
 

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -9,6 +9,8 @@ import os
 import pytest
 import sys
 import rich
+import subprocess
+import shlex
 from pathlib import Path
 
 import nf_core.utils
@@ -62,6 +64,7 @@ class ModulesTest(object):
             )
         self._check_inputs()
         self._set_profile()
+        self._check_profile()
         self._run_pytests()
 
     def _check_inputs(self):
@@ -109,6 +112,14 @@ class ModulesTest(object):
                 profile = answer["profile"].lower()
                 os.environ["PROFILE"] = profile
                 log.info(f"Setting environment variable '$PROFILE' to '{profile}'")
+
+    def _check_profile(self):
+        """Check if profile is available"""
+        profile = os.environ.get("PROFILE")
+        try:
+            profile_check = subprocess.check_output(shlex.split(f"{profile} --help"), stderr=subprocess.STDOUT, shell=True)
+        except subprocess.CalledProcessError as e:
+            raise UserWarning(f"Error with profile {profile} (exit code {e.returncode})\n[red]{e.output.decode()}")
 
     def _run_pytests(self):
         """Given a module name, run tests."""

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -12,6 +12,7 @@ import rich
 import subprocess
 import shlex
 from pathlib import Path
+from shutil import which
 
 import nf_core.utils
 from .modules_repo import ModulesRepo
@@ -118,18 +119,16 @@ class ModulesTest(object):
     def _check_profile(self):
         """Check if profile is available"""
         profile = os.environ.get("PROFILE")
-        try:
-            # Make sure the profile read from the environment is a valid Nextflow profile.
-            valid_nextflow_profiles = ["docker", "singularity", "podman", "shifter", "charliecloud", "conda"]
-            if profile in valid_nextflow_profiles:
-                profile_check = subprocess.check_output([profile, "--help"], stderr=subprocess.STDOUT)
-            else:
-                raise UserWarning(
-                    f"The profile '{profile}' set in the shell environment is not a valid.\n"
-                    f"Valid Nextflow profiles are {valid_nextflow_profiles}."
-                )
-        except subprocess.CalledProcessError as e:
-            raise UserWarning(f"Error with profile {profile} (exit code {e.returncode})\n[red]{e.output.decode()}")
+        # Make sure the profile read from the environment is a valid Nextflow profile.
+        valid_nextflow_profiles = ["docker", "singularity", "podman", "shifter", "charliecloud", "conda"]
+        if profile in valid_nextflow_profiles:
+            if not which(profile):
+                raise UserWarning(f"The PROFILE '{profile}' set in the shell environment is not available.")
+        else:
+            raise UserWarning(
+                f"The PROFILE '{profile}' set in the shell environment is not valid.\n"
+                f"Valid Nextflow profiles are {valid_nextflow_profiles}."
+            )
 
     def _run_pytests(self):
         """Given a module name, run tests."""

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -87,7 +87,7 @@ class ModulesTest(object):
 
         # First, sanity check that the module directory exists
         if not module_dir.is_dir():
-            raise UserWarning(f"Cannot find directory '{module_dir}'. Should be TOOL/SUBTOOL or TOOL")
+            raise UserWarning(f"Cannot find directory '{module_dir}'. Should be TOOL/SUBTOOL or TOOL. Are you running the tests inside the nf-core/modules main directory?")
 
     def _set_profile(self):
         """Set $PROFILE env variable.

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -107,9 +107,8 @@ class ModulesTest(object):
                 }
                 answer = questionary.unsafe_prompt([question], style=nf_core.utils.nfcore_question_style)
                 profile = answer["profile"].lower()
-                if profile in ["singularity", "conda"]:
-                    os.environ["PROFILE"] = profile
-                    log.info(f"Setting env var '$PROFILE' to '{profile}'")
+                os.environ["PROFILE"] = profile
+                log.info(f"Setting env var '$PROFILE' to '{profile}'")
 
     def _run_pytests(self):
         """Given a module name, run tests."""

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -71,7 +71,7 @@ class ModulesTest(object):
         if self.module_name is None:
             if self.no_prompts:
                 raise UserWarning(
-                    f"Tool name not provided and prompts deactivated. Please provide the tool name as TOOL/SUBTOOL or TOOL."
+                    "Tool name not provided and prompts deactivated. Please provide the tool name as TOOL/SUBTOOL or TOOL."
                 )
             modules_repo = ModulesRepo()
             modules_repo.get_modules_file_tree()

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+"""
+The ModulesTest class runs the tests locally
+"""
+
+import logging
+import questionary
+import os
+
+"""from __future__ import print_function
+from rich.syntax import Syntax
+
+import errno
+import gzip
+import hashlib
+import operator
+
+
+import re
+import rich
+import shlex
+import subprocess
+import tempfile
+import yaml
+
+"""
+import nf_core.utils
+from .modules_repo import ModulesRepo
+from .test_yml_builder import ModulesTestYmlBuilder
+
+log = logging.getLogger(__name__)
+
+
+class ModulesTest(ModulesTestYmlBuilder):
+    def __init__(
+        self,
+        module_name=None,
+        no_prompts=False,
+    ):
+        self.run_tests = True
+        self.module_name = module_name
+        self.no_prompts = no_prompts
+        self.module_dir = None
+        self.module_test_main = None
+        self.entry_points = []
+        self.tests = []
+        self.errors = []
+
+    def run(self):
+        """Run test steps"""
+        if not self.no_prompts:
+            log.info(
+                "[yellow]Press enter to use default values [cyan bold](shown in brackets) [yellow]or type your own responses"
+            )
+        self.check_inputs_test()
+        self.scrape_workflow_entry_points()
+        self.build_all_tests()
+        if len(self.errors) > 0:
+            errors = "\n - ".join(self.errors)
+            raise UserWarning(f"Ran, but found errors:\n - {errors}")
+
+    def check_inputs_test(self):
+        """Do more complex checks about supplied flags."""
+
+        # Get the tool name if not specified
+        if self.module_name is None:
+            modules_repo = ModulesRepo()
+            modules_repo.get_modules_file_tree()
+            self.module_name = questionary.autocomplete(
+                "Tool name:",
+                choices=modules_repo.modules_avail_module_names,
+                style=nf_core.utils.nfcore_question_style,
+            ).ask()
+        self.module_dir = os.path.join("modules", *self.module_name.split("/"))
+        self.module_test_main = os.path.join("tests", "modules", *self.module_name.split("/"), "main.nf")
+
+        # First, sanity check that the module directory exists
+        if not os.path.isdir(self.module_dir):
+            raise UserWarning(f"Cannot find directory '{self.module_dir}'. Should be TOOL/SUBTOOL or TOOL")
+        if not os.path.exists(self.module_test_main):
+            raise UserWarning(f"Cannot find module test workflow '{self.module_test_main}'")

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -9,8 +9,6 @@ import os
 import pytest
 import sys
 import rich
-import subprocess
-import shlex
 from pathlib import Path
 from shutil import which
 

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -17,6 +17,31 @@ log = logging.getLogger(__name__)
 
 
 class ModulesTest(object):
+    """
+        Class to run module pytests.
+
+        ...
+
+        Attributes
+        ----------
+        module_name : str
+            name of the tool to run tests for
+        no_prompts : bool
+            flat indicating if prompts are used
+        pytest_args : tuple
+            additional arguments passed to pytest command
+
+        Methods
+        -------
+        run():
+            Run test steps
+        __check_inputs():
+            Check inputs. Ask for module_name if not provided and check that the directory exists
+        __set_profile():
+            Set software profile
+        __run_pytests(self):
+            Run pytest
+        """
     def __init__(
         self,
         module_name=None,
@@ -34,15 +59,17 @@ class ModulesTest(object):
             log.info(
                 "[yellow]Press enter to use default values [cyan bold](shown in brackets) [yellow]or type your own responses"
             )
-        self.check_inputs()
-        self.set_profile()
-        self.run_pytests()
+        self.__check_inputs()
+        self.__set_profile()
+        self.__run_pytests()
 
-    def check_inputs(self):
+    def __check_inputs(self):
         """Do more complex checks about supplied flags."""
 
         # Get the tool name if not specified
         if self.module_name is None:
+            if self.no_prompts:
+                raise UserWarning(f"Tool name not provided and prompts deactivated. Please provide the tool name as TOOL/SUBTOOL or TOOL.")
             modules_repo = ModulesRepo()
             modules_repo.get_modules_file_tree()
             self.module_name = questionary.autocomplete(
@@ -56,7 +83,7 @@ class ModulesTest(object):
         if not os.path.isdir(self.module_dir):
             raise UserWarning(f"Cannot find directory '{self.module_dir}'. Should be TOOL/SUBTOOL or TOOL")
 
-    def set_profile(self):
+    def __set_profile(self):
         """Set $PROFILE env variable.
         The config expects $PROFILE and Nextflow fails if it's not set.
         """
@@ -81,7 +108,7 @@ class ModulesTest(object):
                     os.environ["PROFILE"] = profile
                     log.info(f"Setting env var '$PROFILE' to '{profile}'")
 
-    def run_pytests(self):
+    def __run_pytests(self):
         """Given a module name, run tests."""
         # Print nice divider line
         console = rich.console.Console()

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -117,9 +117,16 @@ class ModulesTest(object):
         """Check if profile is available"""
         profile = os.environ.get("PROFILE")
         try:
-            profile_check = subprocess.check_output(
-                shlex.split(f"{profile} --help"), stderr=subprocess.STDOUT, shell=True
-            )
+
+            # Make sure the profile read from the environment is a valid Nextflow profile.
+            valid_nextflow_profiles = ["docker", "singularity", "podman", "shifter", "charliecloud", "conda"]
+            if profile in valid_nextflow_profiles:
+                profile_check = subprocess.check_output([profile, "--help"], stderr=subprocess.STDOUT)
+            else:
+                raise UserWarning(
+                    f"The profile '{profile}' set in the shell environment is not a valid.\n"
+                    f"Valid Nextflow profiles are {valid_nextflow_profiles}."
+                )
         except subprocess.CalledProcessError as e:
             raise UserWarning(f"Error with profile {profile} (exit code {e.returncode})\n[red]{e.output.decode()}")
 

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -94,7 +94,7 @@ class ModulesTest(object):
             os.environ["PROFILE"] = ""
             if self.no_prompts:
                 log.info(
-                    "Setting env var '$PROFILE' to an empty string as not set.\n"
+                    "Setting environment variable '$PROFILE' to an empty string as not set.\n"
                     "Tests will run with Docker by default. "
                     "To use Singularity set 'export PROFILE=singularity' in your shell before running this command."
                 )
@@ -108,7 +108,7 @@ class ModulesTest(object):
                 answer = questionary.unsafe_prompt([question], style=nf_core.utils.nfcore_question_style)
                 profile = answer["profile"].lower()
                 os.environ["PROFILE"] = profile
-                log.info(f"Setting env var '$PROFILE' to '{profile}'")
+                log.info(f"Setting environment variable '$PROFILE' to '{profile}'")
 
     def _run_pytests(self):
         """Given a module name, run tests."""

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -18,30 +18,31 @@ log = logging.getLogger(__name__)
 
 class ModulesTest(object):
     """
-        Class to run module pytests.
+    Class to run module pytests.
 
-        ...
+    ...
 
-        Attributes
-        ----------
-        module_name : str
-            name of the tool to run tests for
-        no_prompts : bool
-            flat indicating if prompts are used
-        pytest_args : tuple
-            additional arguments passed to pytest command
+    Attributes
+    ----------
+    module_name : str
+        name of the tool to run tests for
+    no_prompts : bool
+        flat indicating if prompts are used
+    pytest_args : tuple
+        additional arguments passed to pytest command
 
-        Methods
-        -------
-        run():
-            Run test steps
-        __check_inputs():
-            Check inputs. Ask for module_name if not provided and check that the directory exists
-        __set_profile():
-            Set software profile
-        __run_pytests(self):
-            Run pytest
-        """
+    Methods
+    -------
+    run():
+        Run test steps
+    __check_inputs():
+        Check inputs. Ask for module_name if not provided and check that the directory exists
+    __set_profile():
+        Set software profile
+    __run_pytests(self):
+        Run pytest
+    """
+
     def __init__(
         self,
         module_name=None,
@@ -69,7 +70,9 @@ class ModulesTest(object):
         # Get the tool name if not specified
         if self.module_name is None:
             if self.no_prompts:
-                raise UserWarning(f"Tool name not provided and prompts deactivated. Please provide the tool name as TOOL/SUBTOOL or TOOL.")
+                raise UserWarning(
+                    f"Tool name not provided and prompts deactivated. Please provide the tool name as TOOL/SUBTOOL or TOOL."
+                )
             modules_repo = ModulesRepo()
             modules_repo.get_modules_file_tree()
             self.module_name = questionary.autocomplete(

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -120,21 +120,21 @@ class ModulesTest(object):
         """Check if profile is available"""
         profile = os.environ.get("PROFILE")
         # Make sure the profile read from the environment is a valid Nextflow profile.
-        valid_nextflow_profiles = ["docker", "singularity", "podman", "shifter", "charliecloud", "conda"]
+        valid_nextflow_profiles = ["docker", "singularity", "conda"]
         if profile in valid_nextflow_profiles:
             if not which(profile):
-                raise UserWarning(f"The PROFILE '{profile}' set in the shell environment is not available.")
+                raise UserWarning(f"Command '{profile}' not found - is it installed?")
         else:
             raise UserWarning(
                 f"The PROFILE '{profile}' set in the shell environment is not valid.\n"
-                f"Valid Nextflow profiles are {valid_nextflow_profiles}."
+                f"Valid Nextflow profiles are '{', '.join(valid_nextflow_profiles)}'."
             )
 
     def _run_pytests(self):
         """Given a module name, run tests."""
         # Print nice divider line
         console = rich.console.Console()
-        console.print("[black]" + "─" * console.width)
+        console.rule(self.module_name, style="black")
 
         # Set pytest arguments
         command_args = ["--tag", f"{self.module_name}", "--symlink", "--keep-workflow-wd", "--git-aware"]

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -35,11 +35,11 @@ class ModulesTest(object):
     -------
     run():
         Run test steps
-    __check_inputs():
+    _check_inputs():
         Check inputs. Ask for module_name if not provided and check that the directory exists
-    __set_profile():
+    _set_profile():
         Set software profile
-    __run_pytests(self):
+    _run_pytests(self):
         Run pytest
     """
 
@@ -60,11 +60,11 @@ class ModulesTest(object):
             log.info(
                 "[yellow]Press enter to use default values [cyan bold](shown in brackets) [yellow]or type your own responses"
             )
-        self.__check_inputs()
-        self.__set_profile()
-        self.__run_pytests()
+        self._check_inputs()
+        self._set_profile()
+        self._run_pytests()
 
-    def __check_inputs(self):
+    def _check_inputs(self):
         """Do more complex checks about supplied flags."""
 
         # Get the tool name if not specified
@@ -86,7 +86,7 @@ class ModulesTest(object):
         if not os.path.isdir(self.module_dir):
             raise UserWarning(f"Cannot find directory '{self.module_dir}'. Should be TOOL/SUBTOOL or TOOL")
 
-    def __set_profile(self):
+    def _set_profile(self):
         """Set $PROFILE env variable.
         The config expects $PROFILE and Nextflow fails if it's not set.
         """
@@ -111,7 +111,7 @@ class ModulesTest(object):
                     os.environ["PROFILE"] = profile
                     log.info(f"Setting env var '$PROFILE' to '{profile}'")
 
-    def __run_pytests(self):
+    def _run_pytests(self):
         """Given a module name, run tests."""
         # Print nice divider line
         console = rich.console.Console()

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ filterwarnings =
     ignore::pytest.PytestRemovedIn8Warning:_pytest.nodes:140
 testpaths =
     tests
+python_files = test_*.py

--- a/tests/modules/module_test.py
+++ b/tests/modules/module_test.py
@@ -1,0 +1,15 @@
+"""Test the 'modules test' command which runs module pytests."""
+import os
+import pytest
+
+import nf_core.modules
+
+def test_modules_test_check_inputs(self):
+    """Test the check_inputs() function - raise UserWarning because module doesn't exist"""
+    cwd = os.getcwd()
+    os.chdir(self.nfcore_modules)
+    meta_builder = nf_core.modules.ModulesTest("none", True, "")
+    with pytest.raises(UserWarning) as excinfo:
+        meta_builder.check_inputs()
+    os.chdir(cwd)
+    assert "Cannot find directory" in str(excinfo.value)

--- a/tests/modules/module_test.py
+++ b/tests/modules/module_test.py
@@ -4,6 +4,7 @@ import pytest
 
 import nf_core.modules
 
+
 def test_modules_test_check_inputs(self):
     """Test the check_inputs() function - raise UserWarning because module doesn't exist"""
     cwd = os.getcwd()

--- a/tests/modules/module_test.py
+++ b/tests/modules/module_test.py
@@ -14,3 +14,14 @@ def test_modules_test_check_inputs(self):
         meta_builder._check_inputs()
     os.chdir(cwd)
     assert "Cannot find directory" in str(excinfo.value)
+
+
+def test_modules_test_no_name_no_prompts(self):
+    """Test the check_inputs() function - raise UserWarning prompts are deactivated and module name is not provided."""
+    cwd = os.getcwd()
+    os.chdir(self.nfcore_modules)
+    meta_builder = nf_core.modules.ModulesTest(None, True, "")
+    with pytest.raises(UserWarning) as excinfo:
+        meta_builder._check_inputs()
+    os.chdir(cwd)
+    assert "Tool name not provided and prompts deactivated." in str(excinfo.value)

--- a/tests/modules/module_test.py
+++ b/tests/modules/module_test.py
@@ -11,6 +11,6 @@ def test_modules_test_check_inputs(self):
     os.chdir(self.nfcore_modules)
     meta_builder = nf_core.modules.ModulesTest("none", True, "")
     with pytest.raises(UserWarning) as excinfo:
-        meta_builder.check_inputs()
+        meta_builder._check_inputs()
     os.chdir(cwd)
     assert "Cannot find directory" in str(excinfo.value)

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -116,4 +116,5 @@ class TestModules(unittest.TestCase):
 
     from .modules.module_test import (
         test_modules_test_check_inputs,
+        test_modules_test_no_name_no_prompts,
     )

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -113,3 +113,7 @@ class TestModules(unittest.TestCase):
         test_modules_bump_versions_fail,
         test_modules_bump_versions_fail_unknown_version,
     )
+
+    from .modules.module_test import (
+        test_modules_test_check_inputs,
+    )


### PR DESCRIPTION
Closes #1276

Add a new command `nf-core modules test` to run module tests locally.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
