### PR TITLE
remove color label in Nextflow image from readme linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Template
 
-- Fix bug in pipeline readme logo URL
+- Fix bug in pipeline readme logo URL ([#1589](https://github.com/nf-core/tools/issues/1589))
 
 ### General
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Template
 
+- Fix bug in pipeline readme logo URL
+
 ### General
 
 ### Modules

--- a/nf_core/lint/readme.py
+++ b/nf_core/lint/readme.py
@@ -38,9 +38,9 @@ def readme(self):
         content = fh.read()
 
     # Check that there is a readme badge showing the minimum required version of Nextflow
-    # [![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A521.10.3-23aa62.svg?labelColor=000000)](https://www.nextflow.io/)
+    # [![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A521.10.3-23aa62.svg)](https://www.nextflow.io/)
     # and that it has the correct version
-    nf_badge_re = r"\[!\[Nextflow\]\(https://img\.shields\.io/badge/nextflow%20DSL2-%E2%89%A5([\d\.]+)-23aa62\.svg\?labelColor=000000\)\]\(https://www\.nextflow\.io/\)"
+    nf_badge_re = r"\[!\[Nextflow\]\(https://img\.shields\.io/badge/nextflow%20DSL2-%E2%89%A5([\d\.]+)-23aa62\.svg\)\]\(https://www\.nextflow\.io/\)"
     match = re.search(nf_badge_re, content)
     if match:
         nf_badge_version = match.group(1).strip("'\"")


### PR DESCRIPTION
Close #1589

Remove color label in Nextflow image from readme linting to fix "readme: README did not have a Nextflow minimum version badge." warning.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
