### PR TITLE
Add gitpod and mamba profiles to the pipeline template

### DIFF
--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -87,6 +87,15 @@ profiles {
         shifter.enabled        = false
         charliecloud.enabled   = false
     }
+    mamba {
+        params.enable_conda    = true
+        conda.useMamba         = true
+        docker.enabled         = false
+        singularity.enabled    = false
+        podman.enabled         = false
+        shifter.enabled        = false
+        charliecloud.enabled   = false
+    }
     docker {
         docker.enabled         = true
         docker.userEmulation   = true
@@ -123,6 +132,11 @@ profiles {
         singularity.enabled    = false
         podman.enabled         = false
         shifter.enabled        = false
+    }
+    gitpod {
+        executor.name          = 'local'
+        executor.cpus          = 16
+        executor.memory        = 60.GB
     }
     test      { includeConfig 'conf/test.config'      }
     test_full { includeConfig 'conf/test_full.config' }


### PR DESCRIPTION
Adds profiles for gitpod and mamba to the pipeline template. 
Gitpod requires a few additional settings in order to make full use of the resources for workflow testing.
Mamba is increasingly used over conda, and so it makes sense to have a profile for it. 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
