### PR TITLE
Decode bytes-like object for logging

### DIFF
--- a/nf_core/modules/test_yml_builder.py
+++ b/nf_core/modules/test_yml_builder.py
@@ -341,9 +341,9 @@ class ModulesTestYmlBuilder(object):
         else:
             log.info("Test workflow finished!")
             try:
-                        log.debug(rich.markup.escape(nfconfig_raw))
+                log.debug(rich.markup.escape(nfconfig_raw))
             except TypeError:
-                        log.debug(rich.markup.escape(nfconfig_raw.decode("utf-8")))
+                log.debug(rich.markup.escape(nfconfig_raw.decode("utf-8")))
 
         return tmp_dir, tmp_dir_repeat
 

--- a/nf_core/modules/test_yml_builder.py
+++ b/nf_core/modules/test_yml_builder.py
@@ -340,7 +340,7 @@ class ModulesTestYmlBuilder(object):
             raise UserWarning(f"Error running test workflow: {e}")
         else:
             log.info("Test workflow finished!")
-            log.debug(rich.markup.escape(nfconfig_raw))
+            log.debug(rich.markup.escape(nfconfig_raw.decode("utf-8")))
 
         return tmp_dir, tmp_dir_repeat
 

--- a/nf_core/modules/test_yml_builder.py
+++ b/nf_core/modules/test_yml_builder.py
@@ -340,7 +340,10 @@ class ModulesTestYmlBuilder(object):
             raise UserWarning(f"Error running test workflow: {e}")
         else:
             log.info("Test workflow finished!")
-            log.debug(rich.markup.escape(nfconfig_raw.decode("utf-8")))
+            try:
+                        log.debug(rich.markup.escape(nfconfig_raw))
+            except TypeError:
+                        log.debug(rich.markup.escape(nfconfig_raw.decode("utf-8")))
 
         return tmp_dir, tmp_dir_repeat
 


### PR DESCRIPTION
Closes #1547 

The command output when running the test is a byte object. Decode it to string to allow the formatting with rich.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
