### PR TITLE
Module lint styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Print include statement to terminal when `modules install` ([#1520](https://github.com/nf-core/tools/pull/1520))
 - Use [`$XDG_CONFIG_HOME`](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) or `~/.config/nf-core` instead of `~/.nfcore` for API cache (the latter can be safely deleted)
 - Consolidate GitHub API calls into a shared function that uses authentication from the [`gh` GitHub cli tool](https://cli.github.com/) or `GITHUB_AUTH_TOKEN` to avoid rate limiting ([#1499](https://github.com/nf-core/tools/pull/1499))
+- Tweaks to CLI output display of lint results
 
 ### Modules
 

--- a/nf_core/lint/__init__.py
+++ b/nf_core/lint/__init__.py
@@ -8,6 +8,7 @@ the nf-core community guidelines.
 from rich.markdown import Markdown
 from rich.table import Table
 from rich.panel import Panel
+from rich.console import group
 import datetime
 import git
 import json
@@ -323,10 +324,14 @@ class PipelineLint(nf_core.utils.Pipeline):
         summarising the linting results.
         """
 
+        # Spacing from log messages above
+        console.print("")
+
         log.debug("Printing final results")
 
         # Helper function to format test links nicely
-        def format_result(test_results, table, row_style=None):
+        @group()
+        def format_result(test_results):
             """
             Given an list of error message IDs and the message texts, return a nicely formatted
             string for the terminal with appropriate ASCII colours.
@@ -335,13 +340,9 @@ class PipelineLint(nf_core.utils.Pipeline):
                 tools_version = __version__
                 if "dev" in __version__:
                     tools_version = "latest"
-                table.add_row(
-                    Markdown(
-                        f"[{eid}](https://nf-co.re/tools/docs/{tools_version}/pipeline_lint_tests/{eid}.html): {msg}"
-                    ),
-                    style=row_style,
+                yield Markdown(
+                    f"[{eid}](https://nf-co.re/tools/docs/{tools_version}/pipeline_lint_tests/{eid}.html): {msg}"
                 )
-            return table
 
         def _s(some_list):
             if len(some_list) != 1:
@@ -350,40 +351,63 @@ class PipelineLint(nf_core.utils.Pipeline):
 
         # Table of passed tests
         if len(self.passed) > 0 and show_passed:
-            table = Table(style="green", box=rich.box.ROUNDED)
-            table.add_column(r"[✔] {} Pipeline Test{} Passed".format(len(self.passed), _s(self.passed)), no_wrap=True)
-            table = format_result(self.passed, table, "green")
-            console.print(table)
+            console.print(
+                rich.panel.Panel(
+                    format_result(self.passed),
+                    title=r"[bold][✔] {} Pipeline Test{} Passed".format(len(self.passed), _s(self.passed)),
+                    title_align="left",
+                    style="green",
+                    padding=1,
+                )
+            )
 
         # Table of fixed tests
         if len(self.fixed) > 0:
-            table = Table(style="bright_blue", box=rich.box.ROUNDED)
-            table.add_column(r"[?] {} Pipeline Test{} Fixed".format(len(self.fixed), _s(self.fixed)), no_wrap=True)
-            table = format_result(self.fixed, table, "bright blue")
-            console.print(table)
+            console.print(
+                rich.panel.Panel(
+                    format_result(self.fixed),
+                    title=r"[bold][?] {} Pipeline Test{} Fixed".format(len(self.fixed), _s(self.fixed)),
+                    title_align="left",
+                    style="bright_blue",
+                    padding=1,
+                )
+            )
 
         # Table of ignored tests
         if len(self.ignored) > 0:
-            table = Table(style="grey58", box=rich.box.ROUNDED)
-            table.add_column(
-                r"[?] {} Pipeline Test{} Ignored".format(len(self.ignored), _s(self.ignored)), no_wrap=True
+            console.print(
+                rich.panel.Panel(
+                    format_result(self.ignored),
+                    title=r"[bold][?] {} Pipeline Test{} Ignored".format(len(self.ignored), _s(self.ignored)),
+                    title_align="left",
+                    style="grey58",
+                    padding=1,
+                )
             )
-            table = format_result(self.ignored, table, "grey58")
-            console.print(table)
 
         # Table of warning tests
         if len(self.warned) > 0:
-            table = Table(style="yellow", box=rich.box.ROUNDED)
-            table.add_column(r"[!] {} Pipeline Test Warning{}".format(len(self.warned), _s(self.warned)), no_wrap=True)
-            table = format_result(self.warned, table, "yellow")
-            console.print(table)
+            console.print(
+                rich.panel.Panel(
+                    format_result(self.warned),
+                    title=r"[bold][!] {} Pipeline Test Warning{}".format(len(self.warned), _s(self.warned)),
+                    title_align="left",
+                    style="yellow",
+                    padding=1,
+                )
+            )
 
         # Table of failing tests
         if len(self.failed) > 0:
-            table = Table(style="red", box=rich.box.ROUNDED)
-            table.add_column(r"[✗] {} Pipeline Test{} Failed".format(len(self.failed), _s(self.failed)), no_wrap=True)
-            table = format_result(self.failed, table, "red")
-            console.print(table)
+            console.print(
+                rich.panel.Panel(
+                    format_result(self.failed),
+                    title=r"[bold][✗] {} Pipeline Test{} Failed".format(len(self.failed), _s(self.failed)),
+                    title_align="left",
+                    style="red",
+                    padding=1,
+                )
+            )
 
     def _print_summary(self):
         def _s(some_list):

--- a/nf_core/lint/__init__.py
+++ b/nf_core/lint/__init__.py
@@ -326,7 +326,7 @@ class PipelineLint(nf_core.utils.Pipeline):
         log.debug("Printing final results")
 
         # Helper function to format test links nicely
-        def format_result(test_results, table):
+        def format_result(test_results, table, row_style=None):
             """
             Given an list of error message IDs and the message texts, return a nicely formatted
             string for the terminal with appropriate ASCII colours.
@@ -338,7 +338,8 @@ class PipelineLint(nf_core.utils.Pipeline):
                 table.add_row(
                     Markdown(
                         f"[{eid}](https://nf-co.re/tools/docs/{tools_version}/pipeline_lint_tests/{eid}.html): {msg}"
-                    )
+                    ),
+                    style=row_style,
                 )
             return table
 
@@ -347,42 +348,41 @@ class PipelineLint(nf_core.utils.Pipeline):
                 return "s"
             return ""
 
-        # Print lint results header
-        console.print(Panel("[magenta]General lint results"))
-
         # Table of passed tests
         if len(self.passed) > 0 and show_passed:
             table = Table(style="green", box=rich.box.ROUNDED)
-            table.add_column(r"[✔] {} Test{} Passed".format(len(self.passed), _s(self.passed)), no_wrap=True)
-            table = format_result(self.passed, table)
+            table.add_column(r"[✔] {} Pipeline Test{} Passed".format(len(self.passed), _s(self.passed)), no_wrap=True)
+            table = format_result(self.passed, table, "green")
             console.print(table)
 
         # Table of fixed tests
         if len(self.fixed) > 0:
             table = Table(style="bright_blue", box=rich.box.ROUNDED)
-            table.add_column(r"[?] {} Test{} Fixed".format(len(self.fixed), _s(self.fixed)), no_wrap=True)
-            table = format_result(self.fixed, table)
+            table.add_column(r"[?] {} Pipeline Test{} Fixed".format(len(self.fixed), _s(self.fixed)), no_wrap=True)
+            table = format_result(self.fixed, table, "bright blue")
             console.print(table)
 
         # Table of ignored tests
         if len(self.ignored) > 0:
             table = Table(style="grey58", box=rich.box.ROUNDED)
-            table.add_column(r"[?] {} Test{} Ignored".format(len(self.ignored), _s(self.ignored)), no_wrap=True)
-            table = format_result(self.ignored, table)
+            table.add_column(
+                r"[?] {} Pipeline Test{} Ignored".format(len(self.ignored), _s(self.ignored)), no_wrap=True
+            )
+            table = format_result(self.ignored, table, "grey58")
             console.print(table)
 
         # Table of warning tests
         if len(self.warned) > 0:
             table = Table(style="yellow", box=rich.box.ROUNDED)
-            table.add_column(r"[!] {} Test Warning{}".format(len(self.warned), _s(self.warned)), no_wrap=True)
-            table = format_result(self.warned, table)
+            table.add_column(r"[!] {} Pipeline Test Warning{}".format(len(self.warned), _s(self.warned)), no_wrap=True)
+            table = format_result(self.warned, table, "yellow")
             console.print(table)
 
         # Table of failing tests
         if len(self.failed) > 0:
             table = Table(style="red", box=rich.box.ROUNDED)
-            table.add_column(r"[✗] {} Test{} Failed".format(len(self.failed), _s(self.failed)), no_wrap=True)
-            table = format_result(self.failed, table)
+            table.add_column(r"[✗] {} Pipeline Test{} Failed".format(len(self.failed), _s(self.failed)), no_wrap=True)
+            table = format_result(self.failed, table, "red")
             console.print(table)
 
     def _print_summary(self):

--- a/nf_core/modules/lint/__init__.py
+++ b/nf_core/modules/lint/__init__.py
@@ -390,46 +390,59 @@ class ModuleLint(ModuleCommand):
                 return "s"
             return ""
 
-        # Print module linting results header
-        console.print(Panel("[magenta]Module lint results"))
+        # Print blank line for spacing
+        console.print("")
 
         # Table of passed tests
         if len(self.passed) > 0 and show_passed:
-            console.print(
-                rich.panel.Panel(r"[!] {} Test{} Passed".format(len(self.passed), _s(self.passed)), style="bold green")
-            )
-            table = Table(style="green", box=rich.box.ROUNDED)
+            table = Table(style="green", box=rich.box.MINIMAL, pad_edge=False, border_style="dim")
             table.add_column("Module name", width=max_mod_name_len)
             table.add_column("File path")
             table.add_column("Test message")
             table = format_result(self.passed, table)
-            console.print(table)
+            console.print(
+                rich.panel.Panel(
+                    table,
+                    title=r"[bold][✔] {} Module Test{} Passed".format(len(self.passed), _s(self.passed)),
+                    title_align="left",
+                    style="green",
+                    padding=0,
+                )
+            )
 
         # Table of warning tests
         if len(self.warned) > 0:
-            console.print(
-                rich.panel.Panel(
-                    r"[!] {} Test Warning{}".format(len(self.warned), _s(self.warned)), style="bold yellow"
-                )
-            )
-            table = Table(style="yellow", box=rich.box.ROUNDED)
+            table = Table(style="yellow", box=rich.box.MINIMAL, pad_edge=False, border_style="dim")
             table.add_column("Module name", width=max_mod_name_len)
             table.add_column("File path")
             table.add_column("Test message")
             table = format_result(self.warned, table)
-            console.print(table)
+            console.print(
+                rich.panel.Panel(
+                    table,
+                    title=r"[bold][!] {} Module Test Warning{}".format(len(self.warned), _s(self.warned)),
+                    title_align="left",
+                    style="yellow",
+                    padding=0,
+                )
+            )
 
         # Table of failing tests
         if len(self.failed) > 0:
-            console.print(
-                rich.panel.Panel(r"[!] {} Test{} Failed".format(len(self.failed), _s(self.failed)), style="bold red")
-            )
-            table = Table(style="red", box=rich.box.ROUNDED)
+            table = Table(style="red", box=rich.box.MINIMAL, pad_edge=False, border_style="dim")
             table.add_column("Module name", width=max_mod_name_len)
             table.add_column("File path")
             table.add_column("Test message")
             table = format_result(self.failed, table)
-            console.print(table)
+            console.print(
+                rich.panel.Panel(
+                    table,
+                    title=r"[bold][✗] {} Module Test{} Failed".format(len(self.failed), _s(self.failed)),
+                    title_align="left",
+                    style="red",
+                    padding=0,
+                )
+            )
 
     def print_summary(self):
         def _s(some_list):

--- a/nf_core/modules/lint/__init__.py
+++ b/nf_core/modules/lint/__init__.py
@@ -392,51 +392,54 @@ class ModuleLint(ModuleCommand):
 
         # Table of passed tests
         if len(self.passed) > 0 and show_passed:
-            inner_table = Table(style="green", box=rich.box.MINIMAL, pad_edge=False, border_style="dim")
-            inner_table.add_column("Module name", width=max_mod_name_len)
-            inner_table.add_column("File path")
-            inner_table.add_column("Test message")
-            inner_table = format_result(self.passed, inner_table)
-
-            wrapper_table = Table(style="green", box=rich.box.ROUNDED)
-            wrapper_table.add_column(
-                r"[bold][✔] {} Module Test{} Passed".format(len(self.passed), _s(self.passed)), no_wrap=True
+            table = Table(style="green", box=rich.box.MINIMAL, pad_edge=False, border_style="dim")
+            table.add_column("Module name", width=max_mod_name_len)
+            table.add_column("File path")
+            table.add_column("Test message")
+            table = format_result(self.passed, table)
+            console.print(
+                rich.panel.Panel(
+                    table,
+                    title=r"[bold][✔] {} Module Test{} Passed".format(len(self.passed), _s(self.passed)),
+                    title_align="left",
+                    style="green",
+                    padding=0,
+                )
             )
-            wrapper_table.add_row(inner_table, style="green")
-
-            console.print(wrapper_table)
 
         # Table of warning tests
         if len(self.warned) > 0:
-            inner_table = Table(style="yellow", box=rich.box.MINIMAL, pad_edge=False, border_style="dim")
-            inner_table.add_column("Module name", width=max_mod_name_len)
-            inner_table.add_column("File path")
-            inner_table.add_column("Test message")
-            inner_table = format_result(self.warned, inner_table)
-
-            wrapper_table = Table(style="yellow", box=rich.box.ROUNDED)
-            wrapper_table.add_column(
-                r"[bold][!] {} Module Test Warning{}".format(len(self.warned), _s(self.warned)), no_wrap=True
+            table = Table(style="yellow", box=rich.box.MINIMAL, pad_edge=False, border_style="dim")
+            table.add_column("Module name", width=max_mod_name_len)
+            table.add_column("File path")
+            table.add_column("Test message")
+            table = format_result(self.warned, table)
+            console.print(
+                rich.panel.Panel(
+                    table,
+                    title=r"[bold][!] {} Module Test Warning{}".format(len(self.warned), _s(self.warned)),
+                    title_align="left",
+                    style="yellow",
+                    padding=0,
+                )
             )
-            wrapper_table.add_row(inner_table, style="yellow")
-
-            console.print(wrapper_table)
 
         # Table of failing tests
         if len(self.failed) > 0:
-            inner_table = Table(style="red", box=rich.box.MINIMAL, pad_edge=False, border_style="dim")
-            inner_table.add_column("Module name", width=max_mod_name_len)
-            inner_table.add_column("File path")
-            inner_table.add_column("Test message")
-            inner_table = format_result(self.failed, inner_table)
-
-            wrapper_table = Table(style="red", box=rich.box.ROUNDED)
-            wrapper_table.add_column(
-                r"[bold][✗] {} Module Test{} Failed".format(len(self.failed), _s(self.failed)), no_wrap=True
+            table = Table(style="red", box=rich.box.MINIMAL, pad_edge=False, border_style="dim")
+            table.add_column("Module name", width=max_mod_name_len)
+            table.add_column("File path")
+            table.add_column("Test message")
+            table = format_result(self.failed, table)
+            console.print(
+                rich.panel.Panel(
+                    table,
+                    title=r"[bold][✗] {} Module Test{} Failed".format(len(self.failed), _s(self.failed)),
+                    title_align="left",
+                    style="red",
+                    padding=0,
+                )
             )
-            wrapper_table.add_row(inner_table, style="red")
-
-            console.print(wrapper_table)
 
     def print_summary(self):
         def _s(some_list):


### PR DESCRIPTION
Tweaks to the linting output for modules, fixing some minor things that have bugged me for a while:

* Drop header row for pipeline / modules (include this in the header)
* Better grouping of linting results + section (less visual noise)
* Use `dim` instead of `magenta` to differentiate table rows
* Use panels for grouping instead of tables

Old, module:
<img width="1682" alt="Screenshot 2022-05-13 at 12 46 34" src="https://user-images.githubusercontent.com/465550/168268053-606223e0-d51c-4214-a5f2-14b735554aa9.png">


New, module:
<img width="1682" alt="Screenshot 2022-05-13 at 13 03 47" src="https://user-images.githubusercontent.com/465550/168270505-dc3c1be9-1b13-4303-a4d0-b9b2d172b681.png">

Old, pipeline:
<img width="1682" alt="Screenshot 2022-05-13 at 12 47 04" src="https://user-images.githubusercontent.com/465550/168268130-5f8160a9-6ce2-4ba5-b2c3-0896966fbd8f.png">


New, pipeline:
<img width="1682" alt="Screenshot 2022-05-13 at 13 02 16" src="https://user-images.githubusercontent.com/465550/168270295-e3fc14aa-ef2c-4876-886c-31ae5de6864d.png">





## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
