### PR TITLE
use pytest.raises to test for raised exception

### DIFF
--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -59,7 +59,6 @@ class DownloadTest(unittest.TestCase):
             == "https://github.com/nf-core/exoseq/archive/819cbac792b76cf66c840b567ed0ee9a2f620db7.zip"
         )
 
-    @pytest.mark.xfail(raises=AssertionError, strict=True)
     def test_get_release_hash_non_existent_release(self):
         wfs = nf_core.list.Workflows()
         wfs.get_remote_workflows()
@@ -70,7 +69,8 @@ class DownloadTest(unittest.TestCase):
             download_obj.wf_revisions,
             download_obj.wf_branches,
         ) = nf_core.utils.get_repo_releases_branches(pipeline, wfs)
-        download_obj.get_revision_hash()
+        with pytest.raises(AssertionError):
+            download_obj.get_revision_hash()
 
     #
     # Tests for 'download_wf_files'
@@ -149,7 +149,6 @@ class DownloadTest(unittest.TestCase):
         download_obj.validate_md5(tmpfile.name, val_hash)
 
     @with_temporary_file
-    @pytest.mark.xfail(raises=IOError, strict=True)
     def test_mismatching_md5sums(self, tmpfile):
         download_obj = DownloadWorkflow(pipeline="dummy")
         test_hash = hashlib.md5()
@@ -159,7 +158,8 @@ class DownloadTest(unittest.TestCase):
         with open(tmpfile.name, "w") as f:
             f.write("test")
 
-        download_obj.validate_md5(tmpfile.name, val_hash)
+        with pytest.raises(IOError):
+            download_obj.validate_md5(tmpfile.name, val_hash)
 
     #
     # Tests for 'singularity_pull_image'

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -62,12 +62,12 @@ class TestLint(unittest.TestCase):
         now_ts = time.mktime(now.timetuple())
         nf_core.list.pretty_date(now_ts)
 
-    @pytest.mark.xfail(raises=AssertionError, strict=True)
     def test_local_workflows_and_fail(self):
         """Test the local workflow class and try to get local
         Nextflow workflow information"""
         loc_wf = nf_core.list.LocalWorkflow("myWF")
-        loc_wf.get_local_nf_workflow_details()
+        with pytest.raises(AssertionError):
+            loc_wf.get_local_nf_workflow_details()
 
     def test_local_workflows_compare_and_fail_silently(self):
         """Test the workflow class and try to compare local

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -41,20 +41,18 @@ class TestSchema(unittest.TestCase):
         self.schema_obj.get_schema_path(self.template_dir)
         self.schema_obj.load_lint_schema()
 
-    @pytest.mark.xfail(raises=AssertionError, strict=True)
     def test_load_lint_schema_nofile(self):
         """Check that linting raises properly if a non-existant file is given"""
-        self.schema_obj.get_schema_path("fake_file")
-        self.schema_obj.load_lint_schema()
+        with pytest.raises(AssertionError):
+            self.schema_obj.get_schema_path("fake_file")
 
-    @pytest.mark.xfail(raises=AssertionError, strict=True)
     def test_load_lint_schema_notjson(self):
         """Check that linting raises properly if a non-JSON file is given"""
         self.schema_obj.get_schema_path(os.path.join(self.template_dir, "nextflow.config"))
-        self.schema_obj.load_lint_schema()
+        with pytest.raises(AssertionError):
+            self.schema_obj.load_lint_schema()
 
     @with_temporary_file
-    @pytest.mark.xfail(raises=AssertionError, strict=True)
     def test_load_lint_schema_noparams(self, tmp_file):
         """
         Check that linting raises properly if a JSON file is given without any params
@@ -63,7 +61,8 @@ class TestSchema(unittest.TestCase):
         with open(tmp_file.name, "w") as fh:
             json.dump({"type": "fubar"}, fh)
         self.schema_obj.get_schema_path(tmp_file.name)
-        self.schema_obj.load_lint_schema()
+        with pytest.raises(AssertionError):
+            self.schema_obj.load_lint_schema()
 
     def test_get_schema_path_dir(self):
         """Get schema file from directory"""
@@ -73,22 +72,22 @@ class TestSchema(unittest.TestCase):
         """Get schema file from a path"""
         self.schema_obj.get_schema_path(self.template_schema)
 
-    @pytest.mark.xfail(raises=AssertionError, strict=True)
     def test_get_schema_path_path_notexist(self):
         """Get schema file from a path"""
-        self.schema_obj.get_schema_path("fubar", local_only=True)
+        with pytest.raises(AssertionError):
+            self.schema_obj.get_schema_path("fubar", local_only=True)
 
     def test_get_schema_path_name(self):
         """Get schema file from the name of a remote pipeline"""
         self.schema_obj.get_schema_path("atacseq")
 
-    @pytest.mark.xfail(raises=AssertionError, strict=True)
     def test_get_schema_path_name_notexist(self):
         """
         Get schema file from the name of a remote pipeline
         that doesn't have a schema file
         """
