### PR TITLE
[MAINT] replyce deprecated log.warn with log.warning

### DIFF
--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -161,7 +161,7 @@ class ModuleCommand:
                     modules_repo.get_modules_file_tree()
                     install_folder = [modules_repo.owner, modules_repo.repo]
                 except LookupError as e:
-                    log.warn(f"Could not get module's file tree for '{repo}': {e}")
+                    log.warning(f"Could not get module's file tree for '{repo}': {e}")
                     remove_from_mod_json[repo] = list(modules.keys())
                     continue
 
@@ -170,7 +170,7 @@ class ModuleCommand:
                     if sha is None:
                         if repo not in remove_from_mod_json:
                             remove_from_mod_json[repo] = []
-                        log.warn(
+                        log.warning(
                             f"Could not find git SHA for module '{module}' in '{repo}' - removing from modules.json"
                         )
                         remove_from_mod_json[repo].append(module)


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

as per [logging docs](https://docs.python.org/3/library/logging.html#logging.Logger.warning) warn is deprecated.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [] `CHANGELOG.md` is updated -> probably not necessary
- [] If you've fixed a bug or added code that should be tested, add tests! -> probably not necessary
- [] Documentation in `docs` is updated -> probably not necessary
