### PR TITLE
Make `nf-core modules update --save-diff` work when files are created or removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Rename methods in `ModulesJson` to remove explicit reference to `modules.json`
 - Fix inconsistencies in the `--save-diff` flag `nf-core modules update`. Refactor `nf-core modules update` ([#1536](https://github.com/nf-core/tools/pull/1536))
 - Fix bug in `ModulesJson.check_up_to_date` causing it to ask for the remote of local modules
+- Make `nf-core modules update --save-diff` fail if files were created or removed between revisions ([#1694](https://github.com/nf-core/tools/issues/1694))
 
 ## [v2.4.1 - Cobolt Koala Patch](https://github.com/nf-core/tools/releases/tag/2.4) - [2022-05-16]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@
 - Rename methods in `ModulesJson` to remove explicit reference to `modules.json`
 - Fix inconsistencies in the `--save-diff` flag `nf-core modules update`. Refactor `nf-core modules update` ([#1536](https://github.com/nf-core/tools/pull/1536))
 - Fix bug in `ModulesJson.check_up_to_date` causing it to ask for the remote of local modules
-- Make `nf-core modules update --save-diff` fail if files were created or removed between revisions ([#1694](https://github.com/nf-core/tools/issues/1694))
+- Make `nf-core modules update --save-diff` work when files were created or removed ([#1694](https://github.com/nf-core/tools/issues/1694))
 
 ## [v2.4.1 - Cobolt Koala Patch](https://github.com/nf-core/tools/releases/tag/2.4) - [2022-05-16]
 

--- a/nf_core/modules/modules_differ.py
+++ b/nf_core/modules/modules_differ.py
@@ -67,8 +67,14 @@ class ModulesDiffer:
         diffs = {}
         # Get all unique filenames in the two folders.
         # `dict.fromkeys()` is used instead of `set()` to preserve order
-        files = dict.fromkeys(os.listdir(to_dir))
-        files.update(dict.fromkeys(os.listdir(from_dir)))
+        files = dict.fromkeys(
+            [Path(dirpath, file).relative_to(to_dir) for dirpath, _, files in os.walk(to_dir) for file in files]
+        )
+        files.update(
+            dict.fromkeys(
+                [Path(dirpath, file).relative_to(from_dir) for dirpath, _, files in os.walk(from_dir) for file in files]
+            )
+        )
         files = list(files)
 
         # Loop through all the module files and compute their diffs if needed

--- a/nf_core/modules/modules_differ.py
+++ b/nf_core/modules/modules_differ.py
@@ -35,7 +35,7 @@ class ModulesDiffer:
         REMOVED = enum.auto()
 
     @staticmethod
-    def get_module_diffs(from_dir, to_dir, for_git, dsp_from_dir=None, dsp_to_dir=None):
+    def get_module_diffs(from_dir, to_dir, for_git=True, dsp_from_dir=None, dsp_to_dir=None):
         """
         Compute the diff between the current module version
         and the new version.
@@ -46,6 +46,11 @@ class ModulesDiffer:
             path_in_diff (strOrPath): The directory displayed containing the module
                                       file in the diff. Added so that temporary dirs
                                       are not shown
+            for_git (bool): indicates whether the diff file is to be
+                            compatible with `git apply`. If true it
+                            adds a/ and b/ prefixes to the file paths
+            dsp_from_dir (str | Path): The from directory to display in the diff
+            dsp_to_dir (str | Path): The to directory to display in the diff
 
         Returns:
             dict[str, (ModulesDiffer.DiffEnum, str)]: A dictionary containing
@@ -135,16 +140,22 @@ class ModulesDiffer:
         Writes the diffs of a module to the diff file.
 
         Args:
-            diff_path (str): The path to the file that should be appended
+            diff_path (str | Path): The path to the file that should be appended
             module (str): The module name
             repo_name (str): The name of the repo where the module resides
-            from_dir (str): The directory containing the old module files
-            to_dir (str): The directory containing the new module files
+            from_dir (str | Path): The directory containing the old module files
+            to_dir (str | Path): The directory containing the new module files
             diffs (dict[str, (ModulesDiffer.DiffEnum, str)]): A dictionary containing
-            the type of change and the diff (if any)
-            module_dir (str): The path to the current installation of the module
+                                                              the type of change and
+                                                              the diff (if any)
+            module_dir (str | Path): The path to the current installation of the module
             current_version (str): The installed version of the module
             new_version (str): The version of the module the diff is computed against
+            for_git (bool): indicates whether the diff file is to be
+                            compatible with `git apply`. If true it
+                            adds a/ and b/ prefixes to the file paths
+            dsp_from_dir (str | Path): The from directory to display in the diff
+            dsp_to_dir (str | Path): The to directory to display in the diff
         """
 
         diffs = ModulesDiffer.get_module_diffs(from_dir, to_dir, for_git, dsp_from_dir, dsp_to_dir)
@@ -182,7 +193,7 @@ class ModulesDiffer:
             modules_json_path (str): The path to the modules.json
             for_git (bool): indicates whether the diff file is to be
                             compatible with `git apply`. If true it
-                            adds a/ and b/ prefixes to the file names
+                            adds a/ and b/ prefixes to the file paths
         """
         fromfile = modules_json_path
         tofile = modules_json_path

--- a/nf_core/modules/modules_differ.py
+++ b/nf_core/modules/modules_differ.py
@@ -12,6 +12,7 @@ from rich.console import Console
 from rich.syntax import Syntax
 
 import nf_core.utils
+from nf_core.utils import plural_s
 
 log = logging.getLogger(__name__)
 
@@ -128,11 +129,19 @@ class ModulesDiffer:
                 warn_msg = ""
                 if created_files:
                     created_files_str = "' ,'".join(created_files)
-                    warn_msg += f"File{nf_core.utils.plural_s(created_files)}  '{created_files_str}' were created. "
+                    created_files_str = (
+                        f"File{plural_s(created_files)} '{created_files_str}' of module '{module}' were created."
+                    )
+                else:
+                    created_files_str = None
                 if removed_files:
                     removed_files_str = "' ,'".join(removed_files)
-                    warn_msg += f"File{nf_core.utils.plural_s(removed_files)}  '{removed_files_str}' were removed."
-                raise UserWarning(warn_msg)
+                    removed_files_str = (
+                        f"File{plural_s(removed_files)} '{removed_files_str}' of module '{module}' were removed."
+                    )
+                else:
+                    removed_files_str = None
+                raise UserWarning(created_files_str, removed_files_str)
 
             for file, (diff_status, diff) in diffs.items():
                 if diff_status == ModulesDiffer.DiffEnum.CHANGED:

--- a/nf_core/modules/modules_differ.py
+++ b/nf_core/modules/modules_differ.py
@@ -117,20 +117,25 @@ class ModulesDiffer:
             else:
                 fh.write(f"Changes in module '{module}'\n")
 
+            # Check if any files were created or removed
+            created_files = [
+                file for file, (diff_status, _) in diffs.items() if diff_status == ModulesDiffer.DiffEnum.CREATED
+            ]
+            removed_files = [
+                file for file, (diff_status, _) in diffs.items() if diff_status == ModulesDiffer.DiffEnum.REMOVED
+            ]
+            if created_files or removed_files:
+                warn_msg = ""
+                if created_files:
+                    created_files_str = "' ,'".join(created_files)
+                    warn_msg += f"File{nf_core.utils.plural_s(created_files)}  '{created_files_str}' were created. "
+                if removed_files:
+                    removed_files_str = "' ,'".join(removed_files)
+                    warn_msg += f"File{nf_core.utils.plural_s(removed_files)}  '{removed_files_str}' were removed."
+                raise UserWarning(warn_msg)
+
             for file, (diff_status, diff) in diffs.items():
-                if diff_status == ModulesDiffer.DiffEnum.UNCHANGED:
-                    # The files are identical
-                    fh.write(f"'{Path(from_dir, file)}' is unchanged\n")
-
-                elif diff_status == ModulesDiffer.DiffEnum.CREATED:
-                    # The file was created between the commits
-                    fh.write(f"'{Path(from_dir, file)}' was created\n")
-
-                elif diff_status == ModulesDiffer.DiffEnum.REMOVED:
-                    # The file was removed between the commits
-                    fh.write(f"'{Path(from_dir, file)}' was removed\n")
-
-                else:
+                if diff_status == ModulesDiffer.DiffEnum.CHANGED:
                     # The file has changed
                     fh.write(f"Changes in '{Path(from_dir, file)}':\n")
                     # Write the diff lines to the file

--- a/nf_core/modules/modules_differ.py
+++ b/nf_core/modules/modules_differ.py
@@ -1,0 +1,204 @@
+import difflib
+import enum
+import json
+import logging
+import os
+import re
+import shutil
+import tempfile
+from pathlib import Path
+
+from rich.console import Console
+from rich.syntax import Syntax
+
+import nf_core.utils
+
+log = logging.getLogger(__name__)
+
+
+class ModulesDiffer:
+    """
+    Static class that provides functionality for computing diffs between
+    different instances of a module
+    """
+
+    class DiffEnum(enum.Enum):
+        """
+        Enumeration for keeping track of
+        the diff status of a pair of files
+        """
+
+        UNCHANGED = enum.auto()
+        CHANGED = enum.auto()
+        CREATED = enum.auto()
+        REMOVED = enum.auto()
+
+    @staticmethod
+    def get_module_diffs(from_dir, to_dir, path_in_diff=None):
+        """
+        Compute the diff between the current module version
+        and the new version.
+
+        Args:
+            from_dir (strOrPath): The folder containing the old module files
+            to_dir (strOrPath): The folder containing the new module files
+            path_in_diff (strOrPath): The directory displayed containing the module
+                                      file in the diff. Added so that temporary dirs
+                                      are not shown
+
+        Returns:
+            dict[str, (ModulesDiffer.DiffEnum, str)]: A dictionary containing
+            the diff type and the diff string (empty if no diff)
+        """
+        if path_in_diff is None:
+            path_in_diff = from_dir
+
+        diffs = {}
+        # Get all unique filenames in the two folders.
+        # `dict.fromkeys()` is used instead of `set()` to preserve order
+        files = dict.fromkeys(os.listdir(to_dir))
+        files.update(dict.fromkeys(os.listdir(from_dir)))
+        files = list(files)
+
+        # Loop through all the module files and compute their diffs if needed
+        for file in files:
+            temp_path = Path(to_dir, file)
+            curr_path = Path(from_dir, file)
+            if temp_path.exists() and curr_path.exists() and temp_path.is_file():
+                with open(temp_path, "r") as fh:
+                    new_lines = fh.readlines()
+                with open(curr_path, "r") as fh:
+                    old_lines = fh.readlines()
+
+                if new_lines == old_lines:
+                    # The files are identical
+                    diffs[file] = (ModulesDiffer.DiffEnum.UNCHANGED, ())
+                else:
+                    # Compute the diff
+                    diff = difflib.unified_diff(
+                        old_lines,
+                        new_lines,
+                        fromfile=str(Path(path_in_diff, file)),
+                        tofile=str(Path(path_in_diff, file)),
+                    )
+                    diffs[file] = (ModulesDiffer.DiffEnum.CHANGED, diff)
+
+            elif temp_path.exists():
+                # The file was created
+                diffs[file] = (ModulesDiffer.DiffEnum.CREATED, ())
+
+            elif curr_path.exists():
+                # The file was removed
+                diffs[file] = (ModulesDiffer.DiffEnum.REMOVED, ())
+
+        return diffs
+
+    @staticmethod
+    def write_diff_file(diff_path, module, from_dir, to_dir, current_version, new_version, file_action="a"):
+        """
+        Writes the diffs of a module to the diff file.
+
+        Args:
+            diff_path (str): The path to the file that should be appended
+            module (str): The module name
+            from_dir (str): The directory containing the old module files
+            to_dir (str): The directory containing the new module files
+            diffs (dict[str, (ModulesDiffer.DiffEnum, str)]): A dictionary containing
+            the type of change and the diff (if any)
+            module_dir (str): The path to the current installation of the module
+            current_version (str): The installed version of the module
+            new_version (str): The version of the module the diff is computed against
+        """
+        diffs = ModulesDiffer.get_module_diffs(from_dir, to_dir)
+        log.info(f"Writing diff of '{module}' to '{diff_path}'")
+        with open(diff_path, file_action) as fh:
+            if current_version is not None and new_version is not None:
+                fh.write(f"Changes in module '{module}' between" f" ({current_version}) and" f" ({new_version})\n")
+            else:
+                fh.write(f"Changes in module '{module}'\n")
+
+            for file, (diff_status, diff) in diffs.items():
+                if diff_status == ModulesDiffer.DiffEnum.UNCHANGED:
+                    # The files are identical
+                    fh.write(f"'{Path(from_dir, file)}' is unchanged\n")
+
+                elif diff_status == ModulesDiffer.DiffEnum.CREATED:
+                    # The file was created between the commits
+                    fh.write(f"'{Path(from_dir, file)}' was created\n")
+
+                elif diff_status == ModulesDiffer.DiffEnum.REMOVED:
+                    # The file was removed between the commits
+                    fh.write(f"'{Path(from_dir, file)}' was removed\n")
+
+                else:
+                    # The file has changed
+                    fh.write(f"Changes in '{Path(from_dir, file)}':\n")
+                    # Write the diff lines to the file
+                    for line in diff:
+                        fh.write(line)
+                    fh.write("\n")
+
+            fh.write("*" * 60 + "\n")
+
+    @staticmethod
+    def append_modules_json_diff(diff_path, old_modules_json, new_modules_json, modules_json_path):
+        """
+        Compare the new modules.json and builds a diff
+
+        Args:
+            diff_fn (str): The diff file to be appended
+            old_modules_json (nested dict): The old modules.json
+            new_modules_json (nested dict): The new modules.json
+            modules_json_path (str): The path to the modules.json
+        """
+        modules_json_diff = difflib.unified_diff(
+            json.dumps(old_modules_json, indent=4).splitlines(keepends=True),
+            json.dumps(new_modules_json, indent=4).splitlines(keepends=True),
+            fromfile=str(modules_json_path),
+            tofile=str(modules_json_path),
+        )
+
+        # Save diff for modules.json to file
+        with open(diff_path, "a") as fh:
+            fh.write("Changes in './modules.json'\n")
+            for line in modules_json_diff:
+                fh.write(line)
+            fh.write("*" * 60 + "\n")
+
+    @staticmethod
+    def print_diff(module, from_dir, to_dir, current_version, new_version):
+        """
+        Prints the diffs between two module versions to the terminal
+
+        Args:
+            module (str): The module name
+            diffs (dict[str, (ModulesDiffer.DiffEnum, str)]): A dictionary containing
+            the type of change and the diff (if any)
+            from_dir (str): The directory containing the old module files
+            to_dir (str): The directory containing the new module files
+            module_dir (str): The path to the current installation of the module
+            current_version (str): The installed version of the module
+            new_version (str): The version of the module the diff is computed against
+        """
+        diffs = ModulesDiffer.get_module_diffs(from_dir, to_dir)
+        console = Console(force_terminal=nf_core.utils.rich_force_colors())
+        if current_version is not None and new_version is not None:
+            log.info(f"Changes in module '{module}' between" f" ({current_version}) and" f" ({new_version})")
+        else:
+            log.info(f"Changes in module '{module}'")
+
+        for file, (diff_status, diff) in diffs.items():
+            if diff_status == ModulesDiffer.DiffEnum.UNCHANGED:
+                # The files are identical
+                log.info(f"'{Path(from_dir, file)}' is unchanged")
+            elif diff_status == ModulesDiffer.DiffEnum.CREATED:
+                # The file was created between the commits
+                log.info(f"'{Path(from_dir, file)}' was created")
+            elif diff_status == ModulesDiffer.DiffEnum.REMOVED:
+                # The file was removed between the commits
+                log.info(f"'{Path(from_dir, file)}' was removed")
+            else:
+                # The file has changed
+                log.info(f"Changes in '{Path(module, file)}':")
+                # Pretty print the diff using the pygments diff lexer
+                console.print(Syntax("".join(diff), "diff", theme="ansi_light"))

--- a/nf_core/modules/modules_differ.py
+++ b/nf_core/modules/modules_differ.py
@@ -93,6 +93,7 @@ class ModulesDiffer:
                 with open(temp_path, "r") as fh:
                     new_lines = fh.readlines()
                 # The file was created
+                # Show file against /dev/null
                 diff = difflib.unified_diff(
                     [],
                     new_lines,
@@ -103,6 +104,7 @@ class ModulesDiffer:
 
             elif curr_path.exists():
                 # The file was removed
+                # Show file against /dev/null
                 with open(curr_path, "r") as fh:
                     old_lines = fh.readlines()
                 diff = difflib.unified_diff(
@@ -119,6 +121,7 @@ class ModulesDiffer:
     def write_diff_file(
         diff_path,
         module,
+        repo_name,
         from_dir,
         to_dir,
         current_version,
@@ -134,6 +137,7 @@ class ModulesDiffer:
         Args:
             diff_path (str): The path to the file that should be appended
             module (str): The module name
+            repo_name (str): The name of the repo where the module resides
             from_dir (str): The directory containing the old module files
             to_dir (str): The directory containing the new module files
             diffs (dict[str, (ModulesDiffer.DiffEnum, str)]): A dictionary containing
@@ -147,9 +151,13 @@ class ModulesDiffer:
         log.info(f"Writing diff of '{module}' to '{diff_path}'")
         with open(diff_path, file_action) as fh:
             if current_version is not None and new_version is not None:
-                fh.write(f"Changes in module '{module}' between" f" ({current_version}) and" f" ({new_version})\n")
+                fh.write(
+                    f"Changes in module '{Path(repo_name, module)}' between"
+                    f" ({current_version}) and"
+                    f" ({new_version})\n"
+                )
             else:
-                fh.write(f"Changes in module '{module}'\n")
+                fh.write(f"Changes in module '{Path(repo_name, module)}'\n")
 
             for file, (diff_status, diff) in diffs.items():
                 if diff_status != ModulesDiffer.DiffEnum.UNCHANGED:
@@ -197,12 +205,13 @@ class ModulesDiffer:
             fh.write("*" * 60 + "\n")
 
     @staticmethod
-    def print_diff(module, from_dir, to_dir, current_version, new_version):
+    def print_diff(module, repo_name, from_dir, to_dir, current_version, new_version):
         """
         Prints the diffs between two module versions to the terminal
 
         Args:
             module (str): The module name
+            repo_name (str): The name of the repo where the module resides
             diffs (dict[str, (ModulesDiffer.DiffEnum, str)]): A dictionary containing
             the type of change and the diff (if any)
             from_dir (str): The directory containing the old module files
@@ -214,9 +223,11 @@ class ModulesDiffer:
         diffs = ModulesDiffer.get_module_diffs(from_dir, to_dir)
         console = Console(force_terminal=nf_core.utils.rich_force_colors())
         if current_version is not None and new_version is not None:
-            log.info(f"Changes in module '{module}' between" f" ({current_version}) and" f" ({new_version})")
+            log.info(
+                f"Changes in module '{Path(repo_name, module)}' between" f" ({current_version}) and" f" ({new_version})"
+            )
         else:
-            log.info(f"Changes in module '{module}'")
+            log.info(f"Changes in module '{Path(repo_name, module)}'")
 
         for file, (diff_status, diff) in diffs.items():
             if diff_status == ModulesDiffer.DiffEnum.UNCHANGED:

--- a/nf_core/modules/update.py
+++ b/nf_core/modules/update.py
@@ -188,7 +188,14 @@ class ModuleUpdate(ModuleCommand):
                 if self.save_diff_fn:
                     try:
                         ModulesDiffer.write_diff_file(
-                            self.save_diff_fn, module, module_dir, module_install_dir, current_version, version
+                            self.save_diff_fn,
+                            module,
+                            module_dir,
+                            module_install_dir,
+                            current_version,
+                            version,
+                            dsp_from_dir=module_dir,
+                            dsp_to_dir=module_dir,
                         )
                     except UserWarning as e:
                         # Remove the diff file

--- a/nf_core/modules/update.py
+++ b/nf_core/modules/update.py
@@ -186,9 +186,16 @@ class ModuleUpdate(ModuleCommand):
             if dry_run:
                 # Compute the diffs for the module
                 if self.save_diff_fn:
-                    ModulesDiffer.write_diff_file(
-                        self.save_diff_fn, module, module_dir, module_install_dir, current_version, version
-                    )
+                    try:
+                        ModulesDiffer.write_diff_file(
+                            self.save_diff_fn, module, module_dir, module_install_dir, current_version, version
+                        )
+                    except UserWarning as e:
+                        log.warning(e)
+                        log.info(
+                            f"Skipping module '{Path(modules_repo.fullname, module)}'. To update use either '--preview' or '--no-preview' options"
+                        )
+                        continue
                 elif self.show_diff:
                     ModulesDiffer.print_diff(module, module_dir, module_install_dir, current_version, version)
 

--- a/nf_core/modules/update.py
+++ b/nf_core/modules/update.py
@@ -190,6 +190,7 @@ class ModuleUpdate(ModuleCommand):
                         ModulesDiffer.write_diff_file(
                             self.save_diff_fn,
                             module,
+                            modules_repo.fullname,
                             module_dir,
                             module_install_dir,
                             current_version,
@@ -210,7 +211,9 @@ class ModuleUpdate(ModuleCommand):
                         )
 
                 elif self.show_diff:
-                    ModulesDiffer.print_diff(module, module_dir, module_install_dir, current_version, version)
+                    ModulesDiffer.print_diff(
+                        module, modules_repo.fullname, module_dir, module_install_dir, current_version, version
+                    )
 
                     # Ask the user if they want to install the module
                     dry_run = not questionary.confirm(

--- a/nf_core/modules/update.py
+++ b/nf_core/modules/update.py
@@ -199,7 +199,7 @@ class ModuleUpdate(ModuleCommand):
                         if removed_files_msg is not None:
                             log.error(removed_files_msg)
                         raise UserWarning(
-                            "Can't use '--save-diff' option when files were created or removed. Please use '--no-preview' or '--preview' options."
+                            "Can't use '--save-diff' option when files were created or removed. Please use either of '--no-preview' or '--preview' options."
                         )
 
                 elif self.show_diff:


### PR DESCRIPTION
As I reported in #1694, `nf-core modules update --save-file` simply ignored files that were created or removed between updates. I've fixed this by letting the output `.diff` file be more similar to the output from `git diff`: 
- Created or removed files are shown to originate from/end up in `/dev/null`
- "from" and "to" file paths are prefixed with `a/` and `b/` respectively. 

I've moved the diff methods in `update` to a separate static class to make the update code a bit cleaner also

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
