### PR TITLE
Update docs with custom URL example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Add `--fix-version` flag to `nf-core modules lint` command to update modules to the latest version ([#1588](https://github.com/nf-core/tools/pull/1588))
 - Fix a bug in the regex extracting the version from biocontainers URLs ([#1598](https://github.com/nf-core/tools/pull/1598))
 - Update how we interface with git remotes. ([#1626](https://github.com/nf-core/tools/issues/1626))
+- Update docs with example of custom git remote ([#1645](https://github.com/nf-core/tools/issues/1645))
 
 ## [v2.4.1 - Cobolt Koala Patch](https://github.com/nf-core/tools/releases/tag/2.4) - [2022-05-16]
 

--- a/README.md
+++ b/README.md
@@ -917,7 +917,7 @@ The modules supercommand comes with two flags for specifying a custom remote:
 For example, if you want to install the `fastqc` module from the repository `nf-core/modules-test` hosted at `gitlab.com`, you can use the following command:
 
 ```terminal
-nf-core modules --git-remote https://gitlab.com/nf-core/modules-test.git install fastqc
+nf-core modules --git-remote git@gitlab.com:nf-core/modules-test.git install fastqc
 ```
 
 Note that a custom remote must follow a similar directory structure to that of `nf-core/moduleś` for the `nf-core modules` commands to work properly.

--- a/README.md
+++ b/README.md
@@ -917,7 +917,7 @@ The modules supercommand comes with two flags for specifying a custom remote:
 For example, if you want to install the `fastqc` module from the repository `nf-core/modules-test` hosted at `gitlab.com`, you can use the following command:
 
 ```terminal
-nf-core modules -git-remote https://gitlab.com/nf-core/modules-test.git install fastqc
+nf-core modules --git-remote https://gitlab.com/nf-core/modules-test.git install fastqc
 ```
 
 Note that a custom remote must follow a similar directory structure to that of `nf-core/moduleś` for the `nf-core modules` commands to work properly.

--- a/README.md
+++ b/README.md
@@ -914,6 +914,12 @@ The modules supercommand comes with two flags for specifying a custom remote:
 - `--git-remote <git remote url>`: Specify the repository from which the modules should be fetched as a git URL. Defaults to the github repository of `nf-core/modules`.
 - `--branch <branch name>`: Specify the branch from which the modules should be fetched. Defaults to the default branch of your repository.
 
+For example, if you want to install the `fastqc` module from the repository `nf-core/modules-test` hosted at `gitlab.com`, you can use the following command:
+
+```terminal
+nf-core modules -git-remote https://gitlab.com/nf-core/modules-test.git install fastqc
+```
+
 Note that a custom remote must follow a similar directory structure to that of `nf-core/moduleś` for the `nf-core modules` commands to work properly.
 
 The modules commands will during initalisation try to pull changes from the remote repositories. If you want to disable this, for example


### PR DESCRIPTION
Added example of how to use the `--git-remote` option to specify a custom remote. Will close #1645.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] Documentation in `docs` is updated
