### PR TITLE
Replace complex split() by regex

### DIFF
--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -211,18 +211,17 @@ def check_process_section(self, lines):
         self.warned.append(("process_standard_label", "Process label unspecified", self.main_nf))
 
     for l in lines:
-        l = l.strip()
-        l = l.lstrip('"')
-        l = l.lstrip("'")
         if re.search("bioconda::", l):
             bioconda_packages = [b for b in l.split() if "bioconda::" in b]
+        l = l.strip()
+        l = l.strip(" '\"")
         if l.startswith("https://containers") or l.startswith("https://depot"):
-            # e.g. 'https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img' :
-            # e.g. 'https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0' :
+            # e.g. "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img' :" -> v1.2.0_cv1
+            # e.g. "https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0' :" -> 0.11.9--0
             singularity_tag = re.search("(?:\/)?(?:biocontainers_)?(?::)?([A-Za-z\d\-_\.]+)(?:\.img)?['\"]", l).group(1)
         if l.startswith("biocontainers/") or l.startswith("quay.io/"):
-            # e.g. 'quay.io/biocontainers/krona:2.7.1--pl526_5' }"
-            # e.g. 'biocontainers/biocontainers:v1.2.0_cv1' }"
+            # e.g. "quay.io/biocontainers/krona:2.7.1--pl526_5' }" -> 2.7.1--pl526_5
+            # e.g. "biocontainers/biocontainers:v1.2.0_cv1' }" -> v1.2.0_cv1
             docker_tag = re.search("(?:[\/])?(?::)?([A-Za-z\d\-_\.]+)['\"]", l).group(1)
 
     # Check that all bioconda packages have build numbers

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -196,7 +196,7 @@ def check_process_section(self, lines):
     correct_process_labels = ["process_low", "process_medium", "process_high", "process_long"]
     process_label = [l for l in lines if "label" in l]
     if len(process_label) > 0:
-        process_label = re.search("process_[A-Za-z]*", process_label[0]).group(0)
+        process_label = re.search("process_[A-Za-z]+", process_label[0]).group(0)
         if not process_label in correct_process_labels:
             self.warned.append(
                 (
@@ -212,26 +212,18 @@ def check_process_section(self, lines):
 
     for l in lines:
         l = l.strip()
-        l = l.replace('"', "")
-        l = l.replace("'", "")
+        l = l.lstrip('"')
+        l = l.lstrip("'")
         if re.search("bioconda::", l):
             bioconda_packages = [b for b in l.split() if "bioconda::" in b]
         if l.startswith("https://containers") or l.startswith("https://depot"):
-            lspl = l.lstrip("https://").split(":")
-            if len(lspl) == 2:
-                # e.g. 'https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img' :
-                if "YOUR-TOOL-HERE" not in lspl[0]:
-                    # Get singularity container version when a container is provided
-                    singularity_tag = re.search("biocontainers_(.*).img", lspl[0]).group(1)
-            else:
-                # e.g. 'https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0' :
-                singularity_tag = lspl[-2].strip()
+            # e.g. 'https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img' :
+            # e.g. 'https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0' :
+            singularity_tag = re.search("(?:\/)?(?:biocontainers_)?(?::)?([A-Za-z\d\-_\.]+)(?:\.img)?['\"]", l).group(1)
         if l.startswith("biocontainers/") or l.startswith("quay.io/"):
             # e.g. 'quay.io/biocontainers/krona:2.7.1--pl526_5' }"
             # e.g. 'biocontainers/biocontainers:v1.2.0_cv1' }"
-            if "YOUR-TOOL-HERE" not in l:
-                # Get docker container version when a container is provided
-                docker_tag = re.search("\:(.*) \}", l).group(1)
+            docker_tag = re.search("(?:[\/])?(?::)?([A-Za-z\d\-_\.]+)['\"]", l).group(1)
 
     # Check that all bioconda packages have build numbers
     # Also check for newer versions

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -220,14 +220,18 @@ def check_process_section(self, lines):
             lspl = l.lstrip("https://").split(":")
             if len(lspl) == 2:
                 # e.g. 'https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img' :
-                singularity_tag = re.search("biocontainers_(.*).img", lspl[0]).group(1)
+                if "YOUR-TOOL-HERE" not in lspl[0]:
+                    # Get singularity container version when a container is provided
+                    singularity_tag = re.search("biocontainers_(.*).img", lspl[0]).group(1)
             else:
                 # e.g. 'https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0' :
                 singularity_tag = lspl[-2].strip()
         if l.startswith("biocontainers/") or l.startswith("quay.io/"):
             # e.g. 'quay.io/biocontainers/krona:2.7.1--pl526_5' }"
             # e.g. 'biocontainers/biocontainers:v1.2.0_cv1' }"
-            docker_tag = re.search("\:(.*) \}", l).group(1)
+            if "YOUR-TOOL-HERE" not in l:
+                # Get docker container version when a container is provided
+                docker_tag = re.search("\:(.*) \}", l).group(1)
 
     # Check that all bioconda packages have build numbers
     # Also check for newer versions

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -196,7 +196,7 @@ def check_process_section(self, lines):
     correct_process_labels = ["process_low", "process_medium", "process_high", "process_long"]
     process_label = [l for l in lines if "label" in l]
     if len(process_label) > 0:
-        process_label = process_label[0].split()[1].strip().strip("'").strip('"')
+        process_label = re.search("process_[A-Za-z]*", process_label[0]).group(0)
         if not process_label in correct_process_labels:
             self.warned.append(
                 (
@@ -220,14 +220,14 @@ def check_process_section(self, lines):
             lspl = l.lstrip("https://").split(":")
             if len(lspl) == 2:
                 # e.g. 'https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img' :
-                singularity_tag = "_".join(lspl[0].split("/")[-1].strip().rstrip(".img").split("_")[1:])
+                singularity_tag = re.search("biocontainers_(.*).img", lspl[0]).group(1)
             else:
                 # e.g. 'https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0' :
                 singularity_tag = lspl[-2].strip()
         if l.startswith("biocontainers/") or l.startswith("quay.io/"):
             # e.g. 'quay.io/biocontainers/krona:2.7.1--pl526_5' }"
             # e.g. 'biocontainers/biocontainers:v1.2.0_cv1' }"
-            docker_tag = l.split(":")[-1].strip("}").strip()
+            docker_tag = re.search("\:(.*) \}", l).group(1)
 
     # Check that all bioconda packages have build numbers
     # Also check for newer versions

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -213,7 +213,6 @@ def check_process_section(self, lines):
     for l in lines:
         if re.search("bioconda::", l):
             bioconda_packages = [b for b in l.split() if "bioconda::" in b]
-        l = l.strip()
         l = l.strip(" '\"")
         if l.startswith("https://containers") or l.startswith("https://depot"):
             # e.g. "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img' :" -> v1.2.0_cv1


### PR DESCRIPTION
Replace commands using complex split() expressions with regular expressions, as mentioned in [#1374 comment](https://github.com/nf-core/tools/pull/1374#discussion_r771317580) and [#1542 comment](https://github.com/nf-core/tools/issues/1542#issuecomment-1118770105)

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
