### PR TITLE
Make `nf-core modules` commands work with arbitrary git remotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - Add `nf-core modules patch` command ([#1312](https://github.com/nf-core/tools/issues/1312))
 - Add support for patch in `nf-core modules update` command ([#1312](https://github.com/nf-core/tools/issues/1312))
 - Add support for patch in `nf-core modules lint` command ([#1312](https://github.com/nf-core/tools/issues/1312))
+- Make `nf-core modules` commands work with arbitrary git remotes ([#1721](https://github.com/nf-core/tools/issues/1721))
 
 ## [v2.4.1 - Cobolt Koala Patch](https://github.com/nf-core/tools/releases/tag/2.4) - [2022-05-16]
 

--- a/nf_core/lint/modules_json.py
+++ b/nf_core/lint/modules_json.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from pathlib import Path
+
 from nf_core.modules.modules_command import ModuleCommand
 from nf_core.modules.modules_json import ModulesJson
 
@@ -21,10 +23,9 @@ def modules_json(self):
     modules_json = ModulesJson(self.wf_path)
     modules_json.load()
     modules_json_dict = modules_json.modules_json
+    modules_dir = Path(self.wf_path, "modules")
 
     if modules_json:
-        modules_command.get_pipeline_modules()
-
         all_modules_passed = True
 
         for repo in modules_json_dict["repos"].keys():
@@ -35,9 +36,11 @@ def modules_json(self):
                 )
                 continue
 
-            for key in modules_json_dict["repos"][repo]["modules"]:
-                if not key in modules_command.module_names[repo]:
-                    failed.append(f"Entry for `{key}` found in `modules.json` but module is not installed in pipeline.")
+            for module in modules_json_dict["repos"][repo]["modules"]:
+                if not Path(modules_dir, repo, module).exists():
+                    failed.append(
+                        f"Entry for `{Path(repo, module)}` found in `modules.json` but module is not installed in pipeline."
+                    )
                     all_modules_passed = False
 
         if all_modules_passed:

--- a/nf_core/modules/info.py
+++ b/nf_core/modules/info.py
@@ -36,12 +36,12 @@ class ModuleInfo(ModuleCommand):
                 log.debug(f"Only showing remote info: {e}")
                 pipeline_dir = None
 
-        self.module = self.init_mod_name(tool)
         if self.repo_type == "pipeline":
             self.modules_json = ModulesJson(self.dir)
             self.modules_json.check_up_to_date()
         else:
             self.modules_json = None
+        self.module = self.init_mod_name(tool)
 
     def init_mod_name(self, module):
         """

--- a/nf_core/modules/info.py
+++ b/nf_core/modules/info.py
@@ -11,6 +11,7 @@ from rich.table import Table
 from rich.text import Text
 
 import nf_core.utils
+from nf_core.modules.modules_json import ModulesJson
 
 from .module_utils import get_repo_type
 from .modules_command import ModuleCommand
@@ -35,8 +36,11 @@ class ModuleInfo(ModuleCommand):
                 log.debug(f"Only showing remote info: {e}")
                 pipeline_dir = None
 
-        self.get_pipeline_modules()
         self.module = self.init_mod_name(tool)
+        if self.repo_type == "pipeline":
+            self.modules_json = ModulesJson(self.dir)
+        else:
+            self.modules_json = None
 
     def init_mod_name(self, module):
         """
@@ -51,9 +55,9 @@ class ModuleInfo(ModuleCommand):
             ).unsafe_ask()
             if local:
                 if self.repo_type == "modules":
-                    modules = self.module_names["modules"]
+                    modules = self.get_modules_clone_modules()
                 else:
-                    modules = self.module_names.get(self.modules_repo.fullname)
+                    modules = self.modules_json.get_all_modules().get(self.modules_repo.fullname)
                     if modules is None:
                         raise UserWarning(f"No modules installed from '{self.modules_repo.remote_url}'")
             else:
@@ -98,7 +102,7 @@ class ModuleInfo(ModuleCommand):
             repo_name = self.modules_repo.fullname
             module_base_path = os.path.join(self.dir, "modules", repo_name)
             # Check that we have any modules installed from this repo
-            modules = self.module_names.get(repo_name)
+            modules = self.modules_json.get_all_modules().get(repo_name)
             if modules is None:
                 raise LookupError(f"No modules installed from {self.modules_repo.remote_url}")
 

--- a/nf_core/modules/info.py
+++ b/nf_core/modules/info.py
@@ -39,6 +39,7 @@ class ModuleInfo(ModuleCommand):
         self.module = self.init_mod_name(tool)
         if self.repo_type == "pipeline":
             self.modules_json = ModulesJson(self.dir)
+            self.modules_json.check_up_to_date()
         else:
             self.modules_json = None
 

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -118,8 +118,7 @@ class ModuleInstall(ModuleCommand):
                 return False
         else:
             # Fetch the latest commit for the module
-            git_log = list(self.modules_repo.get_module_git_log(module, depth=1))
-            version = git_log[0]["git_sha"]
+            version = self.modules_repo.get_latest_module_version(module)
 
         if self.force:
             log.info(f"Removing installed version of '{self.modules_repo.fullname}/{module}'")

--- a/nf_core/modules/lint/__init__.py
+++ b/nf_core/modules/lint/__init__.py
@@ -88,6 +88,8 @@ class ModuleLint(ModuleCommand):
                     NFCoreModule(m, self.modules_repo.fullname, module_dir / m, self.repo_type, Path(self.dir))
                     for m in all_pipeline_modules[self.modules_repo.fullname]
                 ]
+                if not self.all_remote_modules:
+                    raise LookupError(f"No modules from {self.modules_repo.remote_url} installed in pipeline.")
                 local_module_dir = Path(self.dir, "modules", "local")
                 self.all_local_modules = [
                     NFCoreModule(m, None, local_module_dir / m, self.repo_type, Path(self.dir), nf_core_module=False)
@@ -100,9 +102,11 @@ class ModuleLint(ModuleCommand):
             module_dir = Path(self.dir, "modules")
             self.all_remote_modules = [
                 NFCoreModule(m, None, module_dir / m, self.repo_type, Path(self.dir))
-                for m in self.module_names["modules"]
+                for m in self.get_modules_clone_modules()
             ]
             self.all_local_modules = []
+            if not self.all_remote_modules:
+                raise LookupError("No modules in 'modules' directory")
 
         self.lint_config = None
         self.modules_json = None

--- a/nf_core/modules/list.py
+++ b/nf_core/modules/list.py
@@ -68,13 +68,10 @@ class ModuleList(ModuleCommand):
             modules_json = ModulesJson(self.dir)
             modules_json.check_up_to_date()
 
-            # Get installed modules
-            self.get_pipeline_modules()
-
             # Filter by keywords
             repos_with_mods = {
-                repo_name: [mod for mod in self.module_names[repo_name] if all(k in mod for k in keywords)]
-                for repo_name in self.module_names
+                repo_name: [mod for mod in modules if all(k in mod for k in keywords)]
+                for repo_name, modules in modules_json.get_all_modules().items()
             }
 
             # Nothing found

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -91,7 +91,7 @@ class ModulesTest(ModuleCommand):
                 raise UserWarning(
                     "Tool name not provided and prompts deactivated. Please provide the tool name as TOOL/SUBTOOL or TOOL."
                 )
-            if installed_modules is None:
+            if not installed_modules:
                 raise UserWarning(
                     f"No installed modules were found from '{self.modules_repo.remote_url}'.\n"
                     f"Are you running the tests inside the nf-core/modules main directory?\n"

--- a/nf_core/modules/module_test.py
+++ b/nf_core/modules/module_test.py
@@ -16,6 +16,7 @@ import rich
 import nf_core.modules.module_utils
 import nf_core.utils
 from nf_core.modules.modules_command import ModuleCommand
+from nf_core.modules.modules_json import ModulesJson
 
 log = logging.getLogger(__name__)
 
@@ -61,7 +62,6 @@ class ModulesTest(ModuleCommand):
         self.pytest_args = pytest_args
 
         super().__init__(".", remote_url, branch, no_pull)
-        self.get_pipeline_modules()
 
     def run(self):
         """Run test steps"""
@@ -79,9 +79,11 @@ class ModulesTest(ModuleCommand):
 
         # Retrieving installed modules
         if self.repo_type == "modules":
-            installed_modules = self.module_names["modules"]
+            installed_modules = self.get_modules_clone_modules()
         else:
-            installed_modules = self.module_names.get(self.modules_repo.fullname)
+            modules_json = ModulesJson(self.dir)
+            modules_json.check_up_to_date()
+            installed_modules = modules_json.get_all_modules().get(self.modules_repo.fullname)
 
         # Get the tool name if not specified
         if self.module_name is None:

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -46,48 +46,6 @@ class ModuleCommand:
             if "main.nf" in files
         ]
 
-    def get_pipeline_modules(self):
-        """
-        Get the modules installed in the current directory.
-
-        If the current directory is a pipeline, the `module_names`
-        field is set to a dictionary indexed by the different
-        installation repositories in the directory. If the directory
-        is a clone of nf-core/modules the filed is set to
-        `{"modules": modules_in_dir}`
-
-        """
-
-        self.module_names = {}
-
-        module_base_path = f"{self.dir}/modules/"
-
-        if self.repo_type == "pipeline":
-            repo_owners = (owner for owner in os.listdir(module_base_path) if owner != "local")
-            repo_names = (
-                f"{repo_owner}/{name}"
-                for repo_owner in repo_owners
-                for name in os.listdir(f"{module_base_path}/{repo_owner}")
-            )
-            for repo_name in repo_names:
-                repo_path = os.path.join(module_base_path, repo_name)
-                module_mains_path = f"{repo_path}/**/main.nf"
-                module_mains = glob.glob(module_mains_path, recursive=True)
-                if len(module_mains) > 0:
-                    self.module_names[repo_name] = [
-                        os.path.dirname(os.path.relpath(mod, repo_path)) for mod in module_mains
-                    ]
-
-        elif self.repo_type == "modules":
-            module_mains_path = f"{module_base_path}/**/main.nf"
-            module_mains = glob.glob(module_mains_path, recursive=True)
-            self.module_names["modules"] = [
-                os.path.dirname(os.path.relpath(mod, module_base_path)) for mod in module_mains
-            ]
-        else:
-            log.error("Directory is neither a clone of nf-core/modules nor a pipeline")
-            raise SystemError
-
     def has_valid_directory(self):
         """Check that we were given a pipeline or clone of nf-core/modules"""
         if self.repo_type == "modules":

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -35,6 +35,17 @@ class ModuleCommand:
         except LookupError as e:
             raise UserWarning(e)
 
+    def get_modules_clone_modules(self):
+        """
+        Get the modules available in a clone of nf-core/modules
+        """
+        module_base_path = Path(self.dir, "modules")
+        return [
+            str(Path(dir).relative_to(module_base_path))
+            for dir, _, files in os.walk(module_base_path)
+            if "main.nf" in files
+        ]
+
     def get_pipeline_modules(self):
         """
         Get the modules installed in the current directory.

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -108,7 +108,7 @@ class ModuleCommand:
             raise LookupError(f"Nothing installed from {repo_name} in pipeline")
 
         return [
-            str(Path(dir_path).relative_to(repo_dir) for dir_path, _, files in os.walk(repo_dir) if "main.nf" in files)
+            str(Path(dir_path).relative_to(repo_dir)) for dir_path, _, files in os.walk(repo_dir) if "main.nf" in files
         ]
 
     def install_module_files(self, module_name, module_version, modules_repo, install_dir):

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -2,6 +2,7 @@ import glob
 import logging
 import os
 import shutil
+from pathlib import Path
 
 import yaml
 
@@ -115,6 +116,24 @@ class ModuleCommand:
         except OSError as e:
             log.error(f"Could not remove module: {e}")
             return False
+
+    def modules_from_repo(self, repo_name):
+        """
+        Gets the modules installed from a certain repository
+
+        Args:
+            repo_name (str): The name of the repository
+
+        Returns:
+            [str]: The names of the modules
+        """
+        repo_dir = Path(self.dir, "modules", repo_name)
+        if not repo_dir.exists():
+            raise LookupError(f"Nothing installed from {repo_name} in pipeline")
+
+        return [
+            str(Path(dir_path).relative_to(repo_dir) for dir_path, _, files in os.walk(repo_dir) if "main.nf" in files)
+        ]
 
     def install_module_files(self, module_name, module_version, modules_repo, install_dir):
         """

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -26,7 +26,6 @@ class ModuleCommand:
         """
         self.modules_repo = ModulesRepo(remote_url, branch, no_pull, base_path)
         self.dir = dir
-        self.module_names = None
         try:
             if self.dir:
                 self.dir, self.repo_type = nf_core.modules.module_utils.get_repo_type(self.dir)

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -130,7 +130,7 @@ class ModulesJson:
                 log.info(
                     "The following director{s} in the modules directory are untracked: '{l}'".format(
                         s="ies" if len(dirs_not_covered) > 0 else "y",
-                        l="', '".join(str(dir) for dir in dirs_not_covered),
+                        l="', '".join(str(dir.relative_to(modules_dir)) for dir in dirs_not_covered),
                     )
                 )
                 nrepo_remote = questionary.text(

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -32,6 +32,7 @@ class ModulesJson:
         self.dir = pipeline_dir
         self.modules_dir = os.path.join(self.dir, "modules")
         self.modules_json = None
+        self.pipeline_modules = None
 
     def create(self):
         """
@@ -661,11 +662,13 @@ class ModulesJson:
         """
         if self.modules_json is None:
             self.load()
-        pipeline_modules = {}
-        for repo, repo_entry in self.modules_json.get("repos", {}).items():
-            if "modules" in repo_entry:
-                pipeline_modules[repo] = list(repo_entry["modules"])
-        return pipeline_modules
+        if self.pipeline_modules is None:
+            self.pipeline_modules = {}
+            for repo, repo_entry in self.modules_json.get("repos", {}).items():
+                if "modules" in repo_entry:
+                    self.pipeline_modules[repo] = list(repo_entry["modules"])
+
+        return self.pipeline_modules
 
     def dump(self):
         """

--- a/nf_core/modules/patch.py
+++ b/nf_core/modules/patch.py
@@ -34,7 +34,9 @@ class ModulePatch(ModuleCommand):
 
         if module is None:
             module = questionary.autocomplete(
-                "Tool:", self.module_names[self.modules_repo.fullname], style=nf_core.utils.nfcore_question_style
+                "Tool:",
+                self.modules_json.get_all_modules()[self.modules_repo.fullname],
+                style=nf_core.utils.nfcore_question_style,
             ).unsafe_ask()
         module_fullname = str(Path(self.modules_repo.fullname, module))
 

--- a/nf_core/modules/patch.py
+++ b/nf_core/modules/patch.py
@@ -20,16 +20,16 @@ class ModulePatch(ModuleCommand):
         super().__init__(dir, remote_url, branch, no_pull, base_path)
 
         self.modules_json = ModulesJson(dir)
-        self.get_pipeline_modules()
 
     def param_check(self, module):
         if not self.has_valid_directory():
             raise UserWarning()
 
-        if module is not None and module not in self.module_names[self.modules_repo.fullname]:
+        if module is not None and module not in self.modules_json.get_all_modules().get(self.modules_repo.fullname, {}):
             raise UserWarning(f"Module '{Path(self.modules_repo.fullname, module)}' does not exist in the pipeline")
 
     def patch(self, module=None):
+        self.modules_json.check_up_to_date()
         self.param_check(module)
 
         if module is None:

--- a/nf_core/modules/remove.py
+++ b/nf_core/modules/remove.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pathlib import Path
 
 import questionary
 
@@ -30,40 +31,23 @@ class ModuleRemove(ModuleCommand):
         # Check whether pipelines is valid
         self.has_valid_directory()
 
-        # Get the installed modules
-        self.get_pipeline_modules()
-        if sum(map(len, self.module_names)) == 0:
-            log.error("No installed modules found in pipeline")
-            return False
-
-        # Decide from which repo the module was installed
-        # TODO Configure the prompt for repository name in a nice way
-        if True:
-            repo_name = self.modules_repo.fullname
-        elif len(self.module_names) == 1:
-            repo_name = list(self.module_names.keys())[0]
-        else:
-            repo_name = questionary.autocomplete(
-                "Repo name:", choices=self.module_names.keys(), style=nf_core.utils.nfcore_question_style
-            ).unsafe_ask()
-
+        repo_name = self.modules_repo.fullname
         if module is None:
             module = questionary.autocomplete(
-                "Tool name:", choices=self.module_names[repo_name], style=nf_core.utils.nfcore_question_style
+                "Tool name:",
+                choices=self.modules_from_repo(repo_name),
+                style=nf_core.utils.nfcore_question_style,
             ).unsafe_ask()
 
-        # Set the remove folder based on the repository name
-        remove_folder = os.path.split(repo_name)
-
         # Get the module directory
-        module_dir = os.path.join(self.dir, "modules", *remove_folder, module)
+        module_dir = Path(self.dir, "modules", repo_name, module)
 
         # Load the modules.json file
         modules_json = ModulesJson(self.dir)
         modules_json.load()
 
         # Verify that the module is actually installed
-        if not os.path.exists(module_dir):
+        if not module_dir.exists():
             log.error(f"Module directory does not exist: '{module_dir}'")
 
             if modules_json.module_present(module, repo_name):

--- a/nf_core/modules/update.py
+++ b/nf_core/modules/update.py
@@ -46,9 +46,6 @@ class ModuleUpdate(ModuleCommand):
         self.update_config = None
         self.modules_json = ModulesJson(self.dir)
 
-        # Fetch the list of pipeline modules
-        self.get_pipeline_modules()
-
     class DiffEnum(enum.Enum):
         """Enumeration to keeping track of file diffs.
 
@@ -279,18 +276,18 @@ class ModuleUpdate(ModuleCommand):
         """
         # Check if there are any modules installed from the repo
         repo_name = self.modules_repo.fullname
-        if repo_name not in self.module_names:
+        if repo_name not in self.modules_json.get_all_modules():
             raise LookupError(f"No modules installed from '{repo_name}'")
 
         if module is None:
             module = questionary.autocomplete(
                 "Tool name:",
-                choices=self.module_names[repo_name],
+                choices=self.modules_json.get_all_modules()[repo_name],
                 style=nf_core.utils.nfcore_question_style,
             ).unsafe_ask()
 
         # Check if module is installed before trying to update
-        if module not in self.module_names[repo_name]:
+        if module not in self.modules_json.get_all_modules()[repo_name]:
             raise LookupError(f"Module '{module}' is not installed in pipeline and could therefore not be updated")
 
         # Check that the supplied name is an available module
@@ -340,7 +337,7 @@ class ModuleUpdate(ModuleCommand):
         modules_info = {}
         # Loop through all the modules in the pipeline
         # and check if they have an entry in the '.nf-core.yml' file
-        for repo_name, modules in self.module_names.items():
+        for repo_name, modules in self.modules_json.get_all_modules().items():
             if repo_name not in self.update_config or self.update_config[repo_name] is True:
                 modules_info[repo_name] = [(module, self.sha) for module in modules]
             elif isinstance(self.update_config[repo_name], dict):

--- a/tests/modules/module_test.py
+++ b/tests/modules/module_test.py
@@ -1,5 +1,7 @@
 """Test the 'modules test' command which runs module pytests."""
 import os
+import shutil
+from pathlib import Path
 
 import pytest
 
@@ -32,8 +34,10 @@ def test_modules_test_no_installed_modules(self):
     """Test the check_inputs() function - raise UserWarning because installed modules were not found"""
     cwd = os.getcwd()
     os.chdir(self.nfcore_modules)
+    module_dir = Path(self.nfcore_modules, "modules")
+    shutil.rmtree(module_dir)
+    module_dir.mkdir()
     meta_builder = nf_core.modules.ModulesTest(None, False, "")
-    meta_builder.module_names["modules"] = None
     meta_builder.repo_type = "modules"
     with pytest.raises(UserWarning) as excinfo:
         meta_builder._check_inputs()


### PR DESCRIPTION
As @awgymer reported in #1721, several of the `nf-core modules` commands depended on that git remotes had the same format as in GitHub, i.e. `owner/repo`. This meant that the commands failed when repo names of greater nesting were used, for example `group/subgroup/repo`.  

I've fixed this by letting the `modules.json` file be the only source of information for what modules are installed in a pipeline -- the commands should not need to interact with the directory structure directly. 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