-        self.schema_obj.get_schema_path("exoseq")
+        with pytest.raises(AssertionError):
+            self.schema_obj.get_schema_path("exoseq")
 
     def test_load_schema(self):
         """Try to load a schema from a file"""
@@ -134,10 +133,10 @@ class TestSchema(unittest.TestCase):
             yaml.dump({"input": "fubar"}, fh)
         self.schema_obj.load_input_params(tmp_file.name)
 
-    @pytest.mark.xfail(raises=AssertionError, strict=True)
     def test_load_input_params_invalid(self):
         """Check failure when a non-existent file params file is loaded"""
-        self.schema_obj.load_input_params("fubar")
+        with pytest.raises(AssertionError):
+            self.schema_obj.load_input_params("fubar")
 
     def test_validate_params_pass(self):
         """Try validating a set of parameters against a schema"""
@@ -162,11 +161,11 @@ class TestSchema(unittest.TestCase):
         self.schema_obj.load_schema()
         self.schema_obj.validate_schema(self.schema_obj.schema)
 
-    @pytest.mark.xfail(raises=AssertionError, strict=True)
     def test_validate_schema_fail_noparams(self):
         """Check that the schema validation fails when no params described"""
         self.schema_obj.schema = {"type": "invalidthing"}
-        self.schema_obj.validate_schema(self.schema_obj.schema)
+        with pytest.raises(AssertionError):
+            self.schema_obj.validate_schema(self.schema_obj.schema)
 
     def test_validate_schema_fail_duplicate_ids(self):
         """
@@ -326,37 +325,37 @@ class TestSchema(unittest.TestCase):
 
         param = self.schema_obj.build_schema(test_pipeline_dir, True, False, None)
 
-    @pytest.mark.xfail(raises=AssertionError, strict=True)
     @mock.patch("requests.post")
     def test_launch_web_builder_timeout(self, mock_post):
         """Mock launching the web builder, but timeout on the request"""
         # Define the behaviour of the request get mock
         mock_post.side_effect = requests.exceptions.Timeout()
-        self.schema_obj.launch_web_builder()
+        with pytest.raises(AssertionError):
+            self.schema_obj.launch_web_builder()
 
-    @pytest.mark.xfail(raises=AssertionError, strict=True)
     @mock.patch("requests.post")
     def test_launch_web_builder_connection_error(self, mock_post):
         """Mock launching the web builder, but get a connection error"""
         # Define the behaviour of the request get mock
         mock_post.side_effect = requests.exceptions.ConnectionError()
-        self.schema_obj.launch_web_builder()
+        with pytest.raises(AssertionError):
+            self.schema_obj.launch_web_builder()
 
-    @pytest.mark.xfail(raises=AssertionError, strict=True)
     @mock.patch("requests.post")
     def test_get_web_builder_response_timeout(self, mock_post):
         """Mock checking for a web builder response, but timeout on the request"""
         # Define the behaviour of the request get mock
         mock_post.side_effect = requests.exceptions.Timeout()
-        self.schema_obj.launch_web_builder()
+        with pytest.raises(AssertionError):
+            self.schema_obj.launch_web_builder()
 
-    @pytest.mark.xfail(raises=AssertionError, strict=True)
     @mock.patch("requests.post")
     def test_get_web_builder_response_connection_error(self, mock_post):
         """Mock checking for a web builder response, but get a connection error"""
         # Define the behaviour of the request get mock
         mock_post.side_effect = requests.exceptions.ConnectionError()
-        self.schema_obj.launch_web_builder()
+        with pytest.raises(AssertionError):
+            self.schema_obj.launch_web_builder()
 
     def mocked_requests_post(**kwargs):
         """Helper function to emulate POST requests responses from the web"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -166,14 +166,14 @@ class TestUtils(unittest.TestCase):
             raise AssertionError("MultiQC release v1.10 not found")
         assert "master" in wf_branches.keys()
 
-    @pytest.mark.xfail(raises=AssertionError, strict=True)
     def test_get_repo_releases_branches_not_exists(self):
         wfs = nf_core.list.Workflows()
         wfs.get_remote_workflows()
-        pipeline, wf_releases, wf_branches = nf_core.utils.get_repo_releases_branches("made_up_pipeline", wfs)
+        with pytest.raises(AssertionError):
+            nf_core.utils.get_repo_releases_branches("made_up_pipeline", wfs)
 
-    @pytest.mark.xfail(raises=AssertionError, strict=True)
     def test_get_repo_releases_branches_not_exists_slash(self):
         wfs = nf_core.list.Workflows()
         wfs.get_remote_workflows()
-        pipeline, wf_releases, wf_branches = nf_core.utils.get_repo_releases_branches("made-up/pipeline", wfs)
+        with pytest.raises(AssertionError):
+            nf_core.utils.get_repo_releases_branches("made-up/pipeline", wfs)


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

pytest.mark.xfail was used to test if the code raises certain exceptions in certain cases. This PR moves uses pytest.raises instead, which is the pytest way to test if code raises exceptions when desired.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
