### PR TITLE
Fix download of module files

### DIFF
--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -175,8 +175,8 @@ class ModuleCommand:
                         )
                         remove_from_mod_json[repo].append(module)
                         continue
-                    module_dir = os.path.join(self.dir, "modules", *install_folder, module)
-                    self.download_module_file(module, sha, modules_repo, install_folder, module_dir)
+                    module_dir = [self.dir, "modules", *install_folder]
+                    self.download_module_file(module, sha, modules_repo, module_dir)
 
             # If the reinstall fails, we remove those entries in 'modules.json'
             if sum(map(len, remove_from_mod_json.values())) > 0:


### PR DESCRIPTION
# Details

Module files are not written into the expected directory when a module is installed from the `modules.json` file via the `ModuleCommand.modules_json_up_to_date` method.

## Expected and actual behaviour

Take the `custom/dumpsoftwareversions` module as an example and assume it has an entry in `modules.json`. When calling `nf-core modules list local`, module files are not installed into the expected directory:

* Expected: `modules/nf-core/modules/custom/dumpsoftwareversions/` 
* Actual:      `nf-core/modules/custom/dumpsoftwareversions/`

See below for a full MRE.

## Changes

This PR fixes the outlined behaviour by the updating the `module_dir` argument for the `ModuleCommand.download_module_file` call present in `ModuleCommand.modules_json_up_to_date` and correcting the set of arguments passed to the same `ModuleCommand.download_module_file`.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated

## MRE
<details><summary>Click to expand</summary>

Provision environment
```bash
python3 -m venv venv/
. venv/bin/activate

pip install git+https://github.com/nf-core/tools
```

Create necessary files to run `nf-core`
```bash
mkdir -p modules/
touch main.nf nextflow.config
echo 'repository_type: pipeline' > .nf-core.yml
```

Populate the `modules.json` file
```bash
cat <<EOF > modules.json
{
    "name": "nf-core/hmftools",
    "homePage": "https://github.com/nf-core/hmftools",
    "repos": {
        "nf-core/modules": {
            "custom/dumpsoftwareversions": {
                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
            }
        }
     }
}
EOF
```

Trigger install of modules from `modules.json` by listing available modules
```text
$ nf-core modules list local

                                          ,--./,-.
          ___     __   __   __   ___     /,-._.--~\
    |\ | |__  __ /  ` /  \ |__) |__         }  {
    | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                          `._,._,'

    nf-core/tools version 2.4.1 - https://nf-co.re


INFO     Reinstalling modules found in 'modules.json' but missing from directory:                                modules_command.py:153
         'nf-core/modules/custom/dumpsoftwareversions'
INFO     No nf-core modules found in '.'                                                                                     list.py:89
```

The `custom/dumpsoftwareversions` module is installed into `nf-core/modules` rather than `modules/nf-core/modules`:
```text
$ find modules/
modules/

$ find nf-core/
nf-core/
nf-core/modules
nf-core/modules/custom
nf-core/modules/custom/dumpsoftwareversions
nf-core/modules/custom/dumpsoftwareversions/meta.yml
nf-core/modules/custom/dumpsoftwareversions/templates
nf-core/modules/custom/dumpsoftwareversions/templates/dumpsoftwareversions.py
nf-core/modules/custom/dumpsoftwareversions/main.nf
```



Repeat above with patched fork; provision software
```bash
pip install --upgrade git+https://github.com/scwatts/nf-core_tools@fix-module-download:
```

Trigger install of modules from `modules.json` by listing available modules
```text
$ nf-core modules list local

                                          ,--./,-.
          ___     __   __   __   ___     /,-._.--~\
    |\ | |__  __ /  ` /  \ |__) |__         }  {
    | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                          `._,._,'

    nf-core/tools version 2.4.1 - https://nf-co.re


INFO     Reinstalling modules found in 'modules.json' but missing from directory:                                modules_command.py:153
         'nf-core/modules/custom/dumpsoftwareversions'
INFO     Downloaded 3 files to ./modules/nf-core/modules/custom/dumpsoftwareversions                             modules_command.py:273
INFO     Modules installed in '.':                                                                                          list.py:129

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Module Name                 ┃ Repository      ┃ Version SHA                        ┃ Message                           ┃ Date       ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ custom/dumpsoftwareversions │ nf-core/modules │ e745e167c1020928ef20ea1397b6b4d23… │ Fix formatting in yaml files, add │ 2022-02-15 │
│                             │                 │                                    │ yamllint config (#1279)           │            │
└─────────────────────────────┴─────────────────┴────────────────────────────────────┴───────────────────────────────────┴────────────┘
```

Installed into expected directory:
```text
$ find modules/
modules/
modules/nf-core
modules/nf-core/modules
modules/nf-core/modules/custom
modules/nf-core/modules/custom/dumpsoftwareversions
modules/nf-core/modules/custom/dumpsoftwareversions/meta.yml
modules/nf-core/modules/custom/dumpsoftwareversions/templates
modules/nf-core/modules/custom/dumpsoftwareversions/templates/dumpsoftwareversions.py
modules/nf-core/modules/custom/dumpsoftwareversions/main.nf
```
</details>