### PR TITLE
Git default branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add `CITATION.cff` [#361](https://github.com/nf-core/tools/issues/361)
 - Add Gitpod and Mamba profiles to the pipeline template ([#1673](https://github.com/nf-core/tools/pull/1673))
 - Remove call to `getGenomeAttribute` in `main.nf` when running `nf-core create` without iGenomes ([#1670](https://github.com/nf-core/tools/issues/1670))
+- Make `nf-core create` and `nf-core lint` fail if Git default branch name is dev or TEMPLATE [#1705](https://github.com/nf-core/tools/pull/1705)
 
 ### Linting
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Add `CITATION.cff` [#361](https://github.com/nf-core/tools/issues/361)
 - Add Gitpod and Mamba profiles to the pipeline template ([#1673](https://github.com/nf-core/tools/pull/1673))
 - Remove call to `getGenomeAttribute` in `main.nf` when running `nf-core create` without iGenomes ([#1670](https://github.com/nf-core/tools/issues/1670))
-- Make `nf-core create` and `nf-core lint` fail if Git default branch name is dev or TEMPLATE [#1705](https://github.com/nf-core/tools/pull/1705)
+- Make `nf-core create` fail if Git default branch name is dev or TEMPLATE ([#1705](https://github.com/nf-core/tools/pull/1705))
 
 ### Linting
 

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -2,6 +2,7 @@
 """Creates a nf-core pipeline matching the current
 organization's specification based on a template.
 """
+import configparser
 import imghdr
 import logging
 import os
@@ -491,14 +492,17 @@ class PipelineCreate(object):
 
     def git_init_pipeline(self):
         """Initialises the new pipeline as a Git repository and submits first commit.
-        
+
         Raises:
             UserWarning: if Git default branch is set to 'dev' or 'TEMPLATE'.
         """
         # Check that the default branch is not dev
-        default_branch = git.config.GitConfigParser().get_value("init", "defaultBranch")
+        try:
+            default_branch = git.config.GitConfigParser().get_value("init", "defaultBranch")
+        except configparser.Error:
+            default_branch = None
         log.info(default_branch)
-        if default_branch == 'dev' or default_branch == 'TEMPLATE':
+        if default_branch == "dev" or default_branch == "TEMPLATE":
             raise UserWarning(
                 f"Your Git defaultBranch is set to '{default_branch}', which is incompatible with nf-core.\n"
                 "This can be modified with the command [white on grey23] git config --global init.defaultBranch <NAME> [/]\n"

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -501,7 +501,8 @@ class PipelineCreate(object):
         if default_branch == 'dev' or default_branch == 'TEMPLATE':
             raise UserWarning(
                 f"Your Git defaultBranch is set to '{default_branch}', which is incompatible with nf-core.\n"
-                "This can be modified with the command [bold magenta italic] git config --global init.defaultBranch <NAME> [/]"
+                "This can be modified with the command [white on grey23] git config --global init.defaultBranch <NAME> [/]\n"
+                "Pipeline git repository is not initialised."
             )
         # Initialise pipeline
         log.info("Initialising pipeline git repository")

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -490,7 +490,20 @@ class PipelineCreate(object):
             break
 
     def git_init_pipeline(self):
-        """Initialises the new pipeline as a Git repository and submits first commit."""
+        """Initialises the new pipeline as a Git repository and submits first commit.
+        
+        Raises:
+            UserWarning: if Git default branch is set to 'dev' or 'TEMPLATE'.
+        """
+        # Check that the default branch is not dev
+        default_branch = git.config.GitConfigParser().get_value("init", "defaultBranch")
+        log.info(default_branch)
+        if default_branch == 'dev' or default_branch == 'TEMPLATE':
+            raise UserWarning(
+                f"Your Git defaultBranch is set to '{default_branch}', which is incompatible with nf-core.\n"
+                "This can be modified with the command [bold magenta italic] git config --global init.defaultBranch <NAME> [/]"
+            )
+        # Initialise pipeline
         log.info("Initialising pipeline git repository")
         repo = git.Repo.init(self.outdir)
         repo.git.add(A=True)

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -501,7 +501,7 @@ class PipelineCreate(object):
             default_branch = git.config.GitConfigParser().get_value("init", "defaultBranch")
         except configparser.Error:
             default_branch = None
-        log.info(default_branch)
+            log.debug("Could not read init.defaultBranch")
         if default_branch == "dev" or default_branch == "TEMPLATE":
             raise UserWarning(
                 f"Your Git defaultBranch is set to '{default_branch}', which is incompatible with nf-core.\n"


### PR DESCRIPTION
Closes #1688 

If Git `defaultBranch` is set to `dev` or `TEMPLATE` nf-core commands that create a new pipeline repository fail with nice error message and the pipeline git repository is not initialised.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
