### PR TITLE
[MAINT] fix argument order

### DIFF
--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -746,12 +746,12 @@ def custom_yaml_dumper():
             """
             return self.represent_dict(data.items())
 
-        def increase_indent(self, *args, flow=False, **kwargs):
+        def increase_indent(self, flow=False, indentless=False):
             """Indent YAML lists so that YAML validates with Prettier
 
             See https://github.com/yaml/pyyaml/issues/234#issuecomment-765894586
             """
-            return super().increase_indent(flow=flow, indentless=False)
+            return super().increase_indent(flow=flow, indentless=indentless)
 
         # HACK: insert blank lines between top-level objects
         # inspired by https://stackoverflow.com/a/44284819/3786245

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -746,7 +746,7 @@ def custom_yaml_dumper():
             """
             return self.represent_dict(data.items())
 
-        def increase_indent(self, flow=False, *args, **kwargs):
+        def increase_indent(self, *args, flow=False, **kwargs):
             """Indent YAML lists so that YAML validates with Prettier
 
             See https://github.com/yaml/pyyaml/issues/234#issuecomment-765894586


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

The `yaml.Dumper.increase_indent()` function only has the two arguments `flow` and `indentless`. There's no need for the `*args` and `**kwargs`.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
