### PR TITLE
Update gitpod image

### DIFF
--- a/nf_core/gitpod/gitpod.Dockerfile
+++ b/nf_core/gitpod/gitpod.Dockerfile
@@ -26,9 +26,9 @@ RUN conda update -n base -c defaults conda && \
     conda config --add channels conda-forge && \
     conda install \
         openjdk=11.0.13 \
-        nextflow=21.10.6 \
+        nextflow=22.04.0 \
         pytest-workflow=1.6.0 \
-        mamba=0.22.1 \
+        mamba=0.23.1 \
         pip=22.0.4 \
         black=22.1.0 \
         -n base && \

--- a/nf_core/gitpod/gitpod.Dockerfile
+++ b/nf_core/gitpod/gitpod.Dockerfile
@@ -32,7 +32,6 @@ RUN conda update -n base -c defaults conda && \
         pip=22.0.4 \
         black=22.1.0 \
         -n base && \
-    nextflow self-update && \
     conda clean --all -f -y
 
 # Install nf-core


### PR DESCRIPTION
Update Gitpod image
- update nextflow version 21.10.6 -> 22.04.0
- update mamba version 0.22.1 -> 0.23.1
- remove `nextflow self-update` as it defeats the purpose of versioning.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
