### PR TITLE
Rename methods in `ModulesJson`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Update docs with example of custom git remote ([#1645](https://github.com/nf-core/tools/issues/1645))
 - Command `nf-core modules test` obtains module name suggestions from installed modules ([#1624](https://github.com/nf-core/tools/pull/1624))
 - Add `--base-path` flag to `nf-core modules` to specify the base path for the modules in a remote. Also refactored `modules.json` code. ([#1643](https://github.com/nf-core/tools/issues/1643))
+- Rename methods in `ModulesJson` to remove explicit reference to `modules.json`
 
 ## [v2.4.1 - Cobolt Koala Patch](https://github.com/nf-core/tools/releases/tag/2.4) - [2022-05-16]
 

--- a/nf_core/lint/modules_json.py
+++ b/nf_core/lint/modules_json.py
@@ -21,7 +21,7 @@ def modules_json(self):
     # Load pipeline modules and modules.json
     modules_command = ModuleCommand(self.wf_path)
     modules_json = ModulesJson(self.wf_path)
-    modules_json.load_modules_json()
+    modules_json.load()
     modules_json_dict = modules_json.modules_json
 
     if modules_json:

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -50,7 +50,7 @@ class ModuleInstall(ModuleCommand):
 
         # Verify that 'modules.json' is consistent with the installed modules
         modules_json = ModulesJson(self.dir)
-        modules_json.modules_json_up_to_date()
+        modules_json.check_up_to_date()
 
         if self.prompt and self.sha is not None:
             log.error("Cannot use '--sha' and '--prompt' at the same time!")
@@ -138,5 +138,5 @@ class ModuleInstall(ModuleCommand):
         log.info(f"Include statement: include {{ {module_name} }} from '.{os.path.join(*install_folder, module)}/main'")
 
         # Update module.json with newly installed module
-        modules_json.update_modules_json(self.modules_repo, module, version)
+        modules_json.update(self.modules_repo, module, version)
         return True

--- a/nf_core/modules/lint/__init__.py
+++ b/nf_core/modules/lint/__init__.py
@@ -198,7 +198,7 @@ class ModuleLint(ModuleCommand):
     def set_up_pipeline_files(self):
         self.load_lint_config()
         self.modules_json = ModulesJson(self.dir)
-        self.modules_json.load_modules_json()
+        self.modules_json.load()
 
         # Only continue if a lint config has been loaded
         if self.lint_config:

--- a/nf_core/modules/list.py
+++ b/nf_core/modules/list.py
@@ -66,7 +66,7 @@ class ModuleList(ModuleCommand):
 
             # Verify that 'modules.json' is consistent with the installed modules
             modules_json = ModulesJson(self.dir)
-            modules_json.modules_json_up_to_date()
+            modules_json.check_up_to_date()
 
             # Get installed modules
             self.get_pipeline_modules()

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -95,7 +95,7 @@ class ModuleCommand:
         modules_json_path = os.path.join(self.dir, "modules.json")
         if not os.path.exists(modules_json_path):
             log.info("Creating missing 'module.json' file.")
-            ModulesJson(self.dir).create_modules_json()
+            ModulesJson(self.dir).create()
 
     def clear_module_dir(self, module_name, module_dir):
         """Removes all files in the module directory"""

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -32,7 +32,7 @@ class ModulesJson:
         self.modules_dir = os.path.join(self.dir, "modules")
         self.modules_json = None
 
-    def create_modules_json(self):
+    def create(self):
         """
         Creates the modules.json file from the modules installed in the pipeline directory
 
@@ -225,7 +225,7 @@ class ModulesJson:
             depth += 1
         return dirs_not_covered
 
-    def modules_json_up_to_date(self):
+    def check_up_to_date(self):
         """
         Checks whether the modules installed in the directory
         are consistent with the entries in the 'modules.json' file and vice versa.
@@ -237,7 +237,7 @@ class ModulesJson:
         If a module is installed but the entry in 'modules.json' is missing we iterate through
         the commit log in the remote to try to determine the SHA.
         """
-        self.load_modules_json()
+        self.load()
         old_modules_json = copy.deepcopy(self.modules_json)
 
         # Compute the difference between the modules in the directory
@@ -462,9 +462,9 @@ class ModulesJson:
 
             shutil.move(path, local_path)
 
-        self.dump_modules_json()
+        self.dump()
 
-    def load_modules_json(self):
+    def load(self):
         """
         Loads the modules.json file into the variable 'modules_json'
 
@@ -480,7 +480,7 @@ class ModulesJson:
         except FileNotFoundError:
             raise UserWarning("File 'modules.json' is missing")
 
-    def update_modules_json(self, modules_repo, module_name, module_version, write_file=True):
+    def update(self, modules_repo, module_name, module_version, write_file=True):
         """
         Updates the 'module.json' file with new module info
 
@@ -491,7 +491,7 @@ class ModulesJson:
             write_file (bool): whether to write the updated modules.json to a file.
         """
         if self.modules_json is None:
-            self.load_modules_json()
+            self.load()
         repo_name = modules_repo.fullname
         remote_url = modules_repo.remote_url
         base_path = modules_repo.base_path
@@ -501,9 +501,9 @@ class ModulesJson:
         # Sort the 'modules.json' repo entries
         self.modules_json["repos"] = nf_core.utils.sort_dictionary(self.modules_json["repos"])
         if write_file:
-            self.dump_modules_json()
+            self.dump()
 
-    def remove_modules_json_entry(self, module_name, repo_name):
+    def remove_entry(self, module_name, repo_name):
         """
         Removes an entry from the 'modules.json' file.
 
@@ -528,7 +528,7 @@ class ModulesJson:
             log.warning(f"Module '{repo_name}/{module_name}' is missing from 'modules.json' file.")
             return False
 
-        self.dump_modules_json()
+        self.dump()
         return True
 
     def repo_present(self, repo_name):
@@ -540,7 +540,7 @@ class ModulesJson:
             (bool): Whether the repo exists in the modules.json
         """
         if self.modules_json is None:
-            self.load_modules_json()
+            self.load()
         return repo_name in self.modules_json.get("repos", {})
 
     def module_present(self, module_name, repo_name):
@@ -553,7 +553,7 @@ class ModulesJson:
             (bool): Whether the module is present in the 'modules.json' file
         """
         if self.modules_json is None:
-            self.load_modules_json()
+            self.load()
         return module_name in self.modules_json.get("repos", {}).get(repo_name, {}).get("modules", {})
 
     def get_modules_json(self):
@@ -564,7 +564,7 @@ class ModulesJson:
             (dict): A copy of the loaded modules.json
         """
         if self.modules_json is None:
-            self.load_modules_json()
+            self.load()
         return copy.deepcopy(self.modules_json)
 
     def get_module_version(self, module_name, repo_name):
@@ -579,7 +579,7 @@ class ModulesJson:
             (str): The git SHA of the module if it exists, None otherwise
         """
         if self.modules_json is None:
-            self.load_modules_json()
+            self.load()
         return (
             self.modules_json.get("repos", {})
             .get(repo_name, {})
@@ -599,7 +599,7 @@ class ModulesJson:
             (str): The git url of the repository if it exists, None otherwise
         """
         if self.modules_json is None:
-            self.load_modules_json()
+            self.load()
         return self.modules_json.get("repos", {}).get(repo_name, {}).get("git_url", None)
 
     def get_base_path(self, repo_name):
@@ -612,10 +612,10 @@ class ModulesJson:
             (str): The base path of the repository if it exists, None otherwise
         """
         if self.modules_json is None:
-            self.load_modules_json()
+            self.load()
         return self.modules_json.get("repos", {}).get(repo_name, {}).get("base_path", None)
 
-    def dump_modules_json(self):
+    def dump(self):
         """
         Sort the modules.json, and write it to file
         """

--- a/nf_core/modules/remove.py
+++ b/nf_core/modules/remove.py
@@ -60,7 +60,7 @@ class ModuleRemove(ModuleCommand):
 
         # Load the modules.json file
         modules_json = ModulesJson(self.dir)
-        modules_json.load_modules_json()
+        modules_json.load()
 
         # Verify that the module is actually installed
         if not os.path.exists(module_dir):
@@ -68,13 +68,13 @@ class ModuleRemove(ModuleCommand):
 
             if modules_json.module_present(module, repo_name):
                 log.error(f"Found entry for '{module}' in 'modules.json'. Removing...")
-                modules_json.remove_modules_json_entry(module, repo_name)
+                modules_json.remove_entry(module, repo_name)
             return False
 
         log.info(f"Removing {module}")
 
         # Remove entry from modules.json
-        modules_json.remove_modules_json_entry(module, repo_name)
+        modules_json.remove_entry(module, repo_name)
 
         # Remove the module
         return self.clear_module_dir(module_name=module, module_dir=module_dir)

--- a/nf_core/modules/update.py
+++ b/nf_core/modules/update.py
@@ -53,7 +53,7 @@ class ModuleUpdate(ModuleCommand):
 
         # Verify that 'modules.json' is consistent with the installed modules
         modules_json = ModulesJson(self.dir)
-        modules_json.modules_json_up_to_date()
+        modules_json.check_up_to_date()
 
         tool_config = nf_core.utils.load_tools_config(self.dir)
         update_config = tool_config.get("update", {})
@@ -417,11 +417,11 @@ class ModuleUpdate(ModuleCommand):
 
             # Update modules.json with newly installed module
             if not dry_run:
-                modules_json.update_modules_json(modules_repo, module, version)
+                modules_json.update(modules_repo, module, version)
 
             # Don't save to a file, just iteratively update the variable
             else:
-                modules_json.update_modules_json(modules_repo, module, version, write_file=False)
+                modules_json.update(modules_repo, module, version, write_file=False)
 
         if self.save_diff_fn:
             # Compare the new modules.json and build a diff

--- a/tests/modules/modules_json.py
+++ b/tests/modules/modules_json.py
@@ -29,7 +29,7 @@ def test_mod_json_update(self):
     mod_json_obj = ModulesJson(self.pipeline_dir)
     # Update the modules.json file
     mod_repo_obj = ModulesRepo()
-    mod_json_obj.update_modules_json(mod_repo_obj, "MODULE_NAME", "GIT_SHA", False)
+    mod_json_obj.update(mod_repo_obj, "MODULE_NAME", "GIT_SHA", False)
     mod_json = mod_json_obj.get_modules_json()
     assert "MODULE_NAME" in mod_json["repos"][NF_CORE_MODULES_NAME]["modules"]
     assert "git_sha" in mod_json["repos"][NF_CORE_MODULES_NAME]["modules"]["MODULE_NAME"]
@@ -44,7 +44,7 @@ def test_mod_json_create(self):
 
     # Create the new modules.json file
     # (There are no prompts as long as there are only nf-core modules)
-    ModulesJson(self.pipeline_dir).create_modules_json()
+    ModulesJson(self.pipeline_dir).create()
 
     # Check that the file exists
     assert os.path.exists(mod_json_path)
@@ -66,7 +66,7 @@ def test_mod_json_up_to_date(self):
     """
     mod_json_obj = ModulesJson(self.pipeline_dir)
     mod_json_before = mod_json_obj.get_modules_json()
-    mod_json_obj.modules_json_up_to_date()
+    mod_json_obj.check_up_to_date()
     mod_json_after = mod_json_obj.get_modules_json()
 
     # Check that the modules.json hasn't changed
@@ -84,7 +84,7 @@ def test_mod_json_up_to_date_module_removed(self):
 
     # Check that the modules.json file is up to date, and reinstall the module
     mod_json_obj = ModulesJson(self.pipeline_dir)
-    mod_json_obj.modules_json_up_to_date()
+    mod_json_obj.check_up_to_date()
 
     # Check that the module has been reinstalled
     files = ["main.nf", "meta.yml"]
@@ -100,14 +100,14 @@ def test_mod_json_up_to_date_reinstall_fails(self):
     mod_json_obj = ModulesJson(self.pipeline_dir)
 
     # Update the fastqc module entry to an invalid git_sha
-    mod_json_obj.update_modules_json(ModulesRepo(), "fastqc", "INVALID_GIT_SHA", True)
+    mod_json_obj.update(ModulesRepo(), "fastqc", "INVALID_GIT_SHA", True)
 
     # Remove the fastqc module
     fastqc_path = os.path.join(self.pipeline_dir, "modules", NF_CORE_MODULES_NAME, "fastqc")
     shutil.rmtree(fastqc_path)
 
     # Check that the modules.json file is up to date, and remove the fastqc module entry
-    mod_json_obj.modules_json_up_to_date()
+    mod_json_obj.check_up_to_date()
     mod_json = mod_json_obj.get_modules_json()
 
     # Check that the module has been removed from the modules.json
@@ -166,7 +166,7 @@ def test_mod_json_dump(self):
     os.remove(mod_json_path)
 
     # Check that the dump function creates the file
-    mod_json_obj.dump_modules_json()
+    mod_json_obj.dump()
     assert os.path.exists(mod_json_path)
 
     # Check that the dump function writes the correct content


### PR DESCRIPTION
Renamed methods names in `ModulesJson` to not explicitly reference `modules.json`. This should have been done in #1655. 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
