### PR TITLE
Handle exception in `nf-core modules lint` when process name doesn't start with process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Use black also to format python files in workflows ([#1563](https://github.com/nf-core/tools/pull/1563))
 - Add check for mimetype in the `input` parameter. ([#1647](https://github.com/nf-core/tools/issues/1647))
 - Check that the singularity and docker tags are parsable. Add `--fail-warned` flag to `nf-core modules lint` ([#1654](https://github.com/nf-core/tools/issues/1654))
+- Handle exception in `nf-core modules lint` when process name doesn't start with process ([#1733](https://github.com/nf-core/tools/issues/1733))
 
 ### General
 

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -240,19 +240,23 @@ def check_process_section(self, lines, fix_version, progress_bar):
 
     # Check that process labels are correct
     correct_process_labels = ["process_low", "process_medium", "process_high", "process_long"]
-    process_label = [l for l in lines if "label" in l]
+    process_label = [l for l in lines if l.lstrip().startswith("label")]
     if len(process_label) > 0:
-        process_label = re.search("process_[A-Za-z]+", process_label[0]).group(0)
-        if not process_label in correct_process_labels:
-            self.warned.append(
-                (
-                    "process_standard_label",
-                    f"Process label ({process_label}) is not among standard labels: `{'`,`'.join(correct_process_labels)}`",
-                    self.main_nf,
+        try:
+            process_label = re.search("process_[A-Za-z]+", process_label[0]).group(0)
+        except AttributeError:
+            process_label = re.search("'([A-Za-z_-]+)'", process_label[0]).group(0)
+        finally:
+            if not process_label in correct_process_labels:
+                self.warned.append(
+                    (
+                        "process_standard_label",
+                        f"Process label ({process_label}) is not among standard labels: `{'`,`'.join(correct_process_labels)}`",
+                        self.main_nf,
+                    )
                 )
-            )
-        else:
-            self.passed.append(("process_standard_label", "Correct process label", self.main_nf))
+            else:
+                self.passed.append(("process_standard_label", "Correct process label", self.main_nf))
     else:
         self.warned.append(("process_standard_label", "Process label unspecified", self.main_nf))
     for l in lines:


### PR DESCRIPTION
Closes #1733 

If the module process name doesn't start by `process_`, extract the process name and raise a linting warning. 
This PR also modifies the way of determining if the line contains the process name as suggested by @awgymer

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
