### PR TITLE
fix a pylint issue caused by glob imports in `git.exc` and remove unused code

### DIFF
--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -4,7 +4,6 @@
 from __future__ import print_function
 
 import concurrent.futures
-import hashlib
 import io
 import logging
 import os

--- a/nf_core/lint/__init__.py
+++ b/nf_core/lint/__init__.py
@@ -13,6 +13,7 @@ import re
 import git
 import rich
 import rich.progress
+from git.exc import InvalidGitRepositoryError
 from rich.console import group
 from rich.markdown import Markdown
 from rich.panel import Panel
@@ -289,7 +290,7 @@ class PipelineLint(nf_core.utils.Pipeline):
             log.info("Attempting to automatically fix failing tests")
             try:
                 repo = git.Repo(self.wf_path)
-            except git.exc.InvalidGitRepositoryError:
+            except InvalidGitRepositoryError:
                 raise AssertionError(
                     f"'{self.wf_path}' does not appear to be a git repository, "
                     "this is required when running with '--fix'"

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import git
 import questionary
+from git.exc import GitCommandError
 
 import nf_core.modules.module_utils
 import nf_core.modules.modules_repo
@@ -125,7 +126,7 @@ class ModulesJson:
                     try:
                         git.Git().ls_remote(nrepo_remote)
                         break
-                    except git.exc.GitCommandError:
+                    except GitCommandError:
                         nrepo_remote = questionary.text(
                             "The provided remote does not seem to exist, please provide a new remote."
                         ).unsafe_ask()

--- a/nf_core/modules/modules_repo.py
+++ b/nf_core/modules/modules_repo.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import git
 import rich.progress
+from git.exc import GitCommandError
 
 import nf_core.modules.module_utils
 import nf_core.modules.modules_json
@@ -173,7 +174,7 @@ class ModulesRepo(object):
                             progress=RemoteProgressbar(pbar, self.fullname, self.remote_url, "Cloning"),
                         )
                 ModulesRepo.update_local_repo_status(self.fullname, True)
-            except git.exc.GitCommandError:
+            except GitCommandError:
                 raise LookupError(f"Failed to clone from the remote: `{remote}`")
             # Verify that the requested branch exists by checking it out
             self.setup_branch(branch)
@@ -243,7 +244,7 @@ class ModulesRepo(object):
         """
         try:
             self.checkout_branch()
-        except git.exc.GitCommandError:
+        except GitCommandError:
             raise LookupError(f"Branch '{self.branch}' not found in '{self.fullname}'")
 
     def verify_branch(self):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -9,8 +9,6 @@ import tempfile
 import unittest
 from unittest import mock
 
-import git
-
 import nf_core.create
 import nf_core.sync
 
@@ -142,10 +140,6 @@ class TestModules(unittest.TestCase):
         assert psync.commit_template_changes() is True
         # Check that we don't have any uncommitted changes
         assert psync.repo.is_dirty(untracked_files=True) is False
-
-    def raise_git_exception(self):
-        """Raise an exception from GitPython"""
-        raise git.exc.GitCommandError("Test")
 
     def test_push_template_branch_error(self):
         """Try pushing the changes, but without a remote (should fail)"""


### PR DESCRIPTION
This PR removes a now unnecessary hashlib import and come code in the tests that has no function.

Here's a link to the issue decribing the pylint inability in the case of `git.exc`: https://stackoverflow.com/questions/55244396/weird-errors-with-pylint-and-git-exc

## PR checklist

- [x] This comment contains a description of changes (with reason)