### PR TITLE
use packaging instead of deprecated distutils Version classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 - Add `no_git=True` when creating a new pipeline and initialising a git repository is not needed in `nf-core lint` and `nf-core bump-version` ([#1709](https://github.com/nf-core/tools/pull/1709))
 - Move `strip_ansi_code` function in lint to `utils.py`
 - Simplify control flow and don't use equality comparison for `None` and booleans
-- Replace use of the deprecated `distutils` Version object with that from `packaging` [#1735](https://github.com/nf-core/tools/pull/1735)
+- Replace use of the deprecated `distutils` Version object with that from `packaging` ([#1735](https://github.com/nf-core/tools/pull/1735))
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Add `no_git=True` when creating a new pipeline and initialising a git repository is not needed in `nf-core lint` and `nf-core bump-version` ([#1709](https://github.com/nf-core/tools/pull/1709))
 - Move `strip_ansi_code` function in lint to `utils.py`
 - Simplify control flow and don't use equality comparison for `None` and booleans
+- Replace use of the deprecated `distutils` Version object with that from `packaging` [#1735](https://github.com/nf-core/tools/pull/1735)
 
 ### Modules
 

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -15,7 +15,6 @@ import shlex
 import subprocess
 import sys
 import time
-from distutils.version import StrictVersion
 
 import git
 import prompt_toolkit
@@ -24,6 +23,7 @@ import requests
 import requests_cache
 import rich
 import yaml
+from packaging.version import Version
 from rich.live import Live
 from rich.spinner import Spinner
 
@@ -76,7 +76,7 @@ def check_if_outdated(current_version=None, remote_version=None, source_url="htt
         response = requests.get(source_url, timeout=3)
         remote_version = re.sub(r"[^0-9\.]", "", response.text)
     # Check if we have an available update
-    is_outdated = StrictVersion(remote_version) > StrictVersion(current_version)
+    is_outdated = Version(remote_version) > Version(current_version)
     return (is_outdated, current_version, remote_version)
 
 


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

`distutils` Version classes are deprecated in favor of the ones in `packaging`.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
