### PR TITLE
Make nf-core branding optional to help users create non-nf-core pipelines that can still leverage nf-core standards.

### DIFF
--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -267,14 +267,15 @@ def validate_wf_name_prompt(ctx, opts, value):
 @click.option("--no-git", is_flag=True, default=False, help="Do not initialise pipeline as new git repository")
 @click.option("-f", "--force", is_flag=True, default=False, help="Overwrite output directory if it already exists")
 @click.option("-o", "--outdir", type=str, help="Output directory for new pipeline (default: pipeline name)")
-def create(name, description, author, version, no_git, force, outdir):
+@click.option("-p", "--prefix", type=str, default="nf-core", help="Pipeline prefix organisation (default: nf-core)")
+def create(name, description, author, version, no_git, force, outdir, prefix):
     """
     Create a new pipeline using the nf-core template.
 
     Uses the nf-core template to make a skeleton Nextflow pipeline with all required
     files, boilerplate code and bfest-practices.
     """
-    create_obj = nf_core.create.PipelineCreate(name, description, author, version, no_git, force, outdir)
+    create_obj = nf_core.create.PipelineCreate(name, description, author, prefix, version, no_git, force, outdir)
     create_obj.init_pipeline()
 
 

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -34,11 +34,12 @@ class PipelineCreate(object):
         outdir (str): Path to the local output directory.
     """
 
-    def __init__(self, name, description, author, version="1.0dev", no_git=False, force=False, outdir=None):
-        self.short_name = name.lower().replace(r"/\s+/", "-").replace("nf-core/", "").replace("/", "-")
-        self.name = f"nf-core/{self.short_name}"
+    def __init__(self, name, description, author, prefix="nf-core", version="1.0dev", no_git=False, force=False, outdir=None):
+        self.short_name = name.lower().replace(r"/\s+/", "-").replace(f"{prefix}/", "").replace("/", "-")
+        self.name = f"{prefix}/{self.short_name}"
         self.name_noslash = self.name.replace("/", "-")
-        self.name_docker = self.name.replace("nf-core", "nfcore")
+        self.prefix_nodash = prefix.replace("-","")
+        self.name_docker = self.name.replace(prefix, self.prefix_nodash)
         self.logo_light = f"{self.name}_logo_light.png"
         self.logo_dark = f"{self.name}_logo_dark.png"
         self.description = description
@@ -47,6 +48,7 @@ class PipelineCreate(object):
         self.no_git = no_git
         self.force = force
         self.outdir = outdir
+        self.branded = prefix == "nf-core"
         if not self.outdir:
             self.outdir = os.path.join(os.getcwd(), self.name_noslash)
 

--- a/nf_core/pipeline-template/README.md
+++ b/nf_core/pipeline-template/README.md
@@ -1,8 +1,9 @@
 # ![{{ name }}](docs/images/{{ logo_light }}#gh-light-mode-only) ![{{ name }}](docs/images/{{ logo_dark }}#gh-dark-mode-only)
 
+{% if branded -%}
 [![GitHub Actions CI Status](https://github.com/{{ name }}/workflows/nf-core%20CI/badge.svg)](https://github.com/{{ name }}/actions?query=workflow%3A%22nf-core+CI%22)
 [![GitHub Actions Linting Status](https://github.com/{{ name }}/workflows/nf-core%20linting/badge.svg)](https://github.com/{{ name }}/actions?query=workflow%3A%22nf-core+linting%22)
-[![AWS CI](https://img.shields.io/badge/CI%20tests-full%20size-FF9900?labelColor=000000&logo=Amazon%20AWS)](https://nf-co.re/{{ short_name }}/results)
+[![AWS CI](https://img.shields.io/badge/CI%20tests-full%20size-FF9900?labelColor=000000&logo=Amazon%20AWS)](https://nf-co.re/{{ short_name }}/results){% endif %}
 [![Cite with Zenodo](http://img.shields.io/badge/DOI-10.5281/zenodo.XXXXXXX-1073c8?labelColor=000000)](https://doi.org/10.5281/zenodo.XXXXXXX)
 
 [![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A521.10.3-23aa62.svg?labelColor=000000)](https://www.nextflow.io/)
@@ -10,9 +11,11 @@
 [![run with docker](https://img.shields.io/badge/run%20with-docker-0db7ed?labelColor=000000&logo=docker)](https://www.docker.com/)
 [![run with singularity](https://img.shields.io/badge/run%20with-singularity-1d355c.svg?labelColor=000000)](https://sylabs.io/docs/)
 
+{% if branded -%}
 [![Get help on Slack](http://img.shields.io/badge/slack-nf--core%20%23{{ short_name }}-4A154B?labelColor=000000&logo=slack)](https://nfcore.slack.com/channels/{{ short_name }})
 [![Follow on Twitter](http://img.shields.io/badge/twitter-%40nf__core-1DA1F2?labelColor=000000&logo=twitter)](https://twitter.com/nf_core)
 [![Watch on YouTube](http://img.shields.io/badge/youtube-nf--core-FF0000?labelColor=000000&logo=youtube)](https://www.youtube.com/c/nf-core)
+{% endif -%}
 
 ## Introduction
 
@@ -60,10 +63,12 @@ On release, automated continuous integration tests run the pipeline on a full-si
    nextflow run {{ name }} --input samplesheet.csv --outdir <OUTDIR> --genome GRCh37 -profile <docker/singularity/podman/shifter/charliecloud/conda/institute>
    ```
 
+{% if branded -%}
 ## Documentation
 
 The {{ name }} pipeline comes with documentation about the pipeline [usage](https://nf-co.re/{{ short_name }}/usage), [parameters](https://nf-co.re/{{ short_name }}/parameters) and [output](https://nf-co.re/{{ short_name }}/output).
 
+{% endif -%}
 ## Credits
 
 {{ name }} was originally written by {{ author }}.
@@ -76,8 +81,10 @@ We thank the following people for their extensive assistance in the development 
 
 If you would like to contribute to this pipeline, please see the [contributing guidelines](.github/CONTRIBUTING.md).
 
+{% if branded -%}
 For further information or help, don't hesitate to get in touch on the [Slack `#{{ short_name }}` channel](https://nfcore.slack.com/channels/{{ short_name }}) (you can join with [this invite](https://nf-co.re/join/slack)).
 
+{% endif -%}
 ## Citations
 
 <!-- TODO nf-core: Add citation for pipeline after first release. Uncomment lines below and update Zenodo doi and badge at the top of this file. -->
@@ -87,7 +94,12 @@ For further information or help, don't hesitate to get in touch on the [Slack `#
 
 An extensive list of references for the tools used by the pipeline can be found in the [`CITATIONS.md`](CITATIONS.md) file.
 
+
+{% if branded -%}
 You can cite the `nf-core` publication as follows:
+{% else -%}
+This pipeline uses code and infrastructure developed and maintained by the [nf-core](https://nf-co.re) community, reused here under the [MIT license](https://github.com/nf-core/tools/blob/master/LICENSE).
+{% endif -%}
 
 > **The nf-core framework for community-curated bioinformatics pipelines.**
 >

--- a/nf_core/pipeline-template/lib/NfcoreTemplate.groovy
+++ b/nf_core/pipeline-template/lib/NfcoreTemplate.groovy
@@ -244,12 +244,12 @@ class NfcoreTemplate {
         Map colors = logColours(monochrome_logs)
         String.format(
             """\n
