### PR TITLE
Add `branch` field to module entries in `modules.json` to record what branch a module comes from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - Add support for patch in `nf-core modules lint` command ([#1312](https://github.com/nf-core/tools/issues/1312))
 - Add support for custom remotes in `nf-core modules lint` ([#1715](https://github.com/nf-core/tools/issues/1715))
 - Make `nf-core modules` commands work with arbitrary git remotes ([#1721](https://github.com/nf-core/tools/issues/1721))
+- Fix misc. issues with `--branch` and `--base-path` ([#1726](https://github.com/nf-core/tools/issues/1726))
 
 ## [v2.4.1 - Cobolt Koala Patch](https://github.com/nf-core/tools/releases/tag/2.4) - [2022-05-16]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Make `nf-core modules` commands work with arbitrary git remotes ([#1721](https://github.com/nf-core/tools/issues/1721))
 - Add links in `README.md` for `info` and `patch` commands ([#1722](https://github.com/nf-core/tools/issues/1722)])
 - Fix misc. issues with `--branch` and `--base-path` ([#1726](https://github.com/nf-core/tools/issues/1726))
+- Add `branch` field to module entries in `modules.json` to record what branch a module was installed from ([#1728](https://github.com/nf-core/tools/issues/1728))
 
 ## [v2.4.1 - Cobolt Koala Patch](https://github.com/nf-core/tools/releases/tag/2.4) - [2022-05-16]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Remove call to `getGenomeAttribute` in `main.nf` when running `nf-core create` without iGenomes ([#1670](https://github.com/nf-core/tools/issues/1670))
 - Make `nf-core create` fail if Git default branch name is dev or TEMPLATE ([#1705](https://github.com/nf-core/tools/pull/1705))
 - Convert `console` snippets to `bash` snippets in the template where applicable ([#1729](https://github.com/nf-core/tools/pull/1729))
+- Add `branch` field to module entries in `modules.json` to record what branch a module was installed from ([#1728](https://github.com/nf-core/tools/issues/1728))
 
 ### Linting
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -426,19 +426,15 @@ def local(ctx, keywords, json, dir):
     """
     List modules installed locally in a pipeline
     """
-    try:
-        module_list = nf_core.modules.ModuleList(
-            dir,
-            False,
-            ctx.obj["modules_repo_url"],
-            ctx.obj["modules_repo_branch"],
-            ctx.obj["modules_repo_no_pull"],
-            ctx.obj["modules_repo_base_path"],
-        )
-        print(module_list.list_modules(keywords, json))
-    except (UserWarning, LookupError) as e:
-        log.critical(e)
-        sys.exit(1)
+    module_list = nf_core.modules.ModuleList(
+        dir,
+        False,
+        ctx.obj["modules_repo_url"],
+        ctx.obj["modules_repo_branch"],
+        ctx.obj["modules_repo_no_pull"],
+        ctx.obj["modules_repo_base_path"],
+    )
+    print(module_list.list_modules(keywords, json))
 
 
 # nf-core modules install

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -426,15 +426,19 @@ def local(ctx, keywords, json, dir):
     """
     List modules installed locally in a pipeline
     """
-    module_list = nf_core.modules.ModuleList(
-        dir,
-        False,
-        ctx.obj["modules_repo_url"],
-        ctx.obj["modules_repo_branch"],
-        ctx.obj["modules_repo_no_pull"],
-        ctx.obj["modules_repo_base_path"],
-    )
-    print(module_list.list_modules(keywords, json))
+    try:
+        module_list = nf_core.modules.ModuleList(
+            dir,
+            False,
+            ctx.obj["modules_repo_url"],
+            ctx.obj["modules_repo_branch"],
+            ctx.obj["modules_repo_no_pull"],
+            ctx.obj["modules_repo_base_path"],
+        )
+        print(module_list.list_modules(keywords, json))
+    except (UserWarning, LookupError) as e:
+        log.error(e)
+        sys.exit(1)
 
 
 # nf-core modules install

--- a/nf_core/lint/modules_json.py
+++ b/nf_core/lint/modules_json.py
@@ -36,13 +36,16 @@ def modules_json(self):
                 )
                 continue
 
-            for module in modules_json_dict["repos"][repo]["modules"]:
+            for module, module_entry in modules_json_dict["repos"][repo]["modules"].items():
                 if not Path(modules_dir, repo, module).exists():
                     failed.append(
                         f"Entry for `{Path(repo, module)}` found in `modules.json` but module is not installed in pipeline."
                     )
                     all_modules_passed = False
-
+                if module_entry.get("branch") is None:
+                    failed.append(f"Entry for `{Path(repo, module)}` is missing branch information.")
+                if module_entry.get("git_sha") is None:
+                    failed.append(f"Entry for `{Path(repo, module)}` is missing version information.")
         if all_modules_passed:
             passed.append("Only installed modules found in `modules.json`")
     else:

--- a/nf_core/modules/list.py
+++ b/nf_core/modules/list.py
@@ -102,7 +102,9 @@ class ModuleList(ModuleCommand):
                         try:
                             # pass repo_name to get info on modules even outside nf-core/modules
                             message, date = ModulesRepo(
-                                remote_url=repo_entry["git_url"], base_path=repo_entry["base_path"]
+                                remote_url=repo_entry["git_url"],
+                                base_path=repo_entry["base_path"],
+                                branch=module_entry["branch"],
                             ).get_commit_info(version_sha)
                         except LookupError as e:
                             log.warning(e)

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -402,7 +402,7 @@ class ModulesJson:
                 sha = module_entry["git_sha"]
                 if branch not in branches_and_mods:
                     branches_and_mods[branch] = []
-                branches_and_mods.append((module, sha))
+                branches_and_mods[branch].append((module, sha))
 
         for branch, modules in branches_and_mods.items():
             try:
@@ -413,7 +413,7 @@ class ModulesJson:
                 log.error(e)
                 failed_to_install.extend(modules)
             for module, sha in modules:
-                if not modules_repo.install_module(module, (self.modules_dir / repo_name) / module, sha):
+                if not modules_repo.install_module(module, (self.modules_dir / repo_name), sha):
                     log.warning(f"Could not install module '{Path(repo_name, module)}' - removing from modules.json")
                     failed_to_install.append(module)
         return failed_to_install

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -498,12 +498,14 @@ class ModulesJson:
         repo_name = modules_repo.fullname
         remote_url = modules_repo.remote_url
         base_path = modules_repo.base_path
+        branch = modules_repo.branch
         if repo_name not in self.modules_json["repos"]:
             self.modules_json["repos"][repo_name] = {"modules": {}, "git_url": remote_url, "base_path": base_path}
         repo_modules_entry = self.modules_json["repos"][repo_name]["modules"]
         if module_name not in repo_modules_entry:
             repo_modules_entry[module_name] = {}
         repo_modules_entry[module_name]["git_sha"] = module_version
+        repo_modules_entry[module_name]["branch"] = branch
 
         # Sort the 'modules.json' repo entries
         self.modules_json["repos"] = nf_core.utils.sort_dictionary(self.modules_json["repos"])
@@ -669,6 +671,25 @@ class ModulesJson:
                     self.pipeline_modules[repo] = list(repo_entry["modules"])
 
         return self.pipeline_modules
+
+    def get_module_branch(self, module, repo_name):
+        """
+        Gets the branch from which the module was installed
+
+        Returns:
+            (str): The branch name
+        Raises:
+            LookupError: If their is no branch entry in the `modules.json`
+        """
+        if self.modules_json is None:
+            self.load()
+        branch = self.modules_json["repos"].get(repo_name, {}).get("modules", {}).get(module, {}).get("branch")
+        if branch is None:
+            raise LookupError(
+                f"Could not find branch information for module '{Path(repo_name, module)}'."
+                f"Please remove the 'modules.json' and rerun the command to recreate it"
+            )
+        return branch
 
     def dump(self):
         """

--- a/nf_core/modules/modules_repo.py
+++ b/nf_core/modules/modules_repo.py
@@ -2,6 +2,7 @@ import filecmp
 import logging
 import os
 import shutil
+from pathlib import Path
 
 import git
 import rich.progress
@@ -84,6 +85,31 @@ class ModulesRepo(object):
         Updates the clone/pull status of a local repo
         """
         ModulesRepo.local_repo_statuses[repo_name] = up_to_date
+
+    @staticmethod
+    def get_remote_branches(remote_url):
+        """
+        Get all branches from a remote repository
+
+        Args:
+            remote_url (str): The git url to the remote repository
+
+        Returns:
+            (set[str]): All branches found in the remote
+        """
+        try:
+            unparsed_branches = git.Git().ls_remote(remote_url)
+        except git.GitCommandError:
+            raise LookupError(f"Was unable to fetch branches from '{remote_url}'")
+        else:
+            branches = {}
+            for branch_info in unparsed_branches.split("\n"):
+                sha, name = branch_info.split("\t")
+                if name != "HEAD":
+                    # The remote branches are shown as 'ref/head/branch'
+                    branch_name = Path(name).stem
+                    branches[sha] = branch_name
+            return set(branches.values())
 
     def __init__(self, remote_url=None, branch=None, no_pull=False, base_path=None, no_progress=False):
         """

--- a/nf_core/modules/modules_repo.py
+++ b/nf_core/modules/modules_repo.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 NF_CORE_MODULES_NAME = "nf-core/modules"
 NF_CORE_MODULES_REMOTE = "https://github.com/nf-core/modules.git"
 NF_CORE_MODULES_BASE_PATH = "modules"
+NF_CORE_MODULES_DEFAULT_BRANCH = "master"
 
 
 class RemoteProgressbar(git.RemoteProgress):

--- a/nf_core/modules/patch.py
+++ b/nf_core/modules/patch.py
@@ -51,6 +51,12 @@ class ModulePatch(ModuleCommand):
             raise UserWarning(
                 f"The '{module_fullname}' module does not have a valid version in the 'modules.json' file. Cannot compute patch"
             )
+        # Get the module branch and reset it in the ModulesRepo object
+        module_branch = self.modules_json.get_module_branch(module, self.modules_repo.fullname)
+        if module_branch != self.modules_repo.branch:
+            self.modules_repo.branch = module_branch
+            self.modules_repo.setup_branch()
+
         # Set the diff filename based on the module name
         patch_filename = f"{module.replace('/', '-')}.diff"
         module_relpath = Path("modules", self.modules_repo.fullname, module)

--- a/nf_core/modules/patch.py
+++ b/nf_core/modules/patch.py
@@ -54,8 +54,7 @@ class ModulePatch(ModuleCommand):
         # Get the module branch and reset it in the ModulesRepo object
         module_branch = self.modules_json.get_module_branch(module, self.modules_repo.fullname)
         if module_branch != self.modules_repo.branch:
-            self.modules_repo.branch = module_branch
-            self.modules_repo.setup_branch()
+            self.modules_repo.setup_branch(module_branch)
 
         # Set the diff filename based on the module name
         patch_filename = f"{module.replace('/', '-')}.diff"

--- a/nf_core/modules/update.py
+++ b/nf_core/modules/update.py
@@ -328,8 +328,7 @@ class ModuleUpdate(ModuleCommand):
             switch = questionary.confirm(f"Do you want to update using the '{current_branch}' instead?").unsafe_ask()
             if switch:
                 # Change the branch
-                self.modules_repo.branch = current_branch
-                self.modules_repo.setup_branch()
+                self.modules_repo.setup_branch(current_branch)
 
         # If there is a patch file, get its filename
         patch_fn = self.modules_json.get_patch_fn(module, self.modules_repo.fullname)

--- a/nf_core/modules/update.py
+++ b/nf_core/modules/update.py
@@ -1,5 +1,4 @@
 import enum
-import json
 import logging
 import os
 import shutil
@@ -7,7 +6,6 @@ import tempfile
 from pathlib import Path
 
 import questionary
-from importlib_metadata import Lookup
 
 import nf_core.modules.module_utils
 import nf_core.utils

--- a/nf_core/pipeline-template/modules.json
+++ b/nf_core/pipeline-template/modules.json
@@ -7,13 +7,16 @@
             "git_url": "https://github.com/nf-core/modules.git",
             "modules": {
                 "custom/dumpsoftwareversions": {
-                    "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
+                    "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d",
+                    "branch": "master"
                 },
                 "fastqc": {
-                    "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
+                    "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d",
+                    "branch": "master"
                 },
                 "multiqc": {
-                    "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
+                    "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d",
+                    "branch": "master"
                 }
             }
         }

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -1006,3 +1006,15 @@ def strip_ansi_codes(string, replace_with=""):
     From Stack Overflow: https://stackoverflow.com/a/14693789/713980
     """
     return ANSI_ESCAPE_RE.sub(replace_with, string)
+
+
+def is_relative_to(path1, path2):
+    """
+    Checks if a path is relative to another.
+
+    Should mimic Path.is_relative_to which not available in Python < 3.9
+
+    path1 (Path | str): The path that could be a subpath
+    path2 (Path | str): The path the could be the superpath
+    """
+    return str(path1).startswith(str(path2) + os.sep)

--- a/tests/modules/install.py
+++ b/tests/modules/install.py
@@ -4,9 +4,13 @@ import pytest
 
 from nf_core.modules.install import ModuleInstall
 from nf_core.modules.modules_json import ModulesJson
-from nf_core.modules.modules_repo import NF_CORE_MODULES_NAME
 
-from ..utils import GITLAB_BRANCH_TEST_BRACH, GITLAB_URL, with_temporary_folder
+from ..utils import (
+    GITLAB_BRANCH_TEST_BRANCH,
+    GITLAB_REPO,
+    GITLAB_URL,
+    with_temporary_folder,
+)
 
 
 def test_modules_install_nopipeline(self):
@@ -49,17 +53,17 @@ def test_modules_install_from_gitlab(self):
 
 def test_modules_install_different_branch_fail(self):
     """Test installing a module from a different branch"""
-    install_obj = ModuleInstall(self.pipeline_dir, remote_url=GITLAB_URL, branch=GITLAB_BRANCH_TEST_BRACH)
+    install_obj = ModuleInstall(self.pipeline_dir, remote_url=GITLAB_URL, branch=GITLAB_BRANCH_TEST_BRANCH)
     # The FastQC module does not exists in the branch-test branch
     assert install_obj.install("fastqc") is False
 
 
-def test_modules_install_different_branch_succed(self):
+def test_modules_install_different_branch_succeed(self):
     """Test installing a module from a different branch"""
-    install_obj = ModuleInstall(self.pipeline_dir, remote_url=GITLAB_URL, branch=GITLAB_BRANCH_TEST_BRACH)
+    install_obj = ModuleInstall(self.pipeline_dir, remote_url=GITLAB_URL, branch=GITLAB_BRANCH_TEST_BRANCH)
     # The fastp module does exists in the branch-test branch
     assert install_obj.install("fastp") is True
 
     # Verify that the branch entry was added correctly
     modules_json = ModulesJson(self.pipeline_dir)
-    assert modules_json.get_module_branch("fastp", NF_CORE_MODULES_NAME) == GITLAB_BRANCH_TEST_BRACH
+    assert modules_json.get_module_branch("fastp", GITLAB_REPO) == GITLAB_BRANCH_TEST_BRANCH

--- a/tests/modules/install.py
+++ b/tests/modules/install.py
@@ -2,7 +2,11 @@ import os
 
 import pytest
 
-from ..utils import with_temporary_folder
+from nf_core.modules.install import ModuleInstall
+from nf_core.modules.modules_json import ModulesJson
+from nf_core.modules.modules_repo import NF_CORE_MODULES_NAME
+
+from ..utils import GITLAB_BRANCH_TEST_BRACH, GITLAB_URL, with_temporary_folder
 
 
 def test_modules_install_nopipeline(self):
@@ -43,9 +47,19 @@ def test_modules_install_from_gitlab(self):
     assert self.mods_install_gitlab.install("fastqc") is True
 
 
-# TODO Remove comments once external repository to have same structure as nf-core/modules
-# def test_modules_install_trimgalore_alternative_source(self):
-#     """Test installing a module from a different source repository - TrimGalore!"""
-#     assert self.mods_install_alt.install("trimgalore") is not False
-#     module_path = os.path.join(self.mods_install.dir, "modules", "ewels", "nf-core-modules", "trimgalore")
-#     assert os.path.exists(module_path)
+def test_modules_install_different_branch_fail(self):
+    """Test installing a module from a different branch"""
+    install_obj = ModuleInstall(self.pipeline_dir, remote_url=GITLAB_URL, branch=GITLAB_BRANCH_TEST_BRACH)
+    # The FastQC module does not exists in the branch-test branch
+    assert install_obj.install("fastqc") is False
+
+
+def test_modules_install_different_branch_succed(self):
+    """Test installing a module from a different branch"""
+    install_obj = ModuleInstall(self.pipeline_dir, remote_url=GITLAB_URL, branch=GITLAB_BRANCH_TEST_BRACH)
+    # The fastp module does exists in the branch-test branch
+    assert install_obj.install("fastp") is True
+
+    # Verify that the branch entry was added correctly
+    modules_json = ModulesJson(self.pipeline_dir)
+    assert modules_json.get_module_branch("fastp", NF_CORE_MODULES_NAME) == GITLAB_BRANCH_TEST_BRACH

--- a/tests/modules/modules_json.py
+++ b/tests/modules/modules_json.py
@@ -5,6 +5,7 @@ import shutil
 from nf_core.modules.modules_json import ModulesJson
 from nf_core.modules.modules_repo import (
     NF_CORE_MODULES_BASE_PATH,
+    NF_CORE_MODULES_DEFAULT_BRANCH,
     NF_CORE_MODULES_NAME,
     NF_CORE_MODULES_REMOTE,
     ModulesRepo,
@@ -34,6 +35,7 @@ def test_mod_json_update(self):
     assert "MODULE_NAME" in mod_json["repos"][NF_CORE_MODULES_NAME]["modules"]
     assert "git_sha" in mod_json["repos"][NF_CORE_MODULES_NAME]["modules"]["MODULE_NAME"]
     assert "GIT_SHA" == mod_json["repos"][NF_CORE_MODULES_NAME]["modules"]["MODULE_NAME"]["git_sha"]
+    assert NF_CORE_MODULES_DEFAULT_BRANCH == mod_json["repos"][NF_CORE_MODULES_NAME]["modules"]["MODULE_NAME"]["branch"]
 
 
 def test_mod_json_create(self):
@@ -57,6 +59,7 @@ def test_mod_json_create(self):
     for mod in mods:
         assert mod in mod_json["repos"][NF_CORE_MODULES_NAME]["modules"]
         assert "git_sha" in mod_json["repos"][NF_CORE_MODULES_NAME]["modules"][mod]
+        assert "branch" in mod_json["repos"][NF_CORE_MODULES_NAME]["modules"][mod]
 
 
 def test_mod_json_up_to_date(self):

--- a/tests/modules/update.py
+++ b/tests/modules/update.py
@@ -6,11 +6,20 @@ import tempfile
 import yaml
 
 import nf_core.utils
+from nf_core.modules.install import ModuleInstall
 from nf_core.modules.modules_json import ModulesJson
 from nf_core.modules.modules_repo import NF_CORE_MODULES_NAME
 from nf_core.modules.update import ModuleUpdate
 
-from ..utils import OLD_TRIMGALORE_SHA
+from ..utils import (
+    GITLAB_BRANCH_TEST_BRANCH,
+    GITLAB_BRANCH_TEST_NEW_SHA,
+    GITLAB_BRANCH_TEST_OLD_SHA,
+    GITLAB_DEFAULT_BRANCH,
+    GITLAB_REPO,
+    GITLAB_URL,
+    OLD_TRIMGALORE_SHA,
+)
 
 
 def test_install_and_update(self):
@@ -177,6 +186,62 @@ def test_update_with_config_no_updates(self):
             mod_json["repos"][NF_CORE_MODULES_NAME]["modules"][module]["git_sha"]
             == old_mod_json["repos"][NF_CORE_MODULES_NAME]["modules"][module]["git_sha"]
         )
+
+
+def test_update_different_branch_single_module(self):
+    """Try updating a module in a specific branch"""
+    install_obj = ModuleInstall(
+        self.pipeline_dir, remote_url=GITLAB_URL, branch=GITLAB_BRANCH_TEST_BRANCH, sha=GITLAB_BRANCH_TEST_OLD_SHA
+    )
+    install_obj.install("fastp")
+    update_obj = ModuleUpdate(
+        self.pipeline_dir, remote_url=GITLAB_URL, branch=GITLAB_BRANCH_TEST_BRANCH, show_diff=False
+    )
+    update_obj.update("fastp")
+
+    # Verify that the branch entry was updated correctly
+    modules_json = ModulesJson(self.pipeline_dir)
+    assert modules_json.get_module_branch("fastp", GITLAB_REPO) == GITLAB_BRANCH_TEST_BRANCH
+    assert modules_json.get_module_version("fastp", GITLAB_REPO) == GITLAB_BRANCH_TEST_NEW_SHA
+
+
+def test_update_different_branch_mixed_modules_main(self):
+    """Try updating all modules where MultiQC is installed from main branch"""
+    # Install fastp
+    install_obj = ModuleInstall(
+        self.pipeline_dir, remote_url=GITLAB_URL, branch=GITLAB_BRANCH_TEST_BRANCH, sha=GITLAB_BRANCH_TEST_OLD_SHA
+    )
+    install_obj.install("fastp")
+
+    # Install MultiQC from gitlab default branch
+    install_obj = ModuleInstall(self.pipeline_dir, remote_url=GITLAB_URL, branch=GITLAB_DEFAULT_BRANCH)
+    install_obj.install("multiqc")
+
+    # Try updating
+    update_obj = ModuleUpdate(self.pipeline_dir, update_all=True, show_diff=False)
+    assert update_obj.update() is True
+
+    modules_json = ModulesJson(self.pipeline_dir)
+    # Verify that the branch entry was updated correctly
+    assert modules_json.get_module_branch("fastp", GITLAB_REPO) == GITLAB_BRANCH_TEST_BRANCH
+    assert modules_json.get_module_version("fastp", GITLAB_REPO) == GITLAB_BRANCH_TEST_NEW_SHA
+    # MultiQC is present in both branches but should've been updated using the 'main' branch
+    assert modules_json.get_module_branch("multiqc", GITLAB_REPO) == GITLAB_DEFAULT_BRANCH
+
+
+def test_update_different_branch_mix_modules_branch_test(self):
+    """Try updating all modules where MultiQC is installed from branch-test branch"""
+    # Install multiqc from the branch-test branch
+    install_obj = ModuleInstall(
+        self.pipeline_dir, remote_url=GITLAB_URL, branch=GITLAB_BRANCH_TEST_BRANCH, sha=GITLAB_BRANCH_TEST_OLD_SHA
+    )
+    install_obj.install("multiqc")
+    update_obj = ModuleUpdate(self.pipeline_dir, update_all=True, show_diff=False)
+    update_obj.update()
+
+    modules_json = ModulesJson(self.pipeline_dir)
+    assert modules_json.get_module_branch("multiqc", GITLAB_REPO) == GITLAB_BRANCH_TEST_BRANCH
+    assert modules_json.get_module_version("multiqc", GITLAB_REPO) == GITLAB_BRANCH_TEST_NEW_SHA
 
 
 def cmp_module(dir1, dir2):

--- a/tests/modules/update.py
+++ b/tests/modules/update.py
@@ -46,7 +46,7 @@ def test_install_at_hash_and_update(self):
     mod_json_obj = ModulesJson(self.pipeline_dir)
     mod_json = mod_json_obj.get_modules_json()
     # Get the up-to-date git_sha for the module from the ModulesRepo object
-    correct_git_sha = list(update_obj.modules_repo.get_module_git_log("trimgalore", depth=1))[0]["git_sha"]
+    correct_git_sha = update_obj.modules_repo.get_latest_module_version("trimgalore")
     current_git_sha = mod_json["repos"][NF_CORE_MODULES_NAME]["modules"]["trimgalore"]["git_sha"]
     assert correct_git_sha == current_git_sha
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -101,6 +101,8 @@ class TestModules(unittest.TestCase):
         test_modules_test_file_dict,
     )
     from .modules.install import (
+        test_modules_install_different_branch_fail,
+        test_modules_install_different_branch_succeed,
         test_modules_install_emptypipeline,
         test_modules_install_from_gitlab,
         test_modules_install_nomodule,
@@ -158,6 +160,9 @@ class TestModules(unittest.TestCase):
         test_install_at_hash_and_update,
         test_install_at_hash_and_update_and_save_diff_to_file,
         test_update_all,
+        test_update_different_branch_mix_modules_branch_test,
+        test_update_different_branch_mixed_modules_main,
+        test_update_different_branch_single_module,
         test_update_with_config_dont_update,
         test_update_with_config_fix_all,
         test_update_with_config_fixed_version,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,7 +10,11 @@ import tempfile
 OLD_TRIMGALORE_SHA = "20d8250d9f39ddb05dfb437603aaf99b5c0b2b41"
 GITLAB_URL = "https://gitlab.com/nf-core/modules-test.git"
 GITLAB_REPO = "nf-core/modules-test"
-GITLAB_BRANCH_TEST_BRACH = "branch-test"
+GITLAB_DEFAULT_BRANCH = "main"
+# Branch test stuff
+GITLAB_BRANCH_TEST_BRANCH = "branch-tester"
+GITLAB_BRANCH_TEST_OLD_SHA = "eb4bc244de7eaef8e8ff0d451e4ca2e4b2c29821"
+GITLAB_BRANCH_TEST_NEW_SHA = "e43448a2cc17d59e085c4d3f77489af5a4dcc26d"
 
 
 def with_temporary_folder(func):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,6 +10,7 @@ import tempfile
 OLD_TRIMGALORE_SHA = "20d8250d9f39ddb05dfb437603aaf99b5c0b2b41"
 GITLAB_URL = "https://gitlab.com/nf-core/modules-test.git"
 GITLAB_REPO = "nf-core/modules-test"
+GITLAB_BRANCH_TEST_BRACH = "branch-test"
 
 
 def with_temporary_folder(func):


### PR DESCRIPTION
As I reported in #1728, the commands that rely on version information in the `modules.json` fail if a module was installed from a branch other than the default branch. I've fixed this by adding branch information to the module entries in the `modules.json`. The updated `modules.json` looks something like this

```yaml
{
    "name": "a/pipeline",
    "homePage": "https://a-pipeline.com",
    "repos": {
        "some/cool/repo": {
            "base_path": "modules",
            "git_url": "https://git-provider.com/some/cool/repo.git",
            "modules": {
                "first-modules": {
                    "git_sha": "<some sha>",
                    "branch": "main"
                },
                "second/module": {
                    "git_sha": "<another sha>",
                    "branch": "other-branch"
                }
            }
        }
    }
}
```
To add this feature I needed to refactor the `check_up_to_date` method in `modules_json.py` since it was to big and unruly to be modified directly. 

The new feature is tested using a new `branch-tester` branch in the `nf-core/modules-test` repository on gitlab. 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
