### PR TITLE
remove unnecessary dirs_exist_ok argument

### DIFF
--- a/nf_core/modules/lint/module_changes.py
+++ b/nf_core/modules/lint/module_changes.py
@@ -25,7 +25,7 @@ def module_changes(module_lint_object, module):
         # If the module is patched, we need to apply
         # the patch in reverse before comparing with the remote
         tempdir = Path(tempfile.mkdtemp())
-        shutil.copytree(module.module_dir, tempdir, dirs_exist_ok=True)
+        shutil.copytree(module.module_dir, tempdir)
         try:
             new_lines = ModulesDiffer.try_apply_patch(
                 module.module_name, module_lint_object.modules_repo.fullname, module.patch_path, tempdir, reverse=True


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

Closes #1748 

The `dirs_exist_ok` is not available in the still supported Python 3.7 and it is also not necessary because a tree is copied into a newly created temporary folder.

This code is not tested. Tests are needed, hence the marking as WIP.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
