### PR TITLE
transparently use the print function from rich

### DIFF
--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -63,6 +63,7 @@ click.rich_click.OPTION_GROUPS = {
 def run_nf_core():
     # Set up rich stderr console
     stderr = rich.console.Console(stderr=True, force_terminal=nf_core.utils.rich_force_colors())
+    stdout = rich.console.Console(force_terminal=nf_core.utils.rich_force_colors())
 
     # Set up the rich traceback
     rich.traceback.install(console=stderr, width=200, word_wrap=True, extra_lines=1)
@@ -142,7 +143,7 @@ def list(keywords, sort, json, show_archived):
     Checks the web for a list of nf-core pipelines with their latest releases.
     Shows which nf-core pipelines you have pulled locally and whether they are up to date.
     """
-    rich.print(nf_core.list.list_workflows(keywords, sort, json, show_archived))
+    stdout.print(nf_core.list.list_workflows(keywords, sort, json, show_archived))
 
 
 # nf-core launch
@@ -238,7 +239,7 @@ def licences(pipeline, json):
     lic = nf_core.licences.WorkflowLicences(pipeline)
     lic.as_json = json
     try:
-        rich.print(lic.run_licences())
+        stdout.print(lic.run_licences())
     except LookupError as e:
         log.error(e)
         sys.exit(1)
@@ -396,7 +397,7 @@ def remote(ctx, keywords, json):
             ctx.obj["modules_repo_branch"],
             ctx.obj["modules_repo_no_pull"],
         )
-        rich.print(module_list.list_modules(keywords, json))
+        stdout.print(module_list.list_modules(keywords, json))
     except (UserWarning, LookupError) as e:
         log.critical(e)
         sys.exit(1)
@@ -426,7 +427,7 @@ def local(ctx, keywords, json, dir):
             ctx.obj["modules_repo_branch"],
             ctx.obj["modules_repo_no_pull"],
         )
-        rich.print(module_list.list_modules(keywords, json))
+        stdout.print(module_list.list_modules(keywords, json))
     except (UserWarning, LookupError) as e:
         log.error(e)
         sys.exit(1)
@@ -733,7 +734,7 @@ def info(ctx, tool, dir):
             ctx.obj["modules_repo_branch"],
             ctx.obj["modules_repo_no_pull"],
         )
-        rich.print(module_info.get_module_info())
+        stdout.print(module_info.get_module_info())
     except (UserWarning, LookupError) as e:
         log.error(e)
         sys.exit(1)
@@ -807,7 +808,7 @@ def mulled(specifications, build_number):
         )
         sys.exit(1)
     log.info("Mulled container hash:")
-    rich.print(image_name)
+    stdout.print(image_name)
 
 
 # nf-core modules test
@@ -969,7 +970,7 @@ def docs(schema_path, output, format, force, columns):
     schema_obj.get_schema_path(schema_path)
     schema_obj.load_schema()
     if not output:
-        rich.print(schema_obj.print_documentation(output, format, force, columns.split(",")))
+        stdout.print(schema_obj.print_documentation(output, format, force, columns.split(",")))
 
 
 # nf-core bump-version

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -59,15 +59,15 @@ click.rich_click.OPTION_GROUPS = {
     "nf-core modules list local": [{"options": ["--dir", "--json", "--help"]}],
 }
 
+# Set up rich stderr console
+stderr = rich.console.Console(stderr=True, force_terminal=nf_core.utils.rich_force_colors())
+stdout = rich.console.Console(force_terminal=nf_core.utils.rich_force_colors())
+
+# Set up the rich traceback
+rich.traceback.install(console=stderr, width=200, word_wrap=True, extra_lines=1)
+
 
 def run_nf_core():
-    # Set up rich stderr console
-    stderr = rich.console.Console(stderr=True, force_terminal=nf_core.utils.rich_force_colors())
-    stdout = rich.console.Console(force_terminal=nf_core.utils.rich_force_colors())
-
-    # Set up the rich traceback
-    rich.traceback.install(console=stderr, width=200, word_wrap=True, extra_lines=1)
-
     # Print nf-core header
     stderr.print(f"\n[green]{' ' * 42},--.[grey39]/[green],-.", highlight=False)
     stderr.print("[blue]          ___     __   __   __   ___     [green]/,-._.--~\\", highlight=False)

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -4,11 +4,11 @@ import logging
 import os
 import sys
 
+import rich
 import rich.console
 import rich.logging
 import rich.traceback
 import rich_click as click
-from rich import print
 
 import nf_core
 import nf_core.bump_version
@@ -142,7 +142,7 @@ def list(keywords, sort, json, show_archived):
     Checks the web for a list of nf-core pipelines with their latest releases.
     Shows which nf-core pipelines you have pulled locally and whether they are up to date.
     """
-    print(nf_core.list.list_workflows(keywords, sort, json, show_archived))
+    rich.print(nf_core.list.list_workflows(keywords, sort, json, show_archived))
 
 
 # nf-core launch
@@ -238,7 +238,7 @@ def licences(pipeline, json):
     lic = nf_core.licences.WorkflowLicences(pipeline)
     lic.as_json = json
     try:
-        print(lic.run_licences())
+        rich.print(lic.run_licences())
     except LookupError as e:
         log.error(e)
         sys.exit(1)
@@ -396,7 +396,7 @@ def remote(ctx, keywords, json):
             ctx.obj["modules_repo_branch"],
             ctx.obj["modules_repo_no_pull"],
         )
