### PR TITLE
Fix issues related to `--branch` and `--base-path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - Add support for patch in `nf-core modules lint` command ([#1312](https://github.com/nf-core/tools/issues/1312))
 - Add support for custom remotes in `nf-core modules lint` ([#1715](https://github.com/nf-core/tools/issues/1715))
 - Make `nf-core modules` commands work with arbitrary git remotes ([#1721](https://github.com/nf-core/tools/issues/1721))
+- Fix misc. issues with `--branch` and `--base-path` ([#1726](https://github.com/nf-core/tools/issues/1726))
 
 ## [v2.4.1 - Cobolt Koala Patch](https://github.com/nf-core/tools/releases/tag/2.4) - [2022-05-16]
 

--- a/README.md
+++ b/README.md
@@ -943,7 +943,7 @@ For example, if you want to install the `fastqc` module from the repository `nf-
 nf-core modules --git-remote git@gitlab.com:nf-core/modules-test.git install fastqc
 ```
 
-If the modules in your custom remote are stored in another directory than `modules`, you can specify the path by using the `--base-path <path>` flag. This will default to `modules`.
+If the modules in your custom remote are stored in another directory than `modules`, you can specify the path by using the `--base-path <path>` flag. This will default to `modules`. Note that all branches in a remote must use the same base path, otherwise the commands will fail.
 
 Note that a custom remote must follow a similar directory structure to that of `nf-core/moduleś` for the `nf-core modules` commands to work properly.
 

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -529,7 +529,7 @@ class ModulesJson:
             else:
                 log.warning(f"Module '{repo_name}/{module_name}' is missing from 'modules.json' file.")
                 return False
-            if len(repo_entry) == 0:
+            if len(repo_entry["modules"]) == 0:
                 self.modules_json["repos"].pop(repo_name)
         else:
             log.warning(f"Module '{repo_name}/{module_name}' is missing from 'modules.json' file.")


### PR DESCRIPTION
As reported in #1726, `--branch` and `--base-path` are a bit buggy. In this issue I've corrected the following behaviour:
- If new branches were created in an already cloned remote repo, `setup_branch` is unable to find the new branch. Therefore run git fetch in before trying to check out a branch. 
- Fix bug in `ModulesJson.remove_entry` causing empty repo entries to not be removed.
- Updated the `README.md` to better explain what `--base-path` can and can't do.

This is a continuation from #1724, so merge that one first.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