-            ${dashedLine(monochrome_logs)}
+            ${dashedLine(monochrome_logs)}{% if branded %}
                                                     ${colors.green},--.${colors.black}/${colors.green},-.${colors.reset}
             ${colors.blue}        ___     __   __   __   ___     ${colors.green}/,-._.--~\'${colors.reset}
             ${colors.blue}  |\\ | |__  __ /  ` /  \\ |__) |__         ${colors.yellow}}  {${colors.reset}
             ${colors.blue}  | \\| |       \\__, \\__/ |  \\ |___     ${colors.green}\\`-._,-`-,${colors.reset}
-                                                    ${colors.green}`._,._,\'${colors.reset}
+                                                    ${colors.green}`._,._,\'${colors.reset}{% endif %}
             ${colors.purple}  ${workflow.manifest.name} v${workflow.manifest.version}${colors.reset}
             ${dashedLine(monochrome_logs)}
             """.stripIndent()

--- a/nf_core/pipeline-template/main.nf
+++ b/nf_core/pipeline-template/main.nf
@@ -4,8 +4,10 @@
     {{ name }}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     Github : https://github.com/{{ name }}
+{% if branded -%}
     Website: https://nf-co.re/{{ short_name }}
     Slack  : https://nfcore.slack.com/channels/{{ short_name }}
+{% endif -%}
 ----------------------------------------------------------------------------------------
 */
 
@@ -38,7 +40,7 @@ include { {{ short_name|upper }} } from './workflows/{{ short_name }}'
 //
 // WORKFLOW: Run main {{ name }} analysis pipeline
 //
-workflow NFCORE_{{ short_name|upper }} {
+workflow {{ prefix_nodash|upper }}_{{ short_name|upper }} {
     {{ short_name|upper }} ()
 }
 
@@ -53,7 +55,7 @@ workflow NFCORE_{{ short_name|upper }} {
 // See: https://github.com/nf-core/rnaseq/issues/619
 //
 workflow {
-    NFCORE_{{ short_name|upper }} ()
+    {{ prefix_nodash|upper }}_{{ short_name|upper }} ()
 }
 
 /*

--- a/nf_core/pipeline-template/nextflow_schema.json
+++ b/nf_core/pipeline-template/nextflow_schema.json
@@ -10,7 +10,10 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": ["input", "outdir"],
+            "required": [
+                "input",
+                "outdir"
+            ],
             "properties": {
                 "input": {
                     "type": "string",
@@ -19,7 +22,7 @@
                     "pattern": "^\\S+\\.csv$",
                     "schema": "assets/schema_input.json",
                     "description": "Path to comma-separated file containing information about the samples in the experiment.",
-                    "help_text": "You will need to create a design file with information about the samples in your experiment before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 3 columns, and a header row. See [usage docs](https://nf-co.re/{{ short_name }}/usage#samplesheet-input).",
+                    "help_text": "You will need to create a design file with information about the samples in your experiment before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 3 columns, and a header row.{% if branded %} See [usage docs](https://nf-co.re/{{ short_name }}/usage#samplesheet-input).{% endif %}",
                     "fa_icon": "fas fa-file-csv"
                 },
                 "outdir": {
@@ -182,7 +185,14 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
+                    "enum": [
+                        "symlink",
+                        "rellink",
+                        "link",
+                        "copy",
+                        "copyNoFollow",
+                        "move"
+                    ],
                     "hidden": true
                 },
                 "email_on_fail": {


### PR DESCRIPTION
This is an incomplete PR - just to bring the discussion in https://github.com/nf-core/tools/issues/1548 into focus around real code changes.

I expect that there will be more rounds of commits steered by community discussion.

At the moment, changes include:

- Add optional `--prefix` parameter for `nf-core create` where the prefix replaces `nf-core` in templates.
- Add a new `self.branded` instance variable to the `PipelineCreate` class to be used as a handy boolean switch in jinja templates. `branded == True` => nf-core branding, `branded == False` => don't assume nf-core branding.
- Only include ascii-art logo when `branded`
- Only include nf-core slack channel references when `branded`
- Only include results links ([example](https://nf-co.re/rnaseq/results#rnaseq/results-e0dfce9af5c2299bcc2b8a74b6559ce055965455/) when `branded`
- Use new prefix name for primary workflow names in `main.nf`

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
