### PR TITLE
use ubuntu-latest for api docs generatoin and release

### DIFF
--- a/.github/workflows/tools-api-docs-dev.yml
+++ b/.github/workflows/tools-api-docs-dev.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   api-docs:
     name: Build & push Sphinx API docs
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out source-code repository

--- a/.github/workflows/tools-api-docs-release.yml
+++ b/.github/workflows/tools-api-docs-release.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   api-docs:
     name: Build & push Sphinx API docs
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         dir:


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

GitHub Actions  seems to be deprecating Ubuntu 18.04 and thus some of the tests start failing. This PR makes it so ubuntu-latest is used in all workflows as the base image that until now use Ubuntu 18.04.

The issue surfaced because [this](https://github.com/fabianegli/tools/runs/7951535033?check_suite_focus=true) PR test failed.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
