### PR TITLE
Check regex match during modules linting

### DIFF
--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -343,7 +343,8 @@ def _parse_input(self, line_raw):
     else:
         if "(" in line:
             match = re.search(r"\((\w+)\)", line)
-            inputs.append(match.group(1))
+            if match:
+                inputs.append(match.group(1))
         else:
             inputs.append(line.split()[1])
     return inputs


### PR DESCRIPTION
Modules linting is failing when the regex parsing the inputs is unable to find a match.

Example: https://github.com/nf-core/modules/runs/6813009605?check_suite_focus=true
Module artic/minin has these two input lines
```
path  ("primer-schemes/${scheme}/V${scheme_version}/${scheme}.reference.fasta")
path  ("primer-schemes/${scheme}/V${scheme_version}/${scheme}.scheme.bed")
```
The regular expression parsing the inputs `r"\((\w+)\)"` doesn't match those.


## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
