### PR TITLE
replace a weird with a normal dash

### DIFF
--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -420,7 +420,7 @@ class Launch(object):
 
         # If required and got an empty reponse, ask again
         while type(answer[param_id]) is str and answer[param_id].strip() == "" and is_required:
-            log.error("'–-{}' is required".format(param_id))
+            log.error("'--{}' is required".format(param_id))
             answer = questionary.unsafe_prompt([question], style=nf_core.utils.nfcore_question_style)
 
         # Ignore if empty


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

The weird dash (8211, Unicode "EN DASH") means the command will not work if one manually copy-pastes that bit from the log into the command. This kind of dash does not get interpreted flag starter but a string.

* I don't think this warrants an entry in the CHANGELOG.md (It's a weird bug, that's not even a bug in the code that gets executed.)
* I don't think this tests are required for this change
* I don't think additional `docs` are required.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
