### PR TITLE
provide ansi code stripping from utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Allow customization of the `nf-core` pipeline template when using `nf-core create` ([#1548](https://github.com/nf-core/tools/issues/1548))
 - Add Refgenie integration: updating of nextflow config files with a refgenie database ([#1090](https://github.com/nf-core/tools/pull/1090))
 - Fix `--key` option in `nf-core lint` when supplying a module lint test name ([#1681](https://github.com/nf-core/tools/issues/1681))
+- Move `strip_ansi_code` function in lint to `utils.py`
 
 ### Modules
 

--- a/docs/api/_src/api/lint.md
+++ b/docs/api/_src/api/lint.md
@@ -14,6 +14,6 @@ See the [Lint Tests](../pipeline_lint_tests/index.md) docs for information about
 ```{eval-rst}
 .. autoclass:: nf_core.lint.PipelineLint
     :members: _lint_pipeline
-    :private-members: _print_results, _get_results_md, _save_json_results, _wrap_quotes, _strip_ansi_codes
+    :private-members: _print_results, _get_results_md, _save_json_results, _wrap_quotes
     :show-inheritance:
 ```

--- a/nf_core/lint/__init__.py
+++ b/nf_core/lint/__init__.py
@@ -24,6 +24,7 @@ import nf_core.utils
 from nf_core import __version__
 from nf_core.lint_utils import console
 from nf_core.utils import plural_s as _s
+from nf_core.utils import strip_ansi_codes
 
 log = logging.getLogger(__name__)
 
@@ -458,7 +459,7 @@ class PipelineLint(nf_core.utils.Pipeline):
                 "\n".join(
                     [
                         f"* [{eid}](https://nf-co.re/tools-docs/lint_tests/{eid}.html) - "
-                        f"{self._strip_ansi_codes(msg, '`')}"
+                        f"{strip_ansi_codes(msg, '`')}"
                         for eid, msg in self.failed
                     ]
                 )
@@ -472,7 +473,7 @@ class PipelineLint(nf_core.utils.Pipeline):
                 "\n".join(
                     [
                         f"* [{eid}](https://nf-co.re/tools-docs/lint_tests/{eid}.html) - "
-                        f"{self._strip_ansi_codes(msg, '`')}"
+                        f"{strip_ansi_codes(msg, '`')}"
                         for eid, msg in self.ignored
                     ]
                 )
@@ -486,7 +487,7 @@ class PipelineLint(nf_core.utils.Pipeline):
                 "\n".join(
                     [
                         f"* [{eid}](https://nf-co.re/tools-docs/lint_tests/{eid}.html) - "
-                        f"{self._strip_ansi_codes(msg, '`')}"
+                        f"{strip_ansi_codes(msg, '`')}"
                         for eid, msg in self.fixed
                     ]
                 )
@@ -500,7 +501,7 @@ class PipelineLint(nf_core.utils.Pipeline):
                 "\n".join(
                     [
                         f"* [{eid}](https://nf-co.re/tools-docs/lint_tests/{eid}.html) - "
-                        f"{self._strip_ansi_codes(msg, '`')}"
+                        f"{strip_ansi_codes(msg, '`')}"
                         for eid, msg in self.warned
                     ]
                 )
@@ -515,7 +516,7 @@ class PipelineLint(nf_core.utils.Pipeline):
                     [
                         (
                             f"* [{eid}](https://nf-co.re/tools-docs/lint_tests/{eid}.html)"
-                            f" - {self._strip_ansi_codes(msg, '`')}"
+                            f" - {strip_ansi_codes(msg, '`')}"
                         )
                         for eid, msg in self.passed
                     ]
@@ -553,11 +554,11 @@ class PipelineLint(nf_core.utils.Pipeline):
         results = {
             "nf_core_tools_version": nf_core.__version__,
             "date_run": now.strftime("%Y-%m-%d %H:%M:%S"),
-            "tests_pass": [[idx, self._strip_ansi_codes(msg)] for idx, msg in self.passed],
-            "tests_ignored": [[idx, self._strip_ansi_codes(msg)] for idx, msg in self.ignored],
-            "tests_fixed": [[idx, self._strip_ansi_codes(msg)] for idx, msg in self.fixed],
-            "tests_warned": [[idx, self._strip_ansi_codes(msg)] for idx, msg in self.warned],
-            "tests_failed": [[idx, self._strip_ansi_codes(msg)] for idx, msg in self.failed],
+            "tests_pass": [[idx, strip_ansi_codes(msg)] for idx, msg in self.passed],
+            "tests_ignored": [[idx, strip_ansi_codes(msg)] for idx, msg in self.ignored],
+            "tests_fixed": [[idx, strip_ansi_codes(msg)] for idx, msg in self.fixed],
+            "tests_warned": [[idx, strip_ansi_codes(msg)] for idx, msg in self.warned],
+            "tests_failed": [[idx, strip_ansi_codes(msg)] for idx, msg in self.failed],
             "num_tests_pass": len(self.passed),
             "num_tests_ignored": len(self.ignored),
             "num_tests_fixed": len(self.fixed),
@@ -590,11 +591,3 @@ class PipelineLint(nf_core.utils.Pipeline):
             files = [files]
         bfiles = [f"`{f}`" for f in files]
         return " or ".join(bfiles)
-
-    def _strip_ansi_codes(self, string, replace_with=""):
-        """Strip ANSI colouring codes from a string to return plain text.
-
-        Solution found on Stack Overflow: https://stackoverflow.com/a/14693789/713980
-        """
-        ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
-        return ansi_escape.sub(replace_with, string)

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -973,3 +973,15 @@ def plural_y(list_or_int):
     """Return 'ies' if the input is not one or has not the length of one, else 'y'."""
     length = list_or_int if isinstance(list_or_int, int) else len(list_or_int)
     return "ies" if length != 1 else "y"
+
+
+# From Stack Overflow: https://stackoverflow.com/a/14693789/713980
+ANSI_ESCAPE_RE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+
+def strip_ansi_codes(string, replace_with=""):
+    """Strip ANSI colouring codes from a string to return plain text.
+
+    From Stack Overflow: https://stackoverflow.com/a/14693789/713980
+    """
+    return ANSI_ESCAPE_RE.sub(replace_with, string)

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -976,6 +976,7 @@ def plural_y(list_or_int):
 
 
 # From Stack Overflow: https://stackoverflow.com/a/14693789/713980
+# Placed at top level as to only compile it once
 ANSI_ESCAPE_RE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -153,14 +153,6 @@ class TestLint(unittest.TestCase):
         md = self.lint_obj._wrap_quotes(["one", "two", "three"])
         assert md == "`one` or `two` or `three`"
 
-    def test_strip_ansi_codes(self):
-        """Check that we can make rich text strings plain
-
-        String prints ls examplefile.zip, where examplefile.zip is red bold text
-        """
-        stripped = self.lint_obj._strip_ansi_codes("ls \x1b[00m\x1b[01;31mexamplefile.zip\x1b[00m\x1b[01;31m")
-        assert stripped == "ls examplefile.zip"
-
     def test_sphinx_md_files(self):
         """Check that we have .md files for all lint module code,
         and that there are no unexpected files (eg. deleted lint tests)"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,15 @@ import nf_core.utils
 from .utils import with_temporary_folder
 
 
+def test_strip_ansi_codes():
+    """Check that we can make rich text strings plain
+
+    String prints ls examplefile.zip, where examplefile.zip is red bold text
+    """
+    stripped = nf_core.utils.strip_ansi_codes("ls \x1b[00m\x1b[01;31mexamplefile.zip\x1b[00m\x1b[01;31m")
+    assert stripped == "ls examplefile.zip"
+
+
 class TestUtils(unittest.TestCase):
     """Class for utils tests"""
 


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

This is a utility function not necessarily specific to linting.

A minor issue was also the setup of the re.compile within the function. This would compile the regex every time the function is called, now it is only computed once upon import of utils.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
