### PR TITLE
Single-core tasks shouldn't request more than 1 core

### DIFF
--- a/nf_core/pipeline-template/conf/base.config
+++ b/nf_core/pipeline-template/conf/base.config
@@ -27,7 +27,7 @@ process {
     // TODO nf-core: Customise requirements for specific processes.
     // See https://www.nextflow.io/docs/latest/config.html#config-process-selectors
     withLabel:process_single {
-        cpus   = { check_max( 1    * task.attempt, 'cpus'    ) }
+        cpus   = { check_max( 1                  , 'cpus'    ) }
         memory = { check_max( 6.GB * task.attempt, 'memory'  ) }
         time   = { check_max( 4.h  * task.attempt, 'time'    ) }
     }


### PR DESCRIPTION
Follow-up of #1630 . For single-core tasks, there is no need to increase the number of cores at each attempt

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
