### PR TITLE
raise if Singularity container retrieval fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### General
 
+- Fix and improve broken test for Singularity container download [#1622](https://github.com/nf-core/tools/pull/1622).
+
 ### Modules
 
 - Fix a bug in the regex extracting the version from biocontainers URLs [#1598](https://github.com/nf-core/tools/pull/1598)

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -742,16 +742,24 @@ class DownloadWorkflow(object):
         task = progress.add_task(container, start=False, total=False, progress_type="singularity_pull", current_log="")
 
         # Run the singularity pull command
-        proc = subprocess.Popen(
+        with subprocess.Popen(
             singularity_command,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,
             bufsize=1,
-        )
-        for line in proc.stdout:
-            log.debug(line.strip())
-            progress.update(task, current_log=line.strip())
+        ) as proc:
+            lines = []
+            for line in proc.stdout:
+                lines.append(line)
+                progress.update(task, current_log=line.strip())
+
+        if lines:
+            # something went wrong with the container retrieval
+            if any("FATAL: " in line for line in lines):
+                log.info("Singularity container retrieval fialed with the following error:")
+                log.info("".join(lines))
+                raise FileNotFoundError(f'The container "{container}" is unavailable.\n{"".join(lines)}')
 
         # Copy cached download if we are using the cache
         if cache_path:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -178,9 +178,6 @@ class DownloadTest(unittest.TestCase):
         with pytest.raises(FileNotFoundError):
             download_obj.singularity_pull_image("a-container", tmp_dir, None, mock_rich_progress)
 
-    #
-    # Tests for 'singularity_pull_image'
-    #
     # If Singularity is not installed, it raises a FileNotFoundError because the singularity command can't be found.
     @pytest.mark.skipif(
         shutil.which("singularity") is not None,

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -165,14 +165,33 @@ class DownloadTest(unittest.TestCase):
     #
     # Tests for 'singularity_pull_image'
     #
-    # If Singularity is not installed, will log an error and exit
-    # If Singularity is installed, should raise an OSError due to non-existant image
+    # If Singularity is installed, but the container can't be accessed because it does not exist or there are aceess
+    # restrictions, a FileNotFoundError is raised due to the unavailability of the image.
+    @pytest.mark.skipif(
+        shutil.which("singularity") is None,
+        reason="Can't test what Singularity does if it's not installed.",
+    )
     @with_temporary_folder
-    @pytest.mark.xfail(raises=OSError)
     @mock.patch("rich.progress.Progress.add_task")
-    def test_singularity_pull_image(self, tmp_dir, mock_rich_progress):
+    def test_singularity_pull_image_singularity_installed(self, tmp_dir, mock_rich_progress):
         download_obj = DownloadWorkflow(pipeline="dummy", outdir=tmp_dir)
-        download_obj.singularity_pull_image("a-container", tmp_dir, None, mock_rich_progress)
+        with pytest.raises(FileNotFoundError):
+            download_obj.singularity_pull_image("a-container", tmp_dir, None, mock_rich_progress)
+
+    #
+    # Tests for 'singularity_pull_image'
+    #
+    # If Singularity is not installed, it raises a FileNotFoundError because the singularity command can't be found.
+    @pytest.mark.skipif(
+        shutil.which("singularity") is not None,
+        reason="Can't test how the code behaves if sungularity is not installed if it is.",
+    )
+    @with_temporary_folder
+    @mock.patch("rich.progress.Progress.add_task")
+    def test_singularity_pull_image_singularity_not_installed(self, tmp_dir, mock_rich_progress):
+        download_obj = DownloadWorkflow(pipeline="dummy", outdir=tmp_dir)
+        with pytest.raises(FileNotFoundError):
+            download_obj.singularity_pull_image("a-container", tmp_dir, None, mock_rich_progress)
 
     #
     # Tests for the main entry method 'download_workflow'

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -181,7 +181,7 @@ class DownloadTest(unittest.TestCase):
     # If Singularity is not installed, it raises a FileNotFoundError because the singularity command can't be found.
     @pytest.mark.skipif(
         shutil.which("singularity") is not None,
-        reason="Can't test how the code behaves if sungularity is not installed if it is.",
+        reason="Can't test how the code behaves when sungularity is not installed if it is.",
     )
     @with_temporary_folder
     @mock.patch("rich.progress.Progress.add_task")


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

There has been a test that xfailed -  It seems that failing to retrieve a container image should have always raised an exception, but it didn't. Now it does and the test that was maked xfail is now split into two tests, one that tests the failure mode if Singularity isn't installed and one for the case Singularity is installed but the container image retrieval fails.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
