### PR TITLE
Add lint for input mimetype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Update `readme.py` nf version badge validation regexp to accept any signs before version number ([#1613](https://github.com/nf-core/tools/issues/1613))
 - Add isort configuration and GitHub workflow ([#1538](https://github.com/nf-core/tools/pull/1538))
 - Use black also to format python files in workflows ([#1563](https://github.com/nf-core/tools/pull/1563))
+- Add check for mimetype in the `input` parameter. ([#1647](https://github.com/nf-core/tools/issues/1647))
 
 ### General
 

--- a/nf_core/lint/schema_lint.py
+++ b/nf_core/lint/schema_lint.py
@@ -92,7 +92,7 @@ def schema_lint(self):
     # Check for mimetype in the 'input' parameter, warn if missing
     if self.schema_obj.schema is not None:
         try:
-            has_valid_mimetype = self.schema_obj.check_for_mimetype("input")
+            has_valid_mimetype = self.schema_obj.check_for_input_mimetype()
             if has_valid_mimetype:
                 passed.append("Input mimetype lint passed")
             else:

--- a/nf_core/lint/schema_lint.py
+++ b/nf_core/lint/schema_lint.py
@@ -37,6 +37,7 @@ def schema_lint(self):
         * ``$id``: URL to the raw schema file, eg. ``https://raw.githubusercontent.com/YOURPIPELINE/master/nextflow_schema.json``
         * ``title``: ``YOURPIPELINE pipeline parameters``
         * ``description``: The pipeline config ``manifest.description``
+    * That the ``input`` property is defined and has a mimetype. A list of common mimetypes can be found `here <https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types>`_.
 
     For example, an *extremely* minimal schema could look like this:
 
@@ -86,6 +87,17 @@ def schema_lint(self):
             self.schema_obj.validate_schema_title_description()
             passed.append("Schema title + description lint passed")
         except AssertionError as e:
+            warned.append(str(e))
+
+    # Check for mimetype in the 'input' parameter, warn if missing
+    if self.schema_obj.schema is not None:
+        try:
+            has_valid_mimetype = self.schema_obj.check_for_mimetype("input")
+            if has_valid_mimetype:
+                passed.append("Input mimetype lint passed")
+            else:
+                warned.append("Input mimetype is missing or empty")
+        except LookupError as e:
             warned.append(str(e))
 
     return {"passed": passed, "warned": warned, "failed": failed}

--- a/nf_core/lint/schema_lint.py
+++ b/nf_core/lint/schema_lint.py
@@ -93,8 +93,8 @@ def schema_lint(self):
     if self.schema_obj.schema is not None:
         try:
             has_valid_mimetype = self.schema_obj.check_for_input_mimetype()
-            if has_valid_mimetype:
-                passed.append("Input mimetype lint passed")
+            if has_valid_mimetype is not None:
+                passed.append(f"Input mimetype lint passed: '{has_valid_mimetype}'")
             else:
                 warned.append("Input mimetype is missing or empty")
         except LookupError as e:

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -418,6 +418,12 @@ class PipelineSchema(object):
         Check that the input parameter has a mimetype
 
         Common mime types: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
+
+        Returns:
+            mimetype (str): The mimetype of the input parameter
+
+        Raises:
+            LookupError: If the input parameter is not found or defined in the correct place
         """
 
         # Check that the input parameter is defined
@@ -428,11 +434,11 @@ class PipelineSchema(object):
             raise LookupError(f"Parameter `input` is not defined in the correct subschema (input_output_options)")
         input_entry = self.schema["definitions"]["input_output_options"]["properties"]["input"]
         if "mimetype" not in input_entry:
-            return False
+            return None
         mimetype = input_entry["mimetype"]
         if mimetype == "" or mimetype is None:
-            return False
-        return True
+            return None
+        return mimetype
 
     def print_documentation(
         self,

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -424,7 +424,7 @@ class PipelineSchema(object):
         if "input" not in self.schema_params:
             raise LookupError(f"Parameter `input` not found in schema")
         # Check that the input parameter is defined in the right place
-        if "input" not in self.schema.get("definitions", {})("input_output_options", {}).get("properties", {}):
+        if "input" not in self.schema.get("definitions", {}).get("input_output_options", {}).get("properties", {}):
             raise LookupError(f"Parameter `input` is not defined in the correct subschema (input_output_options)")
         input_entry = self.schema["definitions"]["input_output_options"]["properties"]["input"]
         if "mimetype" not in input_entry:

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -413,6 +413,20 @@ class PipelineSchema(object):
                 self.schema["description"] == desc_attr
             ), f"Schema 'description' should be '{desc_attr}'\n Found: '{self.schema['description']}'"
 
+    def check_for_mimetype(self, param):
+        """
+        Check that the given parameter has a mimetype
+
+        Common mime types: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
+        """
+        if param not in self.schema["properties"]:
+            raise LookupError(f"Parameter `{param}` not found in schema")
+        if "mimetype" not in self.schema["properties"][param]:
+            return False
+        if self.schema["properties"][param]["mimetype"] == "" or self.schema["properties"][param]["mimetype"] is None:
+            return False
+        return True
+
     def print_documentation(
         self,
         output_fn=None,

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -413,17 +413,22 @@ class PipelineSchema(object):
                 self.schema["description"] == desc_attr
             ), f"Schema 'description' should be '{desc_attr}'\n Found: '{self.schema['description']}'"
 
-    def check_for_mimetype(self, param):
+    def check_for_input_mimetype(self):
         """
-        Check that the given parameter has a mimetype
+        Check that the input parameter has a mimetype
 
         Common mime types: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
         """
-        if param not in self.schema["properties"]:
-            raise LookupError(f"Parameter `{param}` not found in schema")
-        if "mimetype" not in self.schema["properties"][param]:
+
+        # Check that the input parameter is defined in the right place
+        if "input" not in self.schema_params:
+            raise LookupError(f"Parameter `input` not found in schema")
+        # Assume the input parameter is defined in the right place
+        input_entry = self.schema["definitions"]["input_output_options"]["properties"]["input"]
+        if "mimetype" not in input_entry:
             return False
-        if self.schema["properties"][param]["mimetype"] == "" or self.schema["properties"][param]["mimetype"] is None:
+        mimetype = input_entry["mimetype"]
+        if mimetype == "" or mimetype is None:
             return False
         return True
 

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -420,10 +420,12 @@ class PipelineSchema(object):
         Common mime types: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
         """
 
-        # Check that the input parameter is defined in the right place
+        # Check that the input parameter is defined
         if "input" not in self.schema_params:
             raise LookupError(f"Parameter `input` not found in schema")
-        # Assume the input parameter is defined in the right place
+        # Check that the input parameter is defined in the right place
+        if "input" not in self.schema.get("definitions", {})("input_output_options", {}).get("properties", {}):
+            raise LookupError(f"Parameter `input` is not defined in the correct subschema (input_output_options)")
         input_entry = self.schema["definitions"]["input_output_options"]["properties"]["input"]
         if "mimetype" not in input_entry:
             return False


### PR DESCRIPTION
Check that the `input` parameter has a mimetype. Should close #1647.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
