### PR TITLE
Fix broken link in `nf-core modules info`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 - Add links in `README.md` for `info` and `patch` commands ([#1722](https://github.com/nf-core/tools/issues/1722)])
 - Fix misc. issues with `--branch` and `--base-path` ([#1726](https://github.com/nf-core/tools/issues/1726))
 - Add `branch` field to module entries in `modules.json` to record what branch a module was installed from ([#1728](https://github.com/nf-core/tools/issues/1728))
+- Fix broken link in `nf-core modules info`([#1745](https://github.com/nf-core/tools/pull/1745))
 
 ## [v2.4.1 - Cobolt Koala Patch](https://github.com/nf-core/tools/releases/tag/2.4) - [2022-05-16]
 

--- a/nf_core/modules/info.py
+++ b/nf_core/modules/info.py
@@ -26,6 +26,7 @@ class ModuleInfo(ModuleCommand):
         self.meta = None
         self.local_path = None
         self.remote_location = None
+        self.local = None
 
         # Quietly check if this is a pipeline or not
         if pipeline_dir:
@@ -51,10 +52,10 @@ class ModuleInfo(ModuleCommand):
             module: str: Module name to check
         """
         if module is None:
-            local = questionary.confirm(
+            self.local = questionary.confirm(
                 "Is the module locally installed?", style=nf_core.utils.nfcore_question_style
             ).unsafe_ask()
-            if local:
+            if self.local:
                 if self.repo_type == "modules":
                     modules = self.get_modules_clone_modules()
                 else:
@@ -78,7 +79,7 @@ class ModuleInfo(ModuleCommand):
         """Given the name of a module, parse meta.yml and print usage help."""
 
         # Running with a local install, try to find the local meta
-        if self.dir:
+        if self.local:
             self.meta = self.get_local_yaml()
 
         # Either failed locally or in remote mode
@@ -163,11 +164,11 @@ class ModuleInfo(ModuleCommand):
         elif self.remote_location:
             intro_text.append(
                 Text.from_markup(
-                   ":globe_with_meridians: Repository: "
-                   f"{ '[link={self.remote_location}]' if self.remote_location.startswith('http') else ''}"
-                   f"{self.remote_location}"
-                   f"{'[/link]' if self.remote_location.startswith('http') else '' }"
-                   "\n"
+                    ":globe_with_meridians: Repository: "
+                    f"{ '[link={self.remote_location}]' if self.remote_location.startswith('http') else ''}"
+                    f"{self.remote_location}"
+                    f"{'[/link]' if self.remote_location.startswith('http') else '' }"
+                    "\n"
                 )
             )
 

--- a/nf_core/modules/info.py
+++ b/nf_core/modules/info.py
@@ -21,6 +21,40 @@ log = logging.getLogger(__name__)
 
 
 class ModuleInfo(ModuleCommand):
+    """
+    Class to print information of a module.
+
+    Attributes
+    ----------
+    meta : YAML object
+        stores the information from meta.yml file
+    local_path : str
+        path of the local modules
+    remote_location : str
+        remote repository URL
+    local : bool
+        indicates if the module is locally installed or not
+    repo_type : str
+        repository type. Can be either 'pipeline' or 'modules'
+    modules_json : ModulesJson object
+        contains 'modules.json' file information from a pipeline
+    module : str
+        name of the tool to get information from
+
+    Methods
+    -------
+    init_mod_name(module)
+        Makes sure that we have a module name
+    get_module_info()
+        Given the name of a module, parse meta.yml and print usage help
+    get_local_yaml()
+        Attempt to get the meta.yml file from a locally installed module
+    get_remote_yaml()
+        Attempt to get the meta.yml file from a remote repo
+    generate_module_info_help()
+        Take the parsed meta.yml and generate rich help
+    """
+
     def __init__(self, pipeline_dir, tool, remote_url, branch, no_pull, base_path):
         super().__init__(pipeline_dir, remote_url, branch, no_pull, base_path)
         self.meta = None

--- a/nf_core/modules/info.py
+++ b/nf_core/modules/info.py
@@ -164,9 +164,10 @@ class ModuleInfo(ModuleCommand):
             intro_text.append(
                 Text.from_markup(
                    ":globe_with_meridians: Repository: "
-                   f"{ "[link={self.remote_location}]" if self.remote_location.startswith('http') else ''}"
+                   f"{ '[link={self.remote_location}]' if self.remote_location.startswith('http') else ''}"
                    f"{self.remote_location}"
-                   f"{"[/link]\n" if self.remote_location.startswith('http') else "\n" }"
+                   f"{'[/link]' if self.remote_location.startswith('http') else '' }"
+                   "\n"
                 )
             )
 

--- a/nf_core/modules/info.py
+++ b/nf_core/modules/info.py
@@ -163,7 +163,9 @@ class ModuleInfo(ModuleCommand):
         elif self.remote_location:
             intro_text.append(
                 Text.from_markup(
-                    f":globe_with_meridians: Repository: [link=https://github.com/{self.remote_location}]{self.remote_location}[/]\n"
+                    ":globe_with_meridians: Repository: [link="
+                    f"{'' if self.remote_location.startswith('http') or self.remote_location.startswith('ssh') else 'https://github.com/'}"
+                    f"{self.remote_location}]{self.remote_location}[/link]\n"
                 )
             )
 

--- a/nf_core/modules/info.py
+++ b/nf_core/modules/info.py
@@ -163,9 +163,10 @@ class ModuleInfo(ModuleCommand):
         elif self.remote_location:
             intro_text.append(
                 Text.from_markup(
-                    ":globe_with_meridians: Repository: [link="
-                    f"{'' if self.remote_location.startswith('http') or self.remote_location.startswith('ssh') else 'https://github.com/'}"
-                    f"{self.remote_location}]{self.remote_location}[/link]\n"
+                   ":globe_with_meridians: Repository: "
+                   f"{ "[link={self.remote_location}]" if self.remote_location.startswith('http') else ''}"
+                   f"{self.remote_location}"
+                   f"{"[/link]\n" if self.remote_location.startswith('http') else "\n" }"
                 )
             )
 


### PR DESCRIPTION
Close #1736 

Don't add the prefix `https://github.com` to the link created by nf-core modules info. Make the link clickable if `self.remote_location` starts by 'http'

The command was also failing when there wasn't any module installed from a remote repository. I added the attribute `self.local` to ensure that we only try to obtain information from a local module if it is locally installed.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
