### PR TITLE
Clarify error message when parameter in schema not present in nextflow.config

### DIFF
--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -256,7 +256,9 @@ class PipelineSchema(object):
                 if param in self.pipeline_params:
                     self.validate_config_default_parameter(param, group_properties[param], self.pipeline_params[param])
                 else:
-                    self.invalid_nextflow_config_default_parameters[param] = "Not in pipeline parameters. Check `nextflow.config`."
+                    self.invalid_nextflow_config_default_parameters[
+                        param
+                    ] = "Not in pipeline parameters. Check `nextflow.config`."
 
         # Go over ungrouped params if any exist
         ungrouped_properties = self.schema.get("properties")
@@ -269,7 +271,9 @@ class PipelineSchema(object):
                         param, ungrouped_properties[param], self.pipeline_params[param]
                     )
                 else:
-                    self.invalid_nextflow_config_default_parameters[param] = "Not in pipeline parameters Check `nextflow.config`."
+                    self.invalid_nextflow_config_default_parameters[
+                        param
+                    ] = "Not in pipeline parameters Check `nextflow.config`."
 
     def validate_config_default_parameter(self, param, schema_param, config_default):
         """

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -256,7 +256,7 @@ class PipelineSchema(object):
                 if param in self.pipeline_params:
                     self.validate_config_default_parameter(param, group_properties[param], self.pipeline_params[param])
                 else:
-                    self.invalid_nextflow_config_default_parameters[param] = "Not in pipeline parameters"
+                    self.invalid_nextflow_config_default_parameters[param] = "Not in pipeline parameters. Check `nextflow.config`."
 
         # Go over ungrouped params if any exist
         ungrouped_properties = self.schema.get("properties")
@@ -269,7 +269,7 @@ class PipelineSchema(object):
                         param, ungrouped_properties[param], self.pipeline_params[param]
                     )
                 else:
-                    self.invalid_nextflow_config_default_parameters[param] = "Not in pipeline parameters"
+                    self.invalid_nextflow_config_default_parameters[param] = "Not in pipeline parameters Check `nextflow.config`."
 
     def validate_config_default_parameter(self, param, schema_param, config_default):
         """


### PR DESCRIPTION
It was not clear to a developer what the following message actually meant:

```
schema_params: Default value for param bgc_antismash_database invalid: Not in pipeline parameters
```

i.e. whether pipeline parameters referred to parameters being passed on the CLI or not. However when I looked at the code, my understanding is this comes up when there is a parameter listed in the schema, but is not detected in the resolved parameters, namely: `nextflow.config`.

To make it clearer for people to know where to possibly look, I add a sentence to check `nextflow.config`.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated [Tiny change so not necessary IMO]
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
