### PR TITLE
Replace process tag in module template with prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Add prompt for module name to `nf-core modules info` ([#1644](https://github.com/nf-core/tools/issues/1644))
 - Update docs with example of custom git remote ([#1645](https://github.com/nf-core/tools/issues/1645))
 - Add `--base-path` flag to `nf-core modules` to specify the base path for the modules in a remote. Also refactored `modules.json` code. ([#1643](https://github.com/nf-core/tools/issues/1643))
+- Replace default module tag from `$meta.id` or `$bam` to more flexible `$prefix`
 
 ## [v2.4.1 - Cobolt Koala Patch](https://github.com/nf-core/tools/releases/tag/2.4) - [2022-05-16]
 

--- a/nf_core/module-template/modules/main.nf
+++ b/nf_core/module-template/modules/main.nf
@@ -16,7 +16,7 @@
 //               list (`[]`) instead of a file can be used to work around this issue.
 
 process {{ tool_name_underscore|upper }} {
-    tag {{ '"$meta.id"' if has_meta else "'$bam'" }}
+    tag "$prefix"
     label '{{ process_label }}'
 
     // TODO nf-core: List required Conda package(s).
@@ -49,7 +49,7 @@ process {{ tool_name_underscore|upper }} {
     script:
     def args = task.ext.args ?: ''
     {% if has_meta -%}
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    prefix = task.ext.prefix ?: "${meta.id}"
     {%- endif %}
     // TODO nf-core: Where possible, a command MUST be provided to obtain the version number of the software e.g. 1.10
     //               If the software is unable to output a version number on the command-line then it can be manually specified

--- a/nf_core/module-template/modules/main.nf
+++ b/nf_core/module-template/modules/main.nf
@@ -16,7 +16,7 @@
 //               list (`[]`) instead of a file can be used to work around this issue.
 
 process {{ tool_name_underscore|upper }} {
-    tag "$prefix"
+    tag {{ '"$prefix"' if has_meta else "'$bam'" }}
     label '{{ process_label }}'
 
     // TODO nf-core: List required Conda package(s).

--- a/nf_core/module-template/modules/main.nf
+++ b/nf_core/module-template/modules/main.nf
@@ -16,7 +16,7 @@
 //               list (`[]`) instead of a file can be used to work around this issue.
 
 process {{ tool_name_underscore|upper }} {
-    tag {{ '"$prefix"' if has_meta else "'$bam'" }}
+    tag {{ '"$prefix"' if has_meta else '"$bam"' }}
     label '{{ process_label }}'
 
     // TODO nf-core: List required Conda package(s).


### PR DESCRIPTION
This gives more flexibility to pipeline developers/users to define what the tag of each process is (e.g. to improve console logging), and is less 'presumptious' whether process has a meta or is using a BAM file.

One disadvantage is this requires the definition of `prefix` as a global variable within the process, rather than restricted to just `script:`, however NXF should report a clash if this occurs: 

https://nfcore.slack.com/archives/CJRH30T6V/p1656666128805539?thread_ts=1656605651.609349&cid=CJRH30T6V

e.g if a module developer tries to use `prefix` as an input channel variable name

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
