### PR TITLE
Remove call to `getGenomeAttribute` in `main.nf` when running `nf-core create` without iGenomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix bug in pipeline readme logo URL ([#1590](https://github.com/nf-core/tools/pull/1590))
 - Switch CI to use [setup-nextflow](https://github.com/nf-core/setup-nextflow) action to install Nextflow ([#1650](https://github.com/nf-core/tools/pull/1650))
 - Add `CITATION.cff` [#361](https://github.com/nf-core/tools/issues/361)
+- Remove call to `getGenomeAttribute` in `main.nf` when running `nf-core create` without iGenomes ([#1670](https://github.com/nf-core/tools/issues/1670))
 
 ### Linting
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -246,15 +246,6 @@ def licences(pipeline, json):
         sys.exit(1)
 
 
-def validate_wf_name_prompt(ctx, opts, value):
-    """Force the workflow name to meet the nf-core requirements"""
-    if not re.match(r"^[a-z]+$", value):
-        log.error("[red]Invalid workflow name: must be lowercase without punctuation.")
-        value = click.prompt(opts.prompt)
-        return validate_wf_name_prompt(ctx, opts, value)
-    return value
-
-
 # nf-core create
 @nf_core_cli.command()
 @click.option(
@@ -278,10 +269,14 @@ def create(name, description, author, version, no_git, force, outdir, template_y
     Uses the nf-core template to make a skeleton Nextflow pipeline with all required
     files, boilerplate code and best-practices.
     """
-    create_obj = nf_core.create.PipelineCreate(
-        name, description, author, version, no_git, force, outdir, template_yaml, plain
-    )
-    create_obj.init_pipeline()
+    try:
+        create_obj = nf_core.create.PipelineCreate(
+            name, description, author, version, no_git, force, outdir, template_yaml, plain
+        )
+        create_obj.init_pipeline()
+    except UserWarning as e:
+        log.error(e)
+        sys.exit(1)
 
 
 # nf-core lint

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -85,11 +85,14 @@ class PipelineCreate(object):
         Args:
             template_yaml_path (str): Path to YAML file containing template parameters.
         """
-        if template_yaml_path is not None:
-            with open(template_yaml_path, "r") as f:
-                template_yaml = yaml.safe_load(f)
-        else:
-            template_yaml = {}
+        try:
+            if template_yaml_path is not None:
+                with open(template_yaml_path, "r") as f:
+                    template_yaml = yaml.safe_load(f)
+            else:
+                template_yaml = {}
+        except FileNotFoundError:
+            raise UserWarning(f"Template YAML file '{template_yaml_path}' not found.")
 
         param_dict = {}
         # Get the necessary parameters either from the template or command line arguments

--- a/nf_core/pipeline-template/lib/WorkflowMain.groovy
+++ b/nf_core/pipeline-template/lib/WorkflowMain.groovy
@@ -22,7 +22,11 @@ class WorkflowMain {
     // Print help to screen if required
     //
     public static String help(workflow, params, log) {
+        {% if igenomes -%}
         def command = "nextflow run ${workflow.manifest.name} --input samplesheet.csv --genome GRCh37 -profile docker"
+        {% else -%}
+        def command = "nextflow run ${workflow.manifest.name} --input samplesheet.csv -profile docker"
+        {% endif -%}
         def help_string = ''
         help_string += NfcoreTemplate.logo(workflow, params.monochrome_logs)
         help_string += NfcoreSchema.paramsHelp(workflow, params, command)

--- a/nf_core/pipeline-template/main.nf
+++ b/nf_core/pipeline-template/main.nf
@@ -12,7 +12,7 @@
 */
 
 nextflow.enable.dsl = 2
-
+{% if igenomes %}
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     GENOME PARAMETER VALUES
@@ -20,7 +20,7 @@ nextflow.enable.dsl = 2
 */
 
 params.fasta = WorkflowMain.getGenomeAttribute(params, 'fasta')
-
+{% endif %}
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     VALIDATE & PRINT PARAMETER SUMMARY


### PR DESCRIPTION
The function call to `getGenomesAttribute` was not removed when running `nf-core create` without iGenomes, causing the pipeline to fail as was reported in #1670. This PR removes this function call. 

I also removed references to the `--genomes` parameter when running `nextflow <pipeline> --help` in a pipeline without iGenomes, so it is displayed as 
```terminal
nextflow run fma/nftemplate --input samplesheet.csv -profile docker
```
rather than
```terminal
nextflow run nf-core/testing --input samplesheet.csv --genome GRCh37 -profile docker
```

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
