### PR TITLE
Add no_git=True when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@
 - Use black also to format python files in workflows ([#1563](https://github.com/nf-core/tools/pull/1563))
 - Add check for mimetype in the `input` parameter. ([#1647](https://github.com/nf-core/tools/issues/1647))
 - Check that the singularity and docker tags are parsable. Add `--fail-warned` flag to `nf-core modules lint` ([#1654](https://github.com/nf-core/tools/issues/1654))
-- Don't initialise git pipeline repository from the temporary pipeline created by `nf-core lint`
 
 ### General
 
@@ -41,7 +40,7 @@
 - Allow customization of the `nf-core` pipeline template when using `nf-core create` ([#1548](https://github.com/nf-core/tools/issues/1548))
 - Add Refgenie integration: updating of nextflow config files with a refgenie database ([#1090](https://github.com/nf-core/tools/pull/1090))
 - Fix `--key` option in `nf-core lint` when supplying a module lint test name ([#1681](https://github.com/nf-core/tools/issues/1681))
-- Add `no_git=True` when creating a new pipeline and initialising a git repository is not needed ([#1709](https://github.com/nf-core/tools/pull/1709))
+- Add `no_git=True` when creating a new pipeline and initialising a git repository is not needed in `nf-core lint` and `nf-core bump-version` ([#1709](https://github.com/nf-core/tools/pull/1709))
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Use black also to format python files in workflows ([#1563](https://github.com/nf-core/tools/pull/1563))
 - Add check for mimetype in the `input` parameter. ([#1647](https://github.com/nf-core/tools/issues/1647))
 - Check that the singularity and docker tags are parsable. Add `--fail-warned` flag to `nf-core modules lint` ([#1654](https://github.com/nf-core/tools/issues/1654))
+- Don't initialise git pipeline repository from the temporary pipeline created by `nf-core lint`
 
 ### General
 
@@ -40,6 +41,7 @@
 - Allow customization of the `nf-core` pipeline template when using `nf-core create` ([#1548](https://github.com/nf-core/tools/issues/1548))
 - Add Refgenie integration: updating of nextflow config files with a refgenie database ([#1090](https://github.com/nf-core/tools/pull/1090))
 - Fix `--key` option in `nf-core lint` when supplying a module lint test name ([#1681](https://github.com/nf-core/tools/issues/1681))
+- Add `no_git=True` when creating a new pipeline and initialising a git repository is not needed ([#1709](https://github.com/nf-core/tools/pull/1709))
 
 ### Modules
 

--- a/nf_core/lint/files_unchanged.py
+++ b/nf_core/lint/files_unchanged.py
@@ -133,7 +133,7 @@ def files_unchanged(self):
 
     test_pipeline_dir = os.path.join(tmp_dir, f"{prefix}-{short_name}")
     create_obj = nf_core.create.PipelineCreate(
-        None, None, None, outdir=test_pipeline_dir, template_yaml_path=template_yaml_path
+        None, None, None, no_git=True, outdir=test_pipeline_dir, template_yaml_path=template_yaml_path
     )
     create_obj.init_pipeline()
 

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -18,7 +18,7 @@ def test_bump_pipeline_version(datafiles, tmp_path):
     # Get a workflow and configs
     test_pipeline_dir = os.path.join(tmp_path, "nf-core-testpipeline")
     create_obj = nf_core.create.PipelineCreate(
-        "testpipeline", "This is a test pipeline", "Test McTestFace", outdir=test_pipeline_dir, plain=True
+        "testpipeline", "This is a test pipeline", "Test McTestFace", no_git=True, outdir=test_pipeline_dir, plain=True
     )
     create_obj.init_pipeline()
     pipeline_obj = nf_core.utils.Pipeline(test_pipeline_dir)
@@ -38,7 +38,7 @@ def test_dev_bump_pipeline_version(datafiles, tmp_path):
     # Get a workflow and configs
     test_pipeline_dir = os.path.join(tmp_path, "nf-core-testpipeline")
     create_obj = nf_core.create.PipelineCreate(
-        "testpipeline", "This is a test pipeline", "Test McTestFace", outdir=test_pipeline_dir, plain=True
+        "testpipeline", "This is a test pipeline", "Test McTestFace", no_git=True, outdir=test_pipeline_dir, plain=True
     )
     create_obj.init_pipeline()
     pipeline_obj = nf_core.utils.Pipeline(test_pipeline_dir)
@@ -57,7 +57,7 @@ def test_bump_nextflow_version(datafiles, tmp_path):
     # Get a workflow and configs
     test_pipeline_dir = os.path.join(tmp_path, "nf-core-testpipeline")
     create_obj = nf_core.create.PipelineCreate(
-        "testpipeline", "This is a test pipeline", "Test McTestFace", outdir=test_pipeline_dir, plain=True
+        "testpipeline", "This is a test pipeline", "Test McTestFace", no_git=True, outdir=test_pipeline_dir, plain=True
     )
     create_obj.init_pipeline()
     pipeline_obj = nf_core.utils.Pipeline(test_pipeline_dir)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -105,7 +105,7 @@ class DownloadTest(unittest.TestCase):
         # Get a workflow and configs
         test_pipeline_dir = os.path.join(tmp_path, "nf-core-testpipeline")
         create_obj = nf_core.create.PipelineCreate(
-            "testpipeline", "This is a test pipeline", "Test McTestFace", outdir=test_pipeline_dir, plain=True
+            "testpipeline", "This is a test pipeline", "Test McTestFace", no_git=True, outdir=test_pipeline_dir, plain=True
         )
         create_obj.init_pipeline()
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -105,7 +105,12 @@ class DownloadTest(unittest.TestCase):
         # Get a workflow and configs
         test_pipeline_dir = os.path.join(tmp_path, "nf-core-testpipeline")
         create_obj = nf_core.create.PipelineCreate(
-            "testpipeline", "This is a test pipeline", "Test McTestFace", no_git=True, outdir=test_pipeline_dir, plain=True
+            "testpipeline",
+            "This is a test pipeline",
+            "Test McTestFace",
+            no_git=True,
+            outdir=test_pipeline_dir,
+            plain=True,
         )
         create_obj.init_pipeline()
 

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -72,7 +72,7 @@ class TestLaunch(unittest.TestCase):
         """Create a workflow, but delete the schema file, then try to load it"""
         test_pipeline_dir = os.path.join(tmp_path, "wf")
         create_obj = nf_core.create.PipelineCreate(
-            "test_pipeline", "", "", no_git=True, outdir=test_pipeline_dir, no_git=True, plain=True
+            "test_pipeline", "", "", outdir=test_pipeline_dir, no_git=True, plain=True
         )
         create_obj.init_pipeline()
         os.remove(os.path.join(test_pipeline_dir, "nextflow_schema.json"))

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -72,7 +72,7 @@ class TestLaunch(unittest.TestCase):
         """Create a workflow, but delete the schema file, then try to load it"""
         test_pipeline_dir = os.path.join(tmp_path, "wf")
         create_obj = nf_core.create.PipelineCreate(
-            "test_pipeline", "", "", outdir=test_pipeline_dir, no_git=True, plain=True
+            "test_pipeline", "", "", no_git=True, outdir=test_pipeline_dir, no_git=True, plain=True
         )
         create_obj.init_pipeline()
         os.remove(os.path.join(test_pipeline_dir, "nextflow_schema.json"))

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -44,7 +44,7 @@ class TestModules(unittest.TestCase):
         self.template_dir = os.path.join(root_repo_dir, "nf_core", "pipeline-template")
         self.pipeline_dir = os.path.join(self.tmp_dir, "mypipeline")
         nf_core.create.PipelineCreate(
-            "mypipeline", "it is mine", "me", outdir=self.pipeline_dir, plain=True
+            "mypipeline", "it is mine", "me", no_git=True, outdir=self.pipeline_dir, plain=True
         ).init_pipeline()
         # Set up install objects
         print("Setting up install objects")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,7 +29,12 @@ class TestUtils(unittest.TestCase):
         self.tmp_dir = tempfile.mkdtemp()
         self.test_pipeline_dir = os.path.join(self.tmp_dir, "nf-core-testpipeline")
         self.create_obj = nf_core.create.PipelineCreate(
-            "testpipeline", "This is a test pipeline", "Test McTestFace", no_git=True, outdir=self.test_pipeline_dir, plain=True
+            "testpipeline",
+            "This is a test pipeline",
+            "Test McTestFace",
+            no_git=True,
+            outdir=self.test_pipeline_dir,
+            plain=True,
         )
         self.create_obj.init_pipeline()
         # Base Pipeline object on this directory

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,7 +29,7 @@ class TestUtils(unittest.TestCase):
         self.tmp_dir = tempfile.mkdtemp()
         self.test_pipeline_dir = os.path.join(self.tmp_dir, "nf-core-testpipeline")
         self.create_obj = nf_core.create.PipelineCreate(
-            "testpipeline", "This is a test pipeline", "Test McTestFace", outdir=self.test_pipeline_dir, plain=True
+            "testpipeline", "This is a test pipeline", "Test McTestFace", no_git=True, outdir=self.test_pipeline_dir, plain=True
         )
         self.create_obj.init_pipeline()
         # Base Pipeline object on this directory


### PR DESCRIPTION
As mentioned in [#1688 comment](https://github.com/nf-core/tools/issues/1688#issuecomment-1197912918)

> I think in the case of nf-core lint you could actually pass no_git=True to PipelineCreate here, and skip making a git repository entirely, as the linter does not seem to require a git repository to compare the template files 

The argument no_git=True can be added when a pipeline is created but there's no need to initialise a git repository.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
