### PR TITLE
retrieve last common build of a module for Docker and Singularity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Fix inconsistencies in the `--save-diff` flag `nf-core modules update`. Refactor `nf-core modules update` ([#1536](https://github.com/nf-core/tools/pull/1536))
 - Fix bug in `ModulesJson.check_up_to_date` causing it to ask for the remote of local modules
 - Make `nf-core modules update --save-diff` work when files were created or removed ([#1694](https://github.com/nf-core/tools/issues/1694))
+- Get the latest common build for Docker and Singularity containers of a module ([#1702](https://github.com/nf-core/tools/pull/1702))
 
 ## [v2.4.1 - Cobolt Koala Patch](https://github.com/nf-core/tools/releases/tag/2.4) - [2022-05-16]
 

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -717,12 +717,14 @@ def get_biocontainer_tag(package, version):
                             all_singularity[match.group(1)] = {"date": get_tag_date(img["updated"]), "image": img}
                 # Obtain common builds from Docker and Singularity images
                 common_keys = list(all_docker.keys() & all_singularity.keys())
+                current_date = None
                 for k in common_keys:
                     # Get the most recent common image
-                    if not docker_image or all_docker[k]["date"] > get_tag_date(docker_image["updated"]):
+                    date = max(get_tag_date(all_docker[k]["date"]]), get_tag_date(all_docker[k]["date"]))
+                    if docker_image is None or current_date < date:
                         docker_image = all_docker[k]["image"]
-                    if not singularity_image or all_singularity[k]["date"] > get_tag_date(singularity_image["updated"]):
                         singularity_image = all_singularity[k]["image"]
+                        current_date = date
                 return docker_image["image_name"], singularity_image["image_name"]
             except TypeError:
                 raise LookupError(f"Could not find docker or singularity container for {package}")

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -720,7 +720,7 @@ def get_biocontainer_tag(package, version):
                 current_date = None
                 for k in common_keys:
                     # Get the most recent common image
-                    date = max(get_tag_date(all_docker[k]["date"]]), get_tag_date(all_docker[k]["date"]))
+                    date = max(get_tag_date(all_docker[k]["date"]), get_tag_date(all_docker[k]["date"]))
                     if docker_image is None or current_date < date:
                         docker_image = all_docker[k]["image"]
                         singularity_image = all_singularity[k]["image"]

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -720,7 +720,7 @@ def get_biocontainer_tag(package, version):
                 current_date = None
                 for k in common_keys:
                     # Get the most recent common image
-                    date = max(get_tag_date(all_docker[k]["date"]), get_tag_date(all_docker[k]["date"]))
+                    date = max(all_docker[k]["date"], all_docker[k]["date"])
                     if docker_image is None or current_date < date:
                         docker_image = all_docker[k]["image"]
                         singularity_image = all_singularity[k]["image"]


### PR DESCRIPTION
Closes [#1656](https://github.com/nf-core/tools/issues/1656)

When obtaining Docker and Singularity containers from a bioconda package and version, get the latest common build for both containers.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
