### PR TITLE
Fix `--key` flag for `nf-core lint` for module lint tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Add `CITATION.cff` [#361](https://github.com/nf-core/tools/issues/361)
 - Allow customization of the `nf-core` pipeline template when using `nf-core create` ([#1548](https://github.com/nf-core/tools/issues/1548))
 - Add Refgenie integration: updating of nextflow config files with a refgenie database ([#1090](https://github.com/nf-core/tools/pull/1090))
+- Fix `--key` option in `nf-core lint` when supplying a module lint test name ([#1681](https://github.com/nf-core/tools/issues/1681))
 
 ### Modules
 


### PR DESCRIPTION
When running `nf-core module --key <module-test>` all pipeline lint tests were run in addition to the supplied module test (#1681). With this PR only the tests specified by the `--key` option are run

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
