### PR TITLE
Mulled: Nicer CLI output

### DIFF
--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -702,12 +702,14 @@ def mulled(specifications, build_number):
         log.error(e)
         sys.exit(1)
     if not MulledImageNameGenerator.image_exists(image_name):
-        log.error(
-            "The generated multi-tool container image name does not seem to exist yet. Please double check that your "
-            "provided combination of tools and versions exists in the file:\n"
-            "https://github.com/BioContainers/multi-package-containers/blob/master/combinations/hash.tsv\n"
-            "If it does not, please add your desired combination as detailed at:\n"
-            "https://github.com/BioContainers/multi-package-containers\n"
+        log.error("The generated multi-tool container image name does not seem to exist yet.")
+        log.info(
+            "Please double check that your provided combination of tools and versions exists in the file: "
+            "[link=https://github.com/BioContainers/multi-package-containers/blob/master/combinations/hash.tsv]BioContainers/multi-package-containers 'combinations/hash.tsv'[/link]"
+        )
+        log.info(
+            "If it does not, please add your desired combination as detailed at: "
+            "https://github.com/BioContainers/multi-package-containers"
         )
         sys.exit(1)
     log.info("Mulled container hash:")

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -701,7 +701,6 @@ def mulled(specifications, build_number):
     except ValueError as e:
         log.error(e)
         sys.exit(1)
-    print(image_name)
     if not MulledImageNameGenerator.image_exists(image_name):
         log.error(
             "The generated multi-tool container image name does not seem to exist yet. Please double check that your "
@@ -711,6 +710,8 @@ def mulled(specifications, build_number):
             "https://github.com/BioContainers/multi-package-containers\n"
         )
         sys.exit(1)
+    log.info("Mulled container hash:")
+    print(image_name)
 
 
 # nf-core modules test

--- a/nf_core/modules/mulled.py
+++ b/nf_core/modules/mulled.py
@@ -62,6 +62,12 @@ class MulledImageNameGenerator:
     @classmethod
     def image_exists(cls, image_name: str) -> bool:
         """Check whether a given BioContainers image name exists via a call to the quay.io API."""
-        response = requests.get(f"https://quay.io/biocontainers/{image_name}/", allow_redirects=True)
-        log.debug(response.text)
-        return response.status_code == 200
+        quay_url = f"https://quay.io/biocontainers/{image_name}/"
+        response = requests.get(quay_url, allow_redirects=True)
+        log.debug(f"Got response code '{response.status_code}' for URL {quay_url}")
+        if response.status_code == 200:
+            log.info(f"Found [link={quay_url}]docker image[/link] on quay.io! :sparkles:")
+            return True
+        else:
+            log.error(f"Was not able to find [link={quay_url}]docker image[/link] on quay.io")
+            return False


### PR DESCRIPTION
* Don't print the mulled hash if the container doesn't exist
* Don't debug log the entire page contents, just the URL
* Bit more rich logging, including with a console hyperlink to the quay.io page

<img width="1042" alt="Screenshot 2022-05-12 at 16 50 24" src="https://user-images.githubusercontent.com/465550/168103763-9c1bb08f-9560-47ed-bc8d-04f96212ea08.png">

<img width="1042" alt="Screenshot 2022-05-12 at 16 51 06" src="https://user-images.githubusercontent.com/465550/168103890-5c35e8e0-f950-4fe8-a1f6-83c305b4c826.png">


## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
