### PR TITLE
Fix bug in ModulesJson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Command `nf-core modules test` obtains module name suggestions from installed modules ([#1624](https://github.com/nf-core/tools/pull/1624))
 - Add `--base-path` flag to `nf-core modules` to specify the base path for the modules in a remote. Also refactored `modules.json` code. ([#1643](https://github.com/nf-core/tools/issues/1643))
 - Rename methods in `ModulesJson` to remove explicit reference to `modules.json`
+- Fix bug in `ModulesJson.check_up_to_date` causing it to ask for the remote of local modules
 
 ## [v2.4.1 - Cobolt Koala Patch](https://github.com/nf-core/tools/releases/tag/2.4) - [2022-05-16]
 

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -247,7 +247,7 @@ class ModulesJson:
         dirs = [
             os.path.relpath(dir_name, start=self.modules_dir)
             for dir_name, _, file_names in os.walk(self.modules_dir)
-            if "main.nf" in file_names
+            if "main.nf" in file_names and not os.path.relpath(dir_name, start=self.modules_dir).startswith("local")
         ]
 
         missing_from_modules_json = []


### PR DESCRIPTION
Fixed bug in `ModulesJson.check_up_to_date` causing local modules to not be filtered out when looking for the remote of untracked files. 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
