### PR TITLE
workaround for shutil.copytree's lack of dirs_exist_ok in Python3.7 + added tests for module patch

### DIFF
--- a/nf_core/modules/lint/module_changes.py
+++ b/nf_core/modules/lint/module_changes.py
@@ -24,7 +24,8 @@ def module_changes(module_lint_object, module):
     if module.is_patched:
         # If the module is patched, we need to apply
         # the patch in reverse before comparing with the remote
-        tempdir = Path(tempfile.mkdtemp())
+        tempdir_parent = Path(tempfile.mkdtemp())
+        tempdir = tempdir_parent / "tmp_module_dir"
         shutil.copytree(module.module_dir, tempdir)
         try:
             new_lines = ModulesDiffer.try_apply_patch(

--- a/tests/modules/lint.py
+++ b/tests/modules/lint.py
@@ -1,8 +1,11 @@
+import os
+
 import pytest
 
 import nf_core.modules
 
 from ..utils import GITLAB_URL
+from .patch import BISMARK_ALIGN, PATCH_BRANCH, setup_patch
 
 
 def test_modules_lint_trimgalore(self):
@@ -43,6 +46,24 @@ def test_modules_lint_gitlab_modules(self):
     """Lint modules from a different remote"""
     self.mods_install_gitlab.install("fastqc")
     self.mods_install_gitlab.install("multiqc")
+    module_lint = nf_core.modules.ModuleLint(dir=self.pipeline_dir, remote_url=GITLAB_URL)
+    module_lint.lint(print_results=False, all_modules=True)
+    assert len(module_lint.failed) == 0
+    assert len(module_lint.passed) > 0
+    assert len(module_lint.warned) >= 0
+
+
+def test_modules_lint_patched_modules(self):
+    """
+    Test creating a patch file and applying it to a new version of the the files
+    """
+    setup_patch(self.pipeline_dir, True)
+
+    # Create a patch file
+    patch_obj = nf_core.modules.ModulePatch(self.pipeline_dir, GITLAB_URL, PATCH_BRANCH)
+    patch_obj.patch(BISMARK_ALIGN)
+    # change directory to the module directory
+    os.chdir(self.pipeline_dir)
     module_lint = nf_core.modules.ModuleLint(dir=self.pipeline_dir, remote_url=GITLAB_URL)
     module_lint.lint(print_results=False, all_modules=True)
     assert len(module_lint.failed) == 0

--- a/tests/modules/lint.py
+++ b/tests/modules/lint.py
@@ -62,10 +62,15 @@ def test_modules_lint_patched_modules(self):
     # Create a patch file
     patch_obj = nf_core.modules.ModulePatch(self.pipeline_dir, GITLAB_URL, PATCH_BRANCH)
     patch_obj.patch(BISMARK_ALIGN)
-    # change directory to the module directory
+
+    # change temporarily working directory to the pipeline directory
+    # to avoid error from try_apply_patch() during linting
+    wd_old = os.getcwd()
     os.chdir(self.pipeline_dir)
     module_lint = nf_core.modules.ModuleLint(dir=self.pipeline_dir, remote_url=GITLAB_URL)
     module_lint.lint(print_results=False, all_modules=True)
+    os.chdir(wd_old)
+
     assert len(module_lint.failed) == 0
     assert len(module_lint.passed) > 0
     assert len(module_lint.warned) >= 0

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -115,6 +115,7 @@ class TestModules(unittest.TestCase):
         test_modules_lint_gitlab_modules,
         test_modules_lint_new_modules,
         test_modules_lint_no_gitlab,
+        test_modules_lint_patched_modules,
         test_modules_lint_trimgalore,
     )
     from .modules.list import (


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

Fix issue introduced by https://github.com/nf-core/tools/pull/1755

Not sure what to write in the changelog.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
