### PR TITLE
Module linting: recognise `shell` block.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Escaped test run output before logging it, to avoid a rich ` MarkupError`
 - Add a new command `nf-core modules mulled` which can generate the name for a multi-tool container image.
 - Add a new command `nf-core modules test` which runs pytests locally.
+- Linting now recognised `shell` blocks to avoid error `when: condition has too many lines` ([#1557](https://github.com/nf-core/tools/issues/1557))
 
 ## [v2.3.2 - Mercury Vulture Fixed Formatting](https://github.com/nf-core/tools/releases/tag/2.3.2) - [2022-03-24]
 

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -72,6 +72,9 @@ def main_nf(module_lint_object, module):
         if re.search("script\s*:", l) and state in ["input", "output", "when", "process"]:
             state = "script"
             continue
+        if re.search("shell\s*:", l) and state in ["input", "output", "when", "process"]:
+            state = "shell"
+            continue
 
         # Perform state-specific linting checks
         if state == "process" and not _is_empty(module, l):


### PR DESCRIPTION
Means that we properly exit out of the `when` block when `shell` is used instead of `script`.

Fixes nf-core/tools#1557

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
