### PR TITLE
Lint for container names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Add isort configuration and GitHub workflow ([#1538](https://github.com/nf-core/tools/pull/1538))
 - Use black also to format python files in workflows ([#1563](https://github.com/nf-core/tools/pull/1563))
 - Add check for mimetype in the `input` parameter. ([#1647](https://github.com/nf-core/tools/issues/1647))
+- Check that the singularity and docker tags are parsable. Add `--fail-warned` flag to `nf-core modules lint` ([#1654](https://github.com/nf-core/tools/issues/1654))
 
 ### General
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -643,10 +643,11 @@ def create_test_yml(ctx, tool, run_tests, output, force, no_prompts):
 @click.option("-d", "--dir", type=click.Path(exists=True), default=".", metavar="<pipeline/modules directory>")
 @click.option("-k", "--key", type=str, metavar="<test>", multiple=True, help="Run only these lint tests")
 @click.option("-a", "--all", is_flag=True, help="Run on all modules")
+@click.option("-w", "--fail-warned", is_flag=True, help="Convert warn tests to failures")
 @click.option("--local", is_flag=True, help="Run additional lint tests for local modules")
 @click.option("--passed", is_flag=True, help="Show passed tests")
 @click.option("--fix-version", is_flag=True, help="Fix the module version if a newer version is available")
-def lint(ctx, tool, dir, key, all, local, passed, fix_version):
+def lint(ctx, tool, dir, key, all, fail_warned, local, passed, fix_version):
     """
     Lint one or more modules in a directory.
 
@@ -659,6 +660,7 @@ def lint(ctx, tool, dir, key, all, local, passed, fix_version):
     try:
         module_lint = nf_core.modules.ModuleLint(
             dir,
+            fail_warned,
             ctx.obj["modules_repo_url"],
             ctx.obj["modules_repo_branch"],
             ctx.obj["modules_repo_no_pull"],

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -479,7 +479,7 @@ class DownloadWorkflow(object):
 
                                     # Don't recognise this, throw a warning
                                     else:
-                                        log.error(f"[red]Cannot parse container string, skipping: [green]{match}")
+                                        log.error(f"[red]Cannot parse container string, skipping: [green]'{file}'")
 
                         if this_container:
                             containers_raw.append(this_container)

--- a/nf_core/lint/__init__.py
+++ b/nf_core/lint/__init__.py
@@ -83,7 +83,7 @@ def run_linting(
     lint_obj._list_files()
 
     # Create the modules lint object
-    module_lint_obj = nf_core.modules.lint.ModuleLint(pipeline_dir, fail_warned)
+    module_lint_obj = nf_core.modules.lint.ModuleLint(pipeline_dir)
 
     # Verify that the pipeline is correctly configured
     module_lint_obj.has_valid_directory()

--- a/nf_core/lint/__init__.py
+++ b/nf_core/lint/__init__.py
@@ -83,7 +83,7 @@ def run_linting(
     lint_obj._list_files()
 
     # Create the modules lint object
-    module_lint_obj = nf_core.modules.lint.ModuleLint(pipeline_dir)
+    module_lint_obj = nf_core.modules.lint.ModuleLint(pipeline_dir, fail_warned)
 
     # Verify that the pipeline is correctly configured
     module_lint_obj.has_valid_directory()

--- a/nf_core/modules/lint/__init__.py
+++ b/nf_core/modules/lint/__init__.py
@@ -245,7 +245,7 @@ class ModuleLint(ModuleCommand):
 
             # Filter local modules
             if os.path.exists(local_modules_dir):
-                local_modules = sorted([x for x in local_modules if x.endswith(".nf")])
+                local_modules = sorted([x for x in os.listdir(local_modules_dir) if x.endswith(".nf")])
 
         # nf-core/modules
         if self.repo_type == "modules":
@@ -342,7 +342,8 @@ class ModuleLint(ModuleCommand):
         if local:
             self.main_nf(mod, fix_version, progress_bar)
             self.passed += [LintResult(mod, *m) for m in mod.passed]
-            self.warned += [LintResult(mod, *m) for m in (mod.warned + mod.failed)]
+            self.warned += [LintResult(mod, *m) for m in mod.warned]
+            self.failed += [LintResult(mod, *m) for m in mod.failed]
 
         # Otherwise run all the lint tests
         else:

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -241,7 +241,6 @@ def check_process_section(self, lines, fix_version, progress_bar):
             self.passed.append(("process_standard_label", "Correct process label", self.main_nf))
     else:
         self.warned.append(("process_standard_label", "Process label unspecified", self.main_nf))
-
     for l in lines:
         if _container_type(l) == "bioconda":
             bioconda_packages = [b for b in l.split() if "bioconda::" in b]
@@ -249,11 +248,23 @@ def check_process_section(self, lines, fix_version, progress_bar):
         if _container_type(l) == "singularity":
             # e.g. "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img' :" -> v1.2.0_cv1
             # e.g. "https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0' :" -> 0.11.9--0
-            singularity_tag = re.search(r"(?:/)?(?:biocontainers_)?(?::)?([A-Za-z\d\-_.]+?)(?:\.img)?['\"]", l).group(1)
+            match = re.search(r"(?:/)?(?:biocontainers_)?(?::)?([A-Za-z\d\-_.]+?)(?:\.img)?['\"]", l)
+            if match is not None:
+                singularity_tag = match.group(1)
+                self.passed.append(("singularity_tag", f"Found singularity tag: {singularity_tag}", self.main_nf))
+            else:
+                self.failed.append(("singularity_tag", "Unable to parse singularity tag", self.main_nf))
+                singularity_tag = None
         if _container_type(l) == "docker":
             # e.g. "quay.io/biocontainers/krona:2.7.1--pl526_5' }" -> 2.7.1--pl526_5
             # e.g. "biocontainers/biocontainers:v1.2.0_cv1' }" -> v1.2.0_cv1
-            docker_tag = re.search(r"(?:[/])?(?::)?([A-Za-z\d\-_.]+)['\"]", l).group(1)
+            match = re.search(r"(?:[/])?(?::)?([A-Za-z\d\-_.]+)['\"]", l)
+            if match is not None:
+                docker_tag = match.group(1)
+                self.passed.append(("docker_tag", f"Found docker tag: {docker_tag}", self.main_nf))
+            else:
+                self.failed.append(("docker_tag", "Unable to parse docker tag", self.main_nf))
+                docker_tag = None
 
     # Check that all bioconda packages have build numbers
     # Also check for newer versions
@@ -434,6 +445,15 @@ def _container_type(line):
     if re.search("bioconda::", line):
         return "bioconda"
     if line.startswith("https://containers") or line.startswith("https://depot"):
-        return "singularity"
+        # Look for a http download URL.
+        # Thanks Stack Overflow for the regex: https://stackoverflow.com/a/3809435/713980
+        url_regex = (
+            r"https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)"
+        )
+        url_match = re.search(url_regex, line, re.S)
+        if url_match:
+            return "singularity"
+        else:
+            return None
     if line.startswith("biocontainers/") or line.startswith("quay.io/"):
         return "docker"

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -327,6 +327,7 @@ def setup_requests_cachedir():
         "backend": "sqlite",
     }
 
+    logging.getLogger("requests_cache").setLevel(logging.WARNING)
     try:
         if not os.path.exists(cachedir):
             os.makedirs(cachedir)


### PR DESCRIPTION
Added lint test to check that the container names in modules are parsable, as was suggested in #1654. To have the possibility of making the warned module lint test more prominent, I also added a `--fail-warned` flag. This flag is *not* activated when `nf-core lint` is run with its `--fail-warned` flag, since this will make the "Create and lint pipeline" GH action fail. (An idea on how to solve this is suggested in #1684) 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