-        print(module_list.list_modules(keywords, json))
+        rich.print(module_list.list_modules(keywords, json))
     except (UserWarning, LookupError) as e:
         log.critical(e)
         sys.exit(1)
@@ -426,7 +426,7 @@ def local(ctx, keywords, json, dir):
             ctx.obj["modules_repo_branch"],
             ctx.obj["modules_repo_no_pull"],
         )
-        print(module_list.list_modules(keywords, json))
+        rich.print(module_list.list_modules(keywords, json))
     except (UserWarning, LookupError) as e:
         log.error(e)
         sys.exit(1)
@@ -733,7 +733,7 @@ def info(ctx, tool, dir):
             ctx.obj["modules_repo_branch"],
             ctx.obj["modules_repo_no_pull"],
         )
-        print(module_info.get_module_info())
+        rich.print(module_info.get_module_info())
     except (UserWarning, LookupError) as e:
         log.error(e)
         sys.exit(1)
@@ -807,7 +807,7 @@ def mulled(specifications, build_number):
         )
         sys.exit(1)
     log.info("Mulled container hash:")
-    print(image_name)
+    rich.print(image_name)
 
 
 # nf-core modules test
@@ -969,7 +969,7 @@ def docs(schema_path, output, format, force, columns):
     schema_obj.get_schema_path(schema_path)
     schema_obj.load_schema()
     if not output:
-        print(schema_obj.print_documentation(output, format, force, columns.split(",")))
+        rich.print(schema_obj.print_documentation(output, format, force, columns.split(",")))
 
 
 # nf-core bump-version

--- a/tests/lint/version_consistency.py
+++ b/tests/lint/version_consistency.py
@@ -10,6 +10,5 @@ def test_version_consistency(self):
     lint_obj.nextflow_config()
 
     result = lint_obj.version_consistency()
-    print(result)
     assert result["passed"] == ["Version tags are numeric and consistent between container, release tag and config."]
     assert result["failed"] == ["manifest.version was not numeric: 1.0dev!"]

--- a/tests/modules/module_test.py
+++ b/tests/modules/module_test.py
@@ -42,5 +42,4 @@ def test_modules_test_no_installed_modules(self):
     with pytest.raises(UserWarning) as excinfo:
         meta_builder._check_inputs()
     os.chdir(cwd)
-    print(excinfo.value)
     assert "No installed modules were found" in str(excinfo.value)

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -228,7 +228,6 @@ class TestLaunch(unittest.TestCase):
         assert result["message"] == ""
         assert result["choices"] == ["True", "False"]
         assert result["default"] == "True"
-        print(type(True))
         assert result["filter"]("True") == True
         assert result["filter"]("true") == True
         assert result["filter"](True) == True

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -47,7 +47,6 @@ class TestModules(unittest.TestCase):
             "mypipeline", "it is mine", "me", no_git=True, outdir=self.pipeline_dir, plain=True
         ).init_pipeline()
         # Set up install objects
-        print("Setting up install objects")
         self.mods_install = nf_core.modules.ModuleInstall(self.pipeline_dir, prompt=False, force=True)
         self.mods_install_alt = nf_core.modules.ModuleInstall(self.pipeline_dir, prompt=True, force=True)
         self.mods_install_old = nf_core.modules.ModuleInstall(
@@ -58,7 +57,6 @@ class TestModules(unittest.TestCase):
         )
 
         # Set up remove objects
-        print("Setting up remove objects")
         self.mods_remove = nf_core.modules.ModuleRemove(self.pipeline_dir)
         self.mods_remove_alt = nf_core.modules.ModuleRemove(self.pipeline_dir)
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -104,7 +104,6 @@ class TestSchema(unittest.TestCase):
         self.schema_obj.schema_filename = self.template_schema
         self.schema_obj.load_schema()
         docs = self.schema_obj.print_documentation()
-        print(docs)
         assert self.schema_obj.schema["title"] in docs
         assert self.schema_obj.schema["description"] in docs
         for definition in self.schema_obj.schema.get("definitions", {}).values():
@@ -296,7 +295,6 @@ class TestSchema(unittest.TestCase):
     def test_build_schema_param_bool(self):
         """Build a new schema param from a config value (bool)"""
         param = self.schema_obj.build_schema_param("True")
-        print(param)
         assert param == {"type": "boolean", "default": True}
 
     def test_build_schema_param_int(self):


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

I find replacing builtin functions intransparent and hence propose to make the use of rich.print obvious.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
