### PR TITLE
Bin linting

### DIFF
--- a/nf_core/pipeline-template/.github/workflows/linting.yml
+++ b/nf_core/pipeline-template/.github/workflows/linting.yml
@@ -78,3 +78,21 @@ jobs:
             lint_log.txt
             lint_results.md
             PR_number.txt {%- endraw %}
+
+  bin:
+    name: Lint bin/ directory
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FILTER_REGEX_INCLUDE: ".*bin/.*"


### PR DESCRIPTION
Adds linting for anything in `bin/`using https://github.com/github/super-linter
Figured this was a nice gateway to possibly using super-linter for prettier and editorconfig as well. 

It also has support for https://github.com/rhysd/actionlint

Tested it out on `nascent`:
- [Accidental push to `dev` which shows nothing will fail on scripts that haven't been touched](https://github.com/nf-core/nascent/runs/6280926872?check_suite_focus=true). So we'll avoid a bunch of failing CI messages.
- [Example in use](https://github.com/nf-core/nascent/pull/45)