### PR TITLE
Fix download of module files

### DIFF
--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -176,8 +176,8 @@ class ModuleCommand:
                         )
                         remove_from_mod_json[repo].append(module)
                         continue
-                    module_dir = os.path.join(self.dir, "modules", *install_folder, module)
-                    self.install_module_files(module, sha, modules_repo, install_folder, module_dir)
+                    module_dir = [self.dir, "modules", *install_folder]
+                    self.install_module_files(module, sha, modules_repo, module_dir)
 
             # If the reinstall fails, we remove those entries in 'modules.json'
             if sum(map(len, remove_from_mod_json.values())) > 0:


### PR DESCRIPTION
# Details

Re-opening as a new PR with adjusted patch and MRE. See https://github.com/nf-core/tools/pull/1639#issuecomment-1161721476.

Module files are not written into the expected directory when a module is installed from the `modules.json` file via the `ModuleCommand.modules_json_up_to_date` method.

## Expected and actual behaviour

Take the `custom/dumpsoftwareversions` module as an example and assume it has an entry in `modules.json`. When calling `nf-core modules list local`, module files are not installed into the expected directory:

* Expected: `modules/nf-core/modules/custom/dumpsoftwareversions/` 
* Actual:      `nf-core/modules/custom/dumpsoftwareversions/`

See below for a full MRE.

## Changes

This PR fixes the outlined behaviour by the updating the `module_dir` argument for the `ModuleCommand.install_module_files` call present in `ModuleCommand.modules_json_up_to_date` and correcting the set of arguments passed to the same `ModuleCommand.install_module_files`.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated

## MRE
<details><summary>Click to expand</summary>

Provision environment
```bash
python3 -m venv venv/
. venv/bin/activate

pip install git+https://github.com/nf-core/tools@dev
```

Create necessary files to run `nf-core`
```bash
mkdir -p modules/
touch main.nf nextflow.config
echo 'repository_type: pipeline' > .nf-core.yml
```

Populate the `modules.json` file
```bash
cat <<EOF > modules.json
{
    "name": "nf-core/mre",
    "homePage": "https://github.com/mre",
    "repos": {
        "nf-core/modules": {
            "git_url": "git@github.com@nf-core/modules.git",
            "modules": {
                "custom/dumpsoftwareversions": {
                    "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
                },
                "fastqc": {
                    "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
                },
                "multiqc": {
                    "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
                }
            }
        }
    }
}
EOF
```

Trigger install of modules from `modules.json` by listing available modules
```text
$ nf-core modules list local

                                          ,--./,-.
          ___     __   __   __   ___     /,-._.--~\
    |\ | |__  __ /  ` /  \ |__) |__         }  {
    | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                          `._,._,'

    nf-core/tools version 2.5.dev0 - https://nf-co.re


INFO     Reinstalling modules found in 'modules.json' but missing from directory:                                modules_command.py:157
         'nf-core/modules/custom/dumpsoftwareversions', 'nf-core/modules/fastqc', 'nf-core/modules/multiqc'
╭───────────────────────────────────────────────── Traceback (most recent call last) ─────────────────────────────────────────────────╮
│ /Users/stephen/temp/delete/nfcore_retest/venv/bin/nf-core:8 in <module>                                                             │
│                                                                                                                                     │
│   7 │   sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])                                                            │
│ ❱ 8 │   sys.exit(run_nf_core())                                                                                                     │
│   9                                                                                                                                 │

*** truncated for brevity ***

│ /Users/stephen/temp/delete/nfcore_retest/venv/lib/python3.8/site-packages/nf_core/modules/modules_command.py:180 in                 │
│ modules_json_up_to_date                                                                                                             │
│                                                                                                                                     │
│   179 │   │   │   │   │   module_dir = os.path.join(self.dir, "modules", *install_folder,                                           │
│       module)                                                                                                                       │
│ ❱ 180 │   │   │   │   │   self.install_module_files(module, sha, modules_repo, install_folder,                                      │
│       module_dir)                                                                                                                   │
│   181                                                                                                                               │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: install_module_files() takes 5 positional arguments but 6 were given
```

> Correcting only the arguments for `install_module_files` call results in same issue as previous - modules installed into `./nf-core/` rather than `./modules/nf-core/`

Repeat above with patched fork; provision software
```bash
pip install --upgrade git+https://github.com/scwatts/nf-core_tools@fix-module-download
```

Trigger install of modules from `modules.json` by listing available modules
```text
$ nf-core modules list local

                                          ,--./,-.
          ___     __   __   __   ___     /,-._.--~\
    |\ | |__  __ /  ` /  \ |__) |__         }  {
    | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                          `._,._,'

    nf-core/tools version 2.5.dev0 - https://nf-co.re


INFO     Reinstalling modules found in 'modules.json' but missing from directory:                                modules_command.py:157
         'nf-core/modules/custom/dumpsoftwareversions', 'nf-core/modules/fastqc', 'nf-core/modules/multiqc'
INFO     Modules installed in '.':                                                                                          list.py:131

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Module Name                 ┃ Repository      ┃ Version SHA                        ┃ Message                           ┃ Date       ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ custom/dumpsoftwareversions │ nf-core/modules │ e745e167c1020928ef20ea1397b6b4d23… │ Fix formatting in yaml files, add │ 2022-02-15 │
│                             │                 │                                    │ yamllint config (#1279)           │            │
│ fastqc                      │ nf-core/modules │ e745e167c1020928ef20ea1397b6b4d23… │ Fix formatting in yaml files, add │ 2022-02-15 │
│                             │                 │                                    │ yamllint config (#1279)           │            │
│ multiqc                     │ nf-core/modules │ e745e167c1020928ef20ea1397b6b4d23… │ Fix formatting in yaml files, add │ 2022-02-15 │
│                             │                 │                                    │ yamllint config (#1279)           │            │
└─────────────────────────────┴─────────────────┴────────────────────────────────────┴───────────────────────────────────┴────────────┘
```

Installed into expected directory:
```text
$ find modules/
$ find modules/
modules/
modules/nf-core
modules/nf-core/modules
modules/nf-core/modules/multiqc
modules/nf-core/modules/multiqc/meta.yml
modules/nf-core/modules/multiqc/main.nf
modules/nf-core/modules/fastqc
modules/nf-core/modules/fastqc/meta.yml
modules/nf-core/modules/fastqc/main.nf
modules/nf-core/modules/custom
modules/nf-core/modules/custom/dumpsoftwareversions
modules/nf-core/modules/custom/dumpsoftwareversions/meta.yml
modules/nf-core/modules/custom/dumpsoftwareversions/templates
modules/nf-core/modules/custom/dumpsoftwareversions/templates/dumpsoftwareversions.py
modules/nf-core/modules/custom/dumpsoftwareversions/main.nf
```
</details>