### PR TITLE
Tweak to actions_ci.py

### DIFF
--- a/nf_core/lint/actions_ci.py
+++ b/nf_core/lint/actions_ci.py
@@ -137,7 +137,7 @@ def actions_ci(self):
     # Check that we are testing the minimum nextflow version
     try:
         matrix = ciwf["jobs"]["test"]["strategy"]["matrix"]["include"]
-        assert any([i["NXF_VER"] == self.minNextflowVersion for i in matrix])
+        assert any([i.get("NXF_VER") == self.minNextflowVersion for i in matrix])
     except (KeyError, TypeError):
         failed.append("'.github/workflows/ci.yml' does not check minimum NF version")
     except AssertionError:


### PR DESCRIPTION
In cases where e.g. multiple aligners are specified in the GitHub Actions matrix, trying to pull a 'NXF_VER' key out of the include dictionary can cause line 140 of `actions_ci.py` to fail when it shouldn't. The `get()` method will not error if the key is not present, fixing this problem.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
