### PR TITLE
fix-broken-linting-tests

### DIFF
--- a/tests/lint/actions_schema_validation.py
+++ b/tests/lint/actions_schema_validation.py
@@ -40,3 +40,24 @@ def test_actions_schema_validation_missing_on(self):
 
     assert results["failed"][0] == "Missing 'on' keyword in {}.format(wf)"
     assert "Workflow validation failed for awstest.yml: 'on' is a required property" in results["failed"][1]
+
+
+def test_actions_schema_validation_fails_for_additional_property(self):
+    """Missing 'jobs' field should result in failure"""
+    new_pipeline = self._make_pipeline_copy()
+
+    with open(os.path.join(new_pipeline, ".github", "workflows", "awstest.yml"), "r") as fh:
+        awstest_yml = yaml.safe_load(fh)
+    awstest_yml["not_jobs"] = awstest_yml["jobs"]
+    with open(os.path.join(new_pipeline, ".github", "workflows", "awstest.yml"), "w") as fh:
+        yaml.dump(awstest_yml, fh)
+
+    lint_obj = nf_core.lint.PipelineLint(new_pipeline)
+    lint_obj._load()
+
+    results = lint_obj.actions_schema_validation()
+
+    assert (
+        "Workflow validation failed for awstest.yml: Additional properties are not allowed ('not_jobs' was unexpected)"
+        in results["failed"][0]
+    )

--- a/tests/lint/actions_schema_validation.py
+++ b/tests/lint/actions_schema_validation.py
@@ -11,7 +11,7 @@ def test_actions_schema_validation_missing_jobs(self):
 
     with open(os.path.join(new_pipeline, ".github", "workflows", "awstest.yml"), "r") as fh:
         awstest_yml = yaml.safe_load(fh)
-    awstest_yml["not_jobs"] = awstest_yml.pop("jobs")
+    awstest_yml.pop("jobs")
     with open(os.path.join(new_pipeline, ".github", "workflows", "awstest.yml"), "w") as fh:
         yaml.dump(awstest_yml, fh)
 
@@ -29,7 +29,7 @@ def test_actions_schema_validation_missing_on(self):
 
     with open(os.path.join(new_pipeline, ".github", "workflows", "awstest.yml"), "r") as fh:
         awstest_yml = yaml.safe_load(fh)
-    awstest_yml["not_on"] = awstest_yml.pop(True)
+    awstest_yml.pop(True)
     with open(os.path.join(new_pipeline, ".github", "workflows", "awstest.yml"), "w") as fh:
         yaml.dump(awstest_yml, fh)
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -209,6 +209,7 @@ class TestLint(unittest.TestCase):
     from .lint.actions_schema_validation import (
         test_actions_schema_validation_missing_jobs,
         test_actions_schema_validation_missing_on,
+        test_actions_schema_validation_fails_for_additional_property,
     )
 
     from .lint.merge_markers import test_merge_markers_found


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

The linting test were broken because they introduce new properties to the schema, but some external change makes the additional properties fail now. 

This PR skips the generation of new properties and the tests now exclusively test for the lack of required properties.

- [ ] Are additional properties allowed or not?

The answer to the above question will decide if the additional test for failure upon additional parameter will be merged or if it should be dropped.

Key words: additionalProperties, jsonschema

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
