### PR TITLE
Update Gitpod tool versions to fix Docker build conflicts

### DIFF
--- a/nf_core/gitpod/gitpod.Dockerfile
+++ b/nf_core/gitpod/gitpod.Dockerfile
@@ -25,12 +25,12 @@ RUN conda update -n base -c defaults conda && \
     conda config --add channels bioconda && \
     conda config --add channels conda-forge && \
     conda install \
-        openjdk=11.0.13 \
+        openjdk=11.0.15 \
         nextflow=22.04.0 \
         pytest-workflow=1.6.0 \
-        mamba=0.23.1 \
-        pip=22.0.4 \
-        black=22.1.0 \
+        mamba=0.24.0 \
+        pip=22.1.2 \
+        black=22.6.0 \
         -n base && \
     conda clean --all -f -y
 


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

The Gitpod docker image build was failing because of a tool version conflict in conda. 
Tool versions have been updated and solve the issue. 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
