### PR TITLE
Module lint: Allow no input or output in YAML

### DIFF
--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -92,6 +92,12 @@ def main_nf(module_lint_object, module):
         if state == "shell" and not _is_empty(module, l):
             shell_lines.append(l)
 
+    # Check that we have required sections
+    if not len(outputs):
+        module.failed.append(("main_nf_script_outputs", "No process 'output' block found", module.main_nf))
+    else:
+        module.passed.append(("main_nf_script_outputs", "Process 'output' block found", module.main_nf))
+
     # Check the process definitions
     if check_process_section(module, process_lines):
         module.passed.append(("main_nf_container", "Container versions match", module.main_nf))

--- a/nf_core/modules/lint/meta_yml.py
+++ b/nf_core/modules/lint/meta_yml.py
@@ -20,7 +20,7 @@ def meta_yml(module_lint_object, module):
     ``meta.yml`` and the ``main.nf``.
 
     """
-    required_keys = ["name"]
+    required_keys = ["name", "output"]
     required_keys_lists = ["input", "output"]
     try:
         with open(module.meta_yml, "r") as fh:

--- a/nf_core/modules/lint/meta_yml.py
+++ b/nf_core/modules/lint/meta_yml.py
@@ -20,7 +20,7 @@ def meta_yml(module_lint_object, module):
     ``meta.yml`` and the ``main.nf``.
 
     """
-    required_keys = ["name", "input", "output"]
+    required_keys = ["name"]
     required_keys_lists = ["input", "output"]
     try:
         with open(module.meta_yml, "r") as fh:
@@ -35,9 +35,9 @@ def meta_yml(module_lint_object, module):
     all_list_children = True
     for rk in required_keys:
         if not rk in meta_yaml.keys():
-            module.failed.append(("meta_required_keys", f"`{rk}` not specified", module.meta_yml))
+            module.failed.append(("meta_required_keys", f"`{rk}` not specified in YAML", module.meta_yml))
             contains_required_keys = False
-        elif not isinstance(meta_yaml[rk], list) and rk in required_keys_lists:
+        elif rk in meta_yaml.keys() and not isinstance(meta_yaml[rk], list) and rk in required_keys_lists:
             module.failed.append(("meta_required_keys", f"`{rk}` is not a list", module.meta_yml))
             all_list_children = False
     if contains_required_keys:
@@ -45,24 +45,30 @@ def meta_yml(module_lint_object, module):
 
     # Confirm that all input and output channels are specified
     if contains_required_keys and all_list_children:
-        meta_input = [list(x.keys())[0] for x in meta_yaml["input"]]
-        for input in module.inputs:
-            if input in meta_input:
-                module.passed.append(("meta_input", f"`{input}` specified", module.meta_yml))
-            else:
-                module.failed.append(("meta_input", f"`{input}` missing in `meta.yml`", module.meta_yml))
+        if "input" in meta_yaml:
+            meta_input = [list(x.keys())[0] for x in meta_yaml["input"]]
+            for input in module.inputs:
+                if input in meta_input:
+                    module.passed.append(("meta_input", f"`{input}` specified", module.meta_yml))
+                else:
+                    module.failed.append(("meta_input", f"`{input}` missing in `meta.yml`", module.meta_yml))
 
-        meta_output = [list(x.keys())[0] for x in meta_yaml["output"]]
-        for output in module.outputs:
-            if output in meta_output:
-                module.passed.append(("meta_output", "`{output}` specified", module.meta_yml))
-            else:
-                module.failed.append(("meta_output", "`{output}` missing in `meta.yml`", module.meta_yml))
+        if "output" in meta_yaml:
+            meta_output = [list(x.keys())[0] for x in meta_yaml["output"]]
+            for output in module.outputs:
+                if output in meta_output:
+                    module.passed.append(("meta_output", "`{output}` specified", module.meta_yml))
+                else:
+                    module.failed.append(("meta_output", "`{output}` missing in `meta.yml`", module.meta_yml))
 
         # confirm that the name matches the process name in main.nf
         if meta_yaml["name"].upper() == module.process_name:
             module.passed.append(("meta_name", "Correct name specified in `meta.yml`", module.meta_yml))
         else:
             module.failed.append(
-                ("meta_name", "Conflicting process name between `meta.yml` and `main.nf`", module.meta_yml)
+                (
+                    "meta_name",
+                    f"Conflicting process name between meta.yml (`{meta_yaml['name']}`) and main.nf (`{module.process_name}`)",
+                    module.meta_yml,
+                )
             )

--- a/nf_core/modules/lint/meta_yml.py
+++ b/nf_core/modules/lint/meta_yml.py
@@ -57,9 +57,9 @@ def meta_yml(module_lint_object, module):
             meta_output = [list(x.keys())[0] for x in meta_yaml["output"]]
             for output in module.outputs:
                 if output in meta_output:
-                    module.passed.append(("meta_output", "`{output}` specified", module.meta_yml))
+                    module.passed.append(("meta_output", f"`{output}` specified", module.meta_yml))
                 else:
-                    module.failed.append(("meta_output", "`{output}` missing in `meta.yml`", module.meta_yml))
+                    module.failed.append(("meta_output", f"`{output}` missing in `meta.yml`", module.meta_yml))
 
         # confirm that the name matches the process name in main.nf
         if meta_yaml["name"].upper() == module.process_name:


### PR DESCRIPTION
In https://github.com/nf-core/tools/pull/1374 @drpatelh updated linting to allow `input` and `output` to be omitted from `main.nf`. However, the linting was still checking for these in `meta.yml`.

Also added in some slight lint message tweaks to help clarify things.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
