### PR TITLE
Mulled: handle invalid versions with a nice error message instead of a traceback

### DIFF
--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -694,9 +694,13 @@ def mulled(specifications, build_number):
     """
     from nf_core.modules.mulled import MulledImageNameGenerator
 
-    image_name = MulledImageNameGenerator.generate_image_name(
-        MulledImageNameGenerator.parse_targets(specifications), build_number=build_number
-    )
+    try:
+        image_name = MulledImageNameGenerator.generate_image_name(
+            MulledImageNameGenerator.parse_targets(specifications), build_number=build_number
+        )
+    except ValueError as e:
+        log.error(e)
+        sys.exit(1)
     print(image_name)
     if not MulledImageNameGenerator.image_exists(image_name):
         log.error(

--- a/nf_core/modules/mulled.py
+++ b/nf_core/modules/mulled.py
@@ -43,7 +43,7 @@ class MulledImageNameGenerator:
             try:
                 Version(version)
             except InvalidVersion:
-                raise ValueError(f"{version} in {spec} is not a PEP440 compliant version specification.") from None
+                raise ValueError(f"Not a PEP440 version spec: '{version}' in '{spec}'") from None
             result.append((tool.strip(), version.strip()))
         return result
 


### PR DESCRIPTION
This:
<img width="1001" alt="image" src="https://user-images.githubusercontent.com/465550/168096665-5af8528e-27c8-4049-b05b-a9825dc10d21.png">

instead of:

<img width="1371" alt="image" src="https://user-images.githubusercontent.com/465550/168096709-03dc4c88-02de-41ce-bdc4-bf6de37228ac.png">
