### PR TITLE
add base_path to ModuleInfo init method

### DIFF
--- a/nf_core/modules/info.py
+++ b/nf_core/modules/info.py
@@ -21,8 +21,8 @@ log = logging.getLogger(__name__)
 
 
 class ModuleInfo(ModuleCommand):
-    def __init__(self, pipeline_dir, tool, remote_url, branch, no_pull):
-        super().__init__(pipeline_dir, remote_url, branch, no_pull)
+    def __init__(self, pipeline_dir, tool, remote_url, branch, no_pull, base_path):
+        super().__init__(pipeline_dir, remote_url, branch, no_pull, base_path)
         self.meta = None
         self.local_path = None
         self.remote_location = None


### PR DESCRIPTION
Closes #1719 

Adding missing argument `base_path` to ModuleInfo init method.
Part of implementation of git remotes in #1641 (Issue #1626 )

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
