### PR TITLE
allow single and double quotes when matching container links

### DIFF
--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -396,7 +396,7 @@ def _fix_module_version(self, current_version, latest_version, singularity_tag, 
         elif build_type == "singularity" or build_type == "docker":
             # Check that the new url is valid
             new_url = re.search(
-                "(?:')(.+)(?:')", re.sub(rf"{singularity_tag}", f"{latest_version}--{build}", line)
+                "(?:['\"])(.+)(?:['\"])", re.sub(rf"{singularity_tag}", f"{latest_version}--{build}", line)
             ).group(1)
             response_new_container = requests.get(
                 "https://" + new_url if not new_url.startswith("https://") else new_url, stream=True


### PR DESCRIPTION
Small change in a regular expression to allow both, single and double quotes, in container links from modules.

For example, trying to update module bowtie2/align was giving an error due to [links quoted by double quotes](https://github.com/nf-core/modules/blob/master/modules/bowtie2/align/main.nf#:~:text=%22https%3A//depot.galaxyproject.org/singularity/mulled%2Dv2%2Dac74a7f02cebcfcc07d8e8d1d750af9c83b4d45a%3A1744f68fe955578c63054b55309e05b41c37a80d%2D0%22%20%3A).

## PR checklist

- [x] This comment contains a description of changes (with reason)
