### PR TITLE
obtain module suggestions from installed modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 - Add `--fix-version` flag to `nf-core modules lint` command to update modules to the latest version ([#1588](https://github.com/nf-core/tools/pull/1588))
 - Fix a bug in the regex extracting the version from biocontainers URLs [#1598](https://github.com/nf-core/tools/pull/1598)
-- Command `nf-core modules test` obtains module name suggestions from installed modules and fails if it isn't run from nf-core/modules [#1624](https://github.com/nf-core/tools/pull/1624)
+- Command `nf-core modules test` obtains module name suggestions from installed modules [#1624](https://github.com/nf-core/tools/pull/1624)
 
 ## [v2.4.1 - Cobolt Koala Patch](https://github.com/nf-core/tools/releases/tag/2.4) - [2022-05-16]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - Add `--fix-version` flag to `nf-core modules lint` command to update modules to the latest version ([#1588](https://github.com/nf-core/tools/pull/1588))
 - Fix a bug in the regex extracting the version from biocontainers URLs [#1598](https://github.com/nf-core/tools/pull/1598)
+- Command `nf-core modules test` obtains module name suggestions from installed modules and fails if it isn't run from nf-core/modules [#1624](https://github.com/nf-core/tools/pull/1624)
 
 ## [v2.4.1 - Cobolt Koala Patch](https://github.com/nf-core/tools/releases/tag/2.4) - [2022-05-16]
 

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -69,7 +69,7 @@ class ModulesTest(ModuleCommand):
             pipeline_dir = None
 
         super().__init__(pipeline_dir, remote_url, branch, no_pull)
-        self.get_pipeline_modules()
+        self.get_pipeline_modules(True)  # To change!
 
     def run(self):
         """Run test steps"""
@@ -87,9 +87,14 @@ class ModulesTest(ModuleCommand):
 
         # Retrieving installed modules
         if self.repo_type == "modules":
+            local = False
             installed_modules = self.module_names["modules"]
         else:
-            installed_modules = self.module_names.get(self.modules_repo.fullname)
+            local = questionary.confirm("Is the module local?", style=nf_core.utils.nfcore_question_style).unsafe_ask()
+            if local:
+                installed_modules = self.module_names.get("local/modules")
+            else:
+                installed_modules = self.module_names.get("nf-core/modules")
 
         # Get the tool name if not specified
         if self.module_name is None:
@@ -110,19 +115,26 @@ class ModulesTest(ModuleCommand):
             ).unsafe_ask()
 
         # Sanity check that the module directory exists
-        self._validate_folder_structure()
+        self._validate_folder_structure(local)
 
-    def _validate_folder_structure(self):
+    def _validate_folder_structure(self, local=False):
         """Validate that the modules follow the correct folder structure to run the tests:
         - modules/TOOL/SUBTOOL/
         - tests/modules/TOOL/SUBTOOL/
+
+        local (bool): Testing local modules (True) or nf-core modules (False)
         """
+        if local:
+            basedir = "modules/local"
+        else:
+            basedir = "modules/nf-core"
+
         if self.repo_type == "modules":
             module_path = Path("modules") / self.module_name
             test_path = Path("tests/modules") / self.module_name
         else:
-            module_path = Path("modules/nf-core/modules") / self.module_name
-            test_path = Path("modules/nf-core/tests/modules") / self.module_name
+            module_path = Path(f"{basedir}/modules") / self.module_name
+            test_path = Path(f"{basedir}/tests/modules") / self.module_name
 
         if not module_path.is_dir():
             raise UserWarning(

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -34,10 +34,6 @@ class ModulesTest(ModuleCommand):
         flat indicating if prompts are used
     pytest_args : tuple
         additional arguments passed to pytest command
-    all_local_modules: list
-        List of all installed local modules
-    all_nfcore_modules: list
-        List of all installed nf-core modules
 
     Methods
     -------
@@ -63,8 +59,6 @@ class ModulesTest(ModuleCommand):
         self.module_name = module_name
         self.no_prompts = no_prompts
         self.pytest_args = pytest_args
-        self.all_local_modules = None
-        self.all_nfcore_modules = None
 
         # Check repository type
         try:

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -94,7 +94,7 @@ class ModulesTest(ModuleCommand):
             if local:
                 installed_modules = self.module_names.get("local/modules")
             else:
-                installed_modules = self.module_names.get("nf-core/modules")
+                installed_modules = self.module_names.get(self.modules_repo.fullname)
 
         # Get the tool name if not specified
         if self.module_name is None:
@@ -104,9 +104,9 @@ class ModulesTest(ModuleCommand):
                 )
             if installed_modules is None:
                 raise UserWarning(
-                    "No installed modules were found from '{self.modules_repo.remote_url}'.\n"
-                    "Are you running the tests inside the nf-core/modules main directory?\n"
-                    "Otherwise, make sure that the directory structure is modules/TOOL/SUBTOOL/ and tests/modules/TOOLS/SUBTOOL/"
+                    f"No installed modules were found from '{self.modules_repo.remote_url}'.\n"
+                    f"Are you running the tests inside the nf-core/modules main directory?\n"
+                    f"Otherwise, make sure that the directory structure is modules/TOOL/SUBTOOL/ and tests/modules/TOOLS/SUBTOOL/"
                 )
             self.module_name = questionary.autocomplete(
                 "Tool name:",
@@ -130,20 +130,20 @@ class ModulesTest(ModuleCommand):
             basedir = "modules/nf-core"
 
         if self.repo_type == "modules":
-            module_path = Path("modules") / self.module_name
+            module_path = Path(self.base_path) / self.module_name
             test_path = Path("tests/modules") / self.module_name
         else:
             module_path = Path(f"{basedir}/modules") / self.module_name
             test_path = Path(f"{basedir}/tests/modules") / self.module_name
 
-        if not module_path.is_dir():
+        if not (self.dir / module_path).is_dir():
             raise UserWarning(
                 f"Cannot find directory '{module_path}'. Should be TOOL/SUBTOOL or TOOL. Are you running the tests inside the nf-core/modules main directory?"
             )
-        if not test_path.is_dir():
+        if not (self.dir / test_path).is_dir():
             raise UserWarning(
-                f"Cannot find directory '{test_path}'. Should be TOOL/SUBTOOL or TOOL."
-                "Are you running the tests inside the nf-core/modules main directory?"
+                f"Cannot find directory '{test_path}'. Should be TOOL/SUBTOOL or TOOL. "
+                "Are you running the tests inside the nf-core/modules main directory? "
                 "Do you have tests for the specified module?"
             )
 

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -16,7 +16,6 @@ import rich
 import nf_core.modules.module_utils
 import nf_core.utils
 from nf_core.modules.modules_command import ModuleCommand
-from nf_core.modules.modules_repo import NF_CORE_MODULES_REMOTE, ModulesRepo
 
 log = logging.getLogger(__name__)
 

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -69,7 +69,7 @@ class ModulesTest(ModuleCommand):
             pipeline_dir = None
 
         super().__init__(pipeline_dir, remote_url, branch, no_pull)
-        self.get_pipeline_modules(True)  # To change!
+        self.get_pipeline_modules()
 
     def run(self):
         """Run test steps"""
@@ -87,14 +87,9 @@ class ModulesTest(ModuleCommand):
 
         # Retrieving installed modules
         if self.repo_type == "modules":
-            local = False
             installed_modules = self.module_names["modules"]
         else:
-            local = questionary.confirm("Is the module local?", style=nf_core.utils.nfcore_question_style).unsafe_ask()
-            if local:
-                installed_modules = self.module_names.get("local/modules")
-            else:
-                installed_modules = self.module_names.get(self.modules_repo.fullname)
+            installed_modules = self.module_names.get(self.modules_repo.fullname)
 
         # Get the tool name if not specified
         if self.module_name is None:
@@ -115,19 +110,15 @@ class ModulesTest(ModuleCommand):
             ).unsafe_ask()
 
         # Sanity check that the module directory exists
-        self._validate_folder_structure(local)
+        self._validate_folder_structure()
 
-    def _validate_folder_structure(self, local=False):
+    def _validate_folder_structure(self):
         """Validate that the modules follow the correct folder structure to run the tests:
         - modules/TOOL/SUBTOOL/
         - tests/modules/TOOL/SUBTOOL/
 
-        local (bool): Testing local modules (True) or nf-core modules (False)
         """
-        if local:
-            basedir = "modules/local"
-        else:
-            basedir = "modules/nf-core"
+        basedir = "modules/nf-core"
 
         if self.repo_type == "modules":
             module_path = Path("modules") / self.module_name

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -59,8 +59,8 @@ class ModulesTest(object):
         self.module_name = module_name
         self.no_prompts = no_prompts
         self.pytest_args = pytest_args
-        self.all_local_modules = ""
-        self.all_nfcore_modules = ""
+        self.all_local_modules = None
+        self.all_nfcore_modules = None
 
     def run(self):
         """Run test steps"""

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -60,15 +60,7 @@ class ModulesTest(ModuleCommand):
         self.no_prompts = no_prompts
         self.pytest_args = pytest_args
 
-        # Check repository type
-        try:
-            pipeline_dir, repo_type = nf_core.modules.module_utils.get_repo_type(".", use_prompt=False)
-            log.debug(f"Found {repo_type} repo: {pipeline_dir}")
-        except UserWarning as e:
-            log.debug(f"Only showing remote info: {e}")
-            pipeline_dir = None
-
-        super().__init__(pipeline_dir, remote_url, branch, no_pull)
+        super().__init__(".", remote_url, branch, no_pull)
         self.get_pipeline_modules()
 
     def run(self):

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -66,6 +66,11 @@ class ModulesTest(object):
         # Obtain repo type
         try:
             self.dir, self.repo_type = nf_core.modules.module_utils.get_repo_type(".")
+            if not self.repo_type == "modules":
+                raise UserWarning(
+                    "The working directory doesn't look like a clone of nf-core/modules.\n"
+                    "Are you running the tests inside the nf-core/modules main directory?"
+                )
         except LookupError as e:
             raise UserWarning(e)
         # Get installed modules

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -67,7 +67,7 @@ class ModulesTest(ModuleCommand):
         self.all_local_modules = None
         self.all_nfcore_modules = None
 
-        # Check if this is a pipeline or not
+        # Check repository type
         try:
             pipeline_dir, repo_type = nf_core.modules.module_utils.get_repo_type(".", use_prompt=False)
             log.debug(f"Found {repo_type} repo: {pipeline_dir}")
@@ -115,14 +115,9 @@ class ModulesTest(ModuleCommand):
                 choices=installed_modules,
                 style=nf_core.utils.nfcore_question_style,
             ).unsafe_ask()
-        module_dir = Path("modules") / self.module_name
 
         # Sanity check that the module directory exists
         self._validate_folder_structure()
-        # if not module_dir.is_dir():
-        #     raise UserWarning(
-        #         f"Cannot find directory '{module_dir}'. Should be TOOL/SUBTOOL or TOOL. Are you running the tests inside the nf-core/modules main directory?"
-        #     )
 
     def _validate_folder_structure(self):
         """Validate that the modules follow the correct folder structure to run the tests:

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -130,7 +130,7 @@ class ModulesTest(ModuleCommand):
             basedir = "modules/nf-core"
 
         if self.repo_type == "modules":
-            module_path = Path(self.base_path) / self.module_name
+            module_path = Path("modules") / self.module_name
             test_path = Path("tests/modules") / self.module_name
         else:
             module_path = Path(f"{basedir}/modules") / self.module_name

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -63,20 +63,10 @@ class ModulesTest(object):
         self.module_name = module_name
         self.no_prompts = no_prompts
         self.pytest_args = pytest_args
-        # Obtain repo type
-        try:
-            self.dir, self.repo_type = nf_core.modules.module_utils.get_repo_type(".")
-            if not self.repo_type == "modules":
-                raise UserWarning(
-                    "The working directory doesn't look like a clone of nf-core/modules.\n"
-                    "Are you running the tests inside the nf-core/modules main directory?"
-                )
-        except LookupError as e:
-            raise UserWarning(e)
-        # Get installed modules
-        self.all_local_modules, self.all_nfcore_modules = nf_core.modules.module_utils.get_installed_modules(
-            self.dir, self.repo_type
-        )
+        self.dir = ""
+        self.repo_type = ""
+        self.all_local_modules = ""
+        self.all_nfcore_modules = ""
 
     def run(self):
         """Run test steps"""
@@ -91,6 +81,22 @@ class ModulesTest(object):
 
     def _check_inputs(self):
         """Do more complex checks about supplied flags."""
+
+        # Obtain repo type
+        try:
+            self.dir, self.repo_type = nf_core.modules.module_utils.get_repo_type(".")
+            # Check that the command is run from nf-core/modules directory
+            if not self.repo_type == "modules":
+                raise UserWarning(
+                    "The working directory doesn't look like a clone of nf-core/modules.\n"
+                    "Are you running the tests inside the nf-core/modules main directory?"
+                )
+        except LookupError as e:
+            raise UserWarning(e)
+        # Get installed modules
+        self.all_local_modules, self.all_nfcore_modules = nf_core.modules.module_utils.get_installed_modules(
+            self.dir, self.repo_type
+        )
 
         # Get the tool name if not specified
         if self.module_name is None:

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -33,10 +33,6 @@ class ModulesTest(object):
         flat indicating if prompts are used
     pytest_args : tuple
         additional arguments passed to pytest command
-    dir: str
-        Directory path
-    repo_type: str
-        Type of repository ['pipeline', 'modules']
     all_local_modules: list
         List of all installed local modules
     all_nfcore_modules: list
@@ -63,8 +59,6 @@ class ModulesTest(object):
         self.module_name = module_name
         self.no_prompts = no_prompts
         self.pytest_args = pytest_args
-        self.dir = ""
-        self.repo_type = ""
         self.all_local_modules = ""
         self.all_nfcore_modules = ""
 

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -67,7 +67,7 @@ class ModulesTest(ModuleCommand):
         self.all_local_modules = None
         self.all_nfcore_modules = None
 
-        # Quietly check if this is a pipeline or not
+        # Check if this is a pipeline or not
         try:
             pipeline_dir, repo_type = nf_core.modules.module_utils.get_repo_type(".", use_prompt=False)
             log.debug(f"Found {repo_type} repo: {pipeline_dir}")
@@ -117,10 +117,34 @@ class ModulesTest(ModuleCommand):
             ).unsafe_ask()
         module_dir = Path("modules") / self.module_name
 
-        # First, sanity check that the module directory exists
-        if not module_dir.is_dir():
+        # Sanity check that the module directory exists
+        self._validate_folder_structure()
+        # if not module_dir.is_dir():
+        #     raise UserWarning(
+        #         f"Cannot find directory '{module_dir}'. Should be TOOL/SUBTOOL or TOOL. Are you running the tests inside the nf-core/modules main directory?"
+        #     )
+
+    def _validate_folder_structure(self):
+        """Validate that the modules follow the correct folder structure to run the tests:
+        - modules/TOOL/SUBTOOL/
+        - tests/modules/TOOL/SUBTOOL/
+        """
+        if self.repo_type == "modules":
+            module_path = Path("modules") / self.module_name
+            test_path = Path("tests/modules") / self.module_name
+        else:
+            module_path = Path("modules/nf-core/modules") / self.module_name
+            test_path = Path("modules/nf-core/tests/modules") / self.module_name
+
+        if not module_path.is_dir():
             raise UserWarning(
-                f"Cannot find directory '{module_dir}'. Should be TOOL/SUBTOOL or TOOL. Are you running the tests inside the nf-core/modules main directory?"
+                f"Cannot find directory '{module_path}'. Should be TOOL/SUBTOOL or TOOL. Are you running the tests inside the nf-core/modules main directory?"
+            )
+        if not test_path.is_dir():
+            raise UserWarning(
+                f"Cannot find directory '{test_path}'. Should be TOOL/SUBTOOL or TOOL."
+                "Are you running the tests inside the nf-core/modules main directory?"
+                "Do you have tests for the specified module?"
             )
 
     def _set_profile(self):

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -82,20 +82,9 @@ class ModulesTest(object):
     def _check_inputs(self):
         """Do more complex checks about supplied flags."""
 
-        # Obtain repo type
-        try:
-            self.dir, self.repo_type = nf_core.modules.module_utils.get_repo_type(".")
-            # Check that the command is run from nf-core/modules directory
-            if not self.repo_type == "modules":
-                raise UserWarning(
-                    "The working directory doesn't look like a clone of nf-core/modules.\n"
-                    "Are you running the tests inside the nf-core/modules main directory?"
-                )
-        except LookupError as e:
-            raise UserWarning(e)
         # Get installed modules
         self.all_local_modules, self.all_nfcore_modules = nf_core.modules.module_utils.get_installed_modules(
-            self.dir, self.repo_type
+            ".", "modules"
         )
 
         # Get the tool name if not specified
@@ -107,7 +96,9 @@ class ModulesTest(object):
             all_installed_modules = [m.module_name for m in self.all_nfcore_modules]
             if len(all_installed_modules) == 0:
                 raise UserWarning(
-                    "No installed modules were found. Are you running the tests inside the nf-core/modules main directory?"
+                    "No installed modules were found.\n"
+                    "Are you running the tests inside the nf-core/modules main directory?\n"
+                    "Otherwise, make sure that the directory structure is modules/TOOL/SUBTOOL/ and tests/modules/TOOLS/SUBTOOL/"
                 )
             self.module_name = questionary.autocomplete(
                 "Tool name:",

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -34,7 +34,7 @@ class ModuleCommand:
         except LookupError as e:
             raise UserWarning(e)
 
-    def get_pipeline_modules(self, retrieve_local=False):
+    def get_pipeline_modules(self):
         """
         Get the modules installed in the current directory.
 
@@ -44,8 +44,6 @@ class ModuleCommand:
         is a clone of nf-core/modules the filed is set to
         `{"modules": modules_in_dir}`
 
-        retrieve_local (bool): True if retrieving local modules
-
         """
 
         self.module_names = {}
@@ -53,10 +51,7 @@ class ModuleCommand:
         module_base_path = f"{self.dir}/modules/"
 
         if self.repo_type == "pipeline":
-            if retrieve_local:
-                repo_owners = os.listdir(module_base_path)
-            else:
-                repo_owners = (owner for owner in os.listdir(module_base_path) if owner != "local")
+            repo_owners = (owner for owner in os.listdir(module_base_path) if owner != "local")
             repo_names = (
                 f"{repo_owner}/{name}"
                 for repo_owner in repo_owners

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -42,7 +42,7 @@ class ModuleCommand:
         except LookupError as e:
             raise UserWarning(e)
 
-    def get_pipeline_modules(self):
+    def get_pipeline_modules(self, retrieve_local=False):
         """
         Get the modules installed in the current directory.
 
@@ -52,6 +52,8 @@ class ModuleCommand:
         is a clone of nf-core/modules the filed is set to
         `{"modules": modules_in_dir}`
 
+        retrieve_local (bool): True if retrieving local modules
+
         """
 
         self.module_names = {}
@@ -59,7 +61,10 @@ class ModuleCommand:
         module_base_path = f"{self.dir}/modules/"
 
         if self.repo_type == "pipeline":
-            repo_owners = (owner for owner in os.listdir(module_base_path) if owner != "local")
+            if retrieve_local:
+                repo_owners = os.listdir(module_base_path)
+            else:
+                repo_owners = (owner for owner in os.listdir(module_base_path) if owner != "local")
             repo_names = (
                 f"{repo_owner}/{name}"
                 for repo_owner in repo_owners

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -52,7 +52,7 @@ nfcore_question_style = prompt_toolkit.styles.Style(
 
 NFCORE_CACHE_DIR = os.path.join(
     os.environ.get("XDG_CACHE_HOME", os.path.join(os.getenv("HOME"), ".cache")),
-    "nf-core",
+    "nfcore",
 )
 NFCORE_DIR = os.path.join(os.environ.get("XDG_CONFIG_HOME", os.path.join(os.getenv("HOME"), ".config")), "nfcore")
 

--- a/tests/modules/module_test.py
+++ b/tests/modules/module_test.py
@@ -28,15 +28,11 @@ def test_modules_test_no_name_no_prompts(self):
     assert "Tool name not provided and prompts deactivated." in str(excinfo.value)
 
 
-def test_modules_test_no_modules_dir(self):
-    """Test the check_inputs() function - raise UserWarning because command is not run from nf-core/modules"""
+def test_modules_test_no_installed_modules(self):
+    """Test the check_inputs() function - raise UserWarning because installed modules were not found"""
     cwd = os.getcwd()
-    os.chdir(self.nfcore_modules)
-    meta_builder = nf_core.modules.ModulesTest("none", True, "")
+    meta_builder = nf_core.modules.ModulesTest(None, False, "")
     with pytest.raises(UserWarning) as excinfo:
         meta_builder._check_inputs()
     os.chdir(cwd)
-    assert (
-        str(excinfo.value)
-        == "The working directory doesn't look like a clone of nf-core/modules.\nAre you running the tests inside the nf-core/modules main directory?"
-    )
+    assert "No installed modules were found." in str(excinfo.value)

--- a/tests/modules/module_test.py
+++ b/tests/modules/module_test.py
@@ -26,3 +26,17 @@ def test_modules_test_no_name_no_prompts(self):
         meta_builder._check_inputs()
     os.chdir(cwd)
     assert "Tool name not provided and prompts deactivated." in str(excinfo.value)
+
+
+def test_modules_test_no_modules_dir(self):
+    """Test the check_inputs() function - raise UserWarning because command is not run from nf-core/modules"""
+    cwd = os.getcwd()
+    os.chdir(self.nfcore_modules)
+    meta_builder = nf_core.modules.ModulesTest("none", True, "")
+    with pytest.raises(UserWarning) as excinfo:
+        meta_builder._check_inputs()
+    os.chdir(cwd)
+    assert (
+        str(excinfo.value)
+        == "The working directory doesn't look like a clone of nf-core/modules.\nAre you running the tests inside the nf-core/modules main directory?"
+    )

--- a/tests/modules/module_test.py
+++ b/tests/modules/module_test.py
@@ -28,18 +28,15 @@ def test_modules_test_no_name_no_prompts(self):
     assert "Tool name not provided and prompts deactivated." in str(excinfo.value)
 
 
-def test_modules_test_no_proper_path(self):
+def test_modules_test_no_installed_modules(self):
     """Test the check_inputs() function - raise UserWarning because installed modules were not found"""
     cwd = os.getcwd()
-    with pytest.raises(SystemError):
-        assert nf_core.modules.ModulesTest(".", False, "")
-
-
-def test_modules_test_all_modules_listed(self):
-    """Test the check_inputs() function - raise UserWarning because installed modules were not found"""
-    cwd = os.getcwd()
-    meta_builder = nf_core.modules.ModulesTest(".", False, "")
+    os.chdir(self.nfcore_modules)
+    meta_builder = nf_core.modules.ModulesTest(None, False, "")
+    meta_builder.module_names["modules"] = None
+    meta_builder.repo_type = "modules"
     with pytest.raises(UserWarning) as excinfo:
         meta_builder._check_inputs()
     os.chdir(cwd)
-    assert "No installed modules were found." in str(excinfo.value)
+    print(excinfo.value)
+    assert "No installed modules were found" in str(excinfo.value)

--- a/tests/modules/module_test.py
+++ b/tests/modules/module_test.py
@@ -28,10 +28,17 @@ def test_modules_test_no_name_no_prompts(self):
     assert "Tool name not provided and prompts deactivated." in str(excinfo.value)
 
 
-def test_modules_test_no_installed_modules(self):
+def test_modules_test_no_proper_path(self):
     """Test the check_inputs() function - raise UserWarning because installed modules were not found"""
     cwd = os.getcwd()
-    meta_builder = nf_core.modules.ModulesTest(None, False, "")
+    with pytest.raises(SystemError):
+        assert nf_core.modules.ModulesTest(".", False, "")
+
+
+def test_modules_test_all_modules_listed(self):
+    """Test the check_inputs() function - raise UserWarning because installed modules were not found"""
+    cwd = os.getcwd()
+    meta_builder = nf_core.modules.ModulesTest(".", False, "")
     with pytest.raises(UserWarning) as excinfo:
         meta_builder._check_inputs()
     os.chdir(cwd)

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -109,6 +109,7 @@ class TestModules(unittest.TestCase):
     )
     from .modules.module_test import (
         test_modules_test_check_inputs,
+        test_modules_test_no_modules_dir,
         test_modules_test_no_name_no_prompts,
     )
     from .modules.remove import (

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -109,8 +109,8 @@ class TestModules(unittest.TestCase):
     )
     from .modules.module_test import (
         test_modules_test_check_inputs,
-        test_modules_test_no_installed_modules,
         test_modules_test_no_name_no_prompts,
+        test_modules_test_no_proper_path,
     )
     from .modules.remove import (
         test_modules_remove_trimgalore,

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -109,7 +109,7 @@ class TestModules(unittest.TestCase):
     )
     from .modules.module_test import (
         test_modules_test_check_inputs,
-        test_modules_test_no_modules_dir,
+        test_modules_test_no_installed_modules,
         test_modules_test_no_name_no_prompts,
     )
     from .modules.remove import (

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -109,8 +109,8 @@ class TestModules(unittest.TestCase):
     )
     from .modules.module_test import (
         test_modules_test_check_inputs,
+        test_modules_test_no_installed_modules,
         test_modules_test_no_name_no_prompts,
-        test_modules_test_no_proper_path,
     )
     from .modules.remove import (
         test_modules_remove_trimgalore,


### PR DESCRIPTION
Close #1615 

When `nf-core modules test` is run without specifying a module name, the suggestions from the prompt are obtained from the installed modules (instead of nf-core/modules repository).

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
