### PR TITLE
fix missing output files in test.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Escaped test run output before logging it, to avoid a rich ` MarkupError`
 - Add a new command `nf-core modules mulled` which can generate the name for a multi-tool container image.
 - Add a new command `nf-core modules test` which runs pytests locally.
+- Allow follow links when generating `test.yml` file with `nf-core modules create-test-yml` ([1570](https://github.com/nf-core/tools/pull/1570))
 
 ## [v2.3.2 - Mercury Vulture Fixed Formatting](https://github.com/nf-core/tools/releases/tag/2.3.2) - [2022-03-24]
 

--- a/nf_core/modules/test_yml_builder.py
+++ b/nf_core/modules/test_yml_builder.py
@@ -225,7 +225,7 @@ class ModulesTestYmlBuilder(object):
     def create_test_file_dict(self, results_dir, is_repeat=False):
         """Walk through directory and collect md5 sums"""
         test_files = []
-        for root, dir, files in os.walk(results_dir):
+        for root, dir, files in os.walk(results_dir, followlinks=True):
             for filename in files:
                 # Check that the file is not versions.yml
                 if filename == "versions.yml":


### PR DESCRIPTION
Closes #1564 

When output files are inside a folder (e.g. index files from bowtie2/align module), `os.walk()` needs the parameter `followlinks=True` when creating the test.yml file to be able to retrieve all files.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
