### PR TITLE
add --fasta parameter to command when igenomes is not used

### DIFF
--- a/nf_core/pipeline-template/conf/test.config
+++ b/nf_core/pipeline-template/conf/test.config
@@ -24,10 +24,10 @@ params {
     // TODO nf-core: Give any required params for the test so that command line flags are not needed
     input  = 'https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/samplesheet/samplesheet_test_illumina_amplicon.csv'
 
-    {% if igenomes %}
+    {% if igenomes -%}
     // Genome references
     genome = 'R64-1-1'
-    {% else -%}
+    {%- else -%}
     // Fasta references
     fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/genome/NC_045512.2/GCF_009858895.2_ASM985889v3_genomic.200409.fna.gz'
     {%- endif %}

--- a/nf_core/pipeline-template/conf/test.config
+++ b/nf_core/pipeline-template/conf/test.config
@@ -30,5 +30,5 @@ params {
     {% else -%}
     // Fasta references
     fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/genome/NC_045512.2/GCF_009858895.2_ASM985889v3_genomic.200409.fna.gz'
-    {% endif %}
+    {%- endif %}
 }

--- a/nf_core/pipeline-template/conf/test.config
+++ b/nf_core/pipeline-template/conf/test.config
@@ -24,6 +24,11 @@ params {
     // TODO nf-core: Give any required params for the test so that command line flags are not needed
     input  = 'https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/samplesheet/samplesheet_test_illumina_amplicon.csv'
 
+    {% if igenomes %}
     // Genome references
     genome = 'R64-1-1'
+    {% else -%}
+    // Fasta references
+    fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/genome/NC_045512.2/GCF_009858895.2_ASM985889v3_genomic.200409.fna.gz'
+    {% endif %}
 }

--- a/nf_core/pipeline-template/conf/test_full.config
+++ b/nf_core/pipeline-template/conf/test_full.config
@@ -25,5 +25,5 @@ params {
     {% else -%}
     // Fasta references
     fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/genome/NC_045512.2/GCF_009858895.2_ASM985889v3_genomic.200409.fna.gz'
-    {% endif %}
+    {%- endif %}
 }

--- a/nf_core/pipeline-template/conf/test_full.config
+++ b/nf_core/pipeline-template/conf/test_full.config
@@ -19,6 +19,11 @@ params {
     // TODO nf-core: Give any required params for the test so that command line flags are not needed
     input = 'https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/samplesheet/samplesheet_full_illumina_amplicon.csv'
 
+    {% if igenomes %}
     // Genome references
     genome = 'R64-1-1'
+    {% else -%}
+    // Fasta references
+    fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/genome/NC_045512.2/GCF_009858895.2_ASM985889v3_genomic.200409.fna.gz'
+    {% endif %}
 }

--- a/nf_core/pipeline-template/conf/test_full.config
+++ b/nf_core/pipeline-template/conf/test_full.config
@@ -19,10 +19,10 @@ params {
     // TODO nf-core: Give any required params for the test so that command line flags are not needed
     input = 'https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/samplesheet/samplesheet_full_illumina_amplicon.csv'
 
-    {% if igenomes %}
+    {% if igenomes -%}
     // Genome references
     genome = 'R64-1-1'
-    {% else -%}
+    {%- else -%}
     // Fasta references
     fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/genome/NC_045512.2/GCF_009858895.2_ASM985889v3_genomic.200409.fna.gz'
     {%- endif %}

--- a/nf_core/pipeline-template/lib/WorkflowMain.groovy
+++ b/nf_core/pipeline-template/lib/WorkflowMain.groovy
@@ -25,7 +25,7 @@ class WorkflowMain {
         {% if igenomes -%}
         def command = "nextflow run ${workflow.manifest.name} --input samplesheet.csv --genome GRCh37 -profile docker"
         {% else -%}
-        def command = "nextflow run ${workflow.manifest.name} --input samplesheet.csv -profile docker"
+        def command = "nextflow run ${workflow.manifest.name} --input samplesheet.csv --fasta reference.fa -profile docker"
         {% endif -%}
         def help_string = ''
         help_string += NfcoreTemplate.logo(workflow, params.monochrome_logs)


### PR DESCRIPTION
When creating a template without igenomes, a reference file has to be given with the `--fasta` parameter for the test pipeline to run.
Here we add the parameter to the example command from help message and also a reference fasta file to test.config and test_full.config
Closes [#1679](https://github.com/nf-core/tools/issues/1679)

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
