### PR TITLE
add apply patch reverse when create modules.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 - Add `branch` field to module entries in `modules.json` to record what branch a module was installed from ([#1728](https://github.com/nf-core/tools/issues/1728))
 - Fix broken link in `nf-core modules info`([#1745](https://github.com/nf-core/tools/pull/1745))
 - Fix unbound variable issues and minor refactoring [#1742](https://github.com/nf-core/tools/pull/1742/)
+- Add support for patch when creating `modules.json` file ([#1752](https://github.com/nf-core/tools/pull/1752))
 
 ## [v2.4.1 - Cobolt Koala Patch](https://github.com/nf-core/tools/releases/tag/2.4) - [2022-05-16]
 

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -638,7 +638,6 @@ class ModulesJson:
         """
         Try reverse applying a patch file to the modified module files
 
-
         Args:
             module (str): The name of the module
             repo_name (str): The name of the repository where the module resides
@@ -646,12 +645,13 @@ class ModulesJson:
             module_dir (Path | str): The module directory in the pipeline
 
         Returns:
-            (bool): Whether the patch application was successful
+            (Path | str): The path of the folder where the module patched files are
+
+        Raises:
+            LookupError: If patch was not applied
         """
         module_fullname = str(Path(repo_name, module))
-
         patch_path = Path(self.dir / patch_relpath)
-        # module_relpath = Path("modules", repo_name, module)
 
         try:
             new_files = ModulesDiffer.try_apply_patch(module, repo_name, patch_path, module_dir, reverse=True)

--- a/tests/modules/modules_json.py
+++ b/tests/modules/modules_json.py
@@ -87,9 +87,6 @@ def test_mod_json_create_with_patch(self):
     patch_obj.patch("fastqc")
 
     patch_fn = "fastqc.diff"
-    # TO REMOVE
-    # Check that a patch file with the correct name has been created
-    assert set(os.listdir(module_path)) == {"main.nf", "meta.yml", patch_fn}
 
     # Remove the existing modules.json file
     os.remove(mod_json_path)

--- a/tests/modules/modules_json.py
+++ b/tests/modules/modules_json.py
@@ -86,8 +86,6 @@ def test_mod_json_create_with_patch(self):
     patch_obj = ModulePatch(self.pipeline_dir)
     patch_obj.patch("fastqc")
 
-    patch_fn = "fastqc.diff"
-
     # Remove the existing modules.json file
     os.remove(mod_json_path)
 

--- a/tests/modules/modules_json.py
+++ b/tests/modules/modules_json.py
@@ -68,7 +68,7 @@ def modify_main_nf(path):
     """Modify a file to test patch creation"""
     with open(path, "r") as fh:
         lines = fh.readlines()
-    # Modify $meat.id by $meta.single_end
+    # Modify $meta.id to $meta.single_end
     lines[1] = '    tag "$meta.single_end"\n'
     with open(path, "w") as fh:
         fh.writelines(lines)

--- a/tests/modules/modules_json.py
+++ b/tests/modules/modules_json.py
@@ -1,6 +1,7 @@
 import json
 import os
 import shutil
+from pathlib import Path
 
 from nf_core.modules.modules_json import ModulesJson
 from nf_core.modules.modules_repo import (
@@ -10,6 +11,7 @@ from nf_core.modules.modules_repo import (
     NF_CORE_MODULES_REMOTE,
     ModulesRepo,
 )
+from nf_core.modules.patch import ModulePatch
 
 
 def test_get_modules_json(self):
@@ -39,7 +41,7 @@ def test_mod_json_update(self):
 
 
 def test_mod_json_create(self):
-    """Test creating a modules.json file from scratch""" ""
+    """Test creating a modules.json file from scratch"""
     mod_json_path = os.path.join(self.pipeline_dir, "modules.json")
     # Remove the existing modules.json file
     os.remove(mod_json_path)
@@ -60,6 +62,57 @@ def test_mod_json_create(self):
         assert mod in mod_json["repos"][NF_CORE_MODULES_NAME]["modules"]
         assert "git_sha" in mod_json["repos"][NF_CORE_MODULES_NAME]["modules"][mod]
         assert "branch" in mod_json["repos"][NF_CORE_MODULES_NAME]["modules"][mod]
+
+
+def modify_main_nf(path):
+    """Modify a file to test patch creation"""
+    with open(path, "r") as fh:
+        lines = fh.readlines()
+    # Modify $meat.id by $meta.single_end
+    lines[1] = '    tag "$meta.single_end"\n'
+    with open(path, "w") as fh:
+        fh.writelines(lines)
+
+
+def test_mod_json_create_with_patch(self):
+    """Test creating a modules.json file from scratch when there are patched modules"""
+    mod_json_path = Path(self.pipeline_dir, "modules.json")
+
+    # Modify the module
+    module_path = Path(self.pipeline_dir, "modules", "nf-core", "modules", "fastqc")
+    modify_main_nf(module_path / "main.nf")
+
+    # Try creating a patch file
+    patch_obj = ModulePatch(self.pipeline_dir)
+    patch_obj.patch("fastqc")
+
+    patch_fn = "fastqc.diff"
+    # TO REMOVE
+    # Check that a patch file with the correct name has been created
+    assert set(os.listdir(module_path)) == {"main.nf", "meta.yml", patch_fn}
+
+    # Remove the existing modules.json file
+    os.remove(mod_json_path)
+
+    # Create the new modules.json file
+    ModulesJson(self.pipeline_dir).create()
+
+    # Check that the file exists
+    assert mod_json_path.is_file()
+
+    # Get the contents of the file
+    mod_json_obj = ModulesJson(self.pipeline_dir)
+    mod_json = mod_json_obj.get_modules_json()
+
+    # Check that fastqc is in the file
+    assert "fastqc" in mod_json["repos"][NF_CORE_MODULES_NAME]["modules"]
+    assert "git_sha" in mod_json["repos"][NF_CORE_MODULES_NAME]["modules"]["fastqc"]
+    assert "branch" in mod_json["repos"][NF_CORE_MODULES_NAME]["modules"]["fastqc"]
+
+    # Check that fastqc/main.nf maintains the changes
+    with open(module_path / "main.nf", "r") as fh:
+        lines = fh.readlines()
+    assert lines[1] == '    tag "$meta.single_end"\n'
 
 
 def test_mod_json_up_to_date(self):

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -142,6 +142,7 @@ class TestModules(unittest.TestCase):
         test_mod_json_up_to_date_module_removed,
         test_mod_json_up_to_date_reinstall_fails,
         test_mod_json_update,
+        test_mod_json_create_with_patch,
     )
     from .modules.patch import (
         test_create_patch_change,

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -132,6 +132,7 @@ class TestModules(unittest.TestCase):
     from .modules.modules_json import (
         test_get_modules_json,
         test_mod_json_create,
+        test_mod_json_create_with_patch,
         test_mod_json_dump,
         test_mod_json_get_base_path,
         test_mod_json_get_git_url,
@@ -142,7 +143,6 @@ class TestModules(unittest.TestCase):
         test_mod_json_up_to_date_module_removed,
         test_mod_json_up_to_date_reinstall_fails,
         test_mod_json_update,
-        test_mod_json_create_with_patch,
     )
     from .modules.patch import (
         test_create_patch_change,


### PR DESCRIPTION
Closes #1723 

When creating `modules.json` file, if a patch file exists for a module, apply the patch in reverse to find the commit_sha.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
