### PR TITLE
Add fail-warned to pipeline linting workflow

### DIFF
--- a/.github/workflows/create-lint-wf.yml
+++ b/.github/workflows/create-lint-wf.yml
@@ -82,7 +82,7 @@ jobs:
 
       # Run nf-core linting
       - name: nf-core lint
-        run: nf-core --log-file log.txt lint --dir nf-core-testpipeline --fail-ignored
+        run: nf-core --log-file log.txt lint --dir nf-core-testpipeline --fail-ignored --fail-warned
 
       # Run the other nf-core commands
       - name: nf-core list

--- a/.github/workflows/create-lint-wf.yml
+++ b/.github/workflows/create-lint-wf.yml
@@ -61,6 +61,10 @@ jobs:
       - name: nf-core create
         run: nf-core --log-file log.txt create -n testpipeline -d "This pipeline is for testing" -a "Testing McTestface"
 
+      # Remove TODO statements
+      - name: remove TODO
+        run: find nf-core-testpipeline -type f -exec sed -i '/^\s*\/\/ TODO nf-core:/d' {} \;
+
       # Try syncing it before we change anything
       - name: nf-core sync
         run: nf-core --log-file log.txt sync --dir nf-core-testpipeline/


### PR DESCRIPTION
The GitHub workflow for pipeline linting does not fail on warnings.

- Remove TODO statements from template pipeline. Those lines are expected to produce a warning during linting.
- Add --fail-warned to pipeline linting

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
