### PR TITLE
change-rich-codex-run-condition

### DIFF
--- a/.github/workflows/rich-codex.yml
+++ b/.github/workflows/rich-codex.yml
@@ -1,12 +1,11 @@
 name: Generate images for docs
 on:
-  push:
-    branches-ignore:
-      - "master"
-      - "dev"
+  pull_request_review:
+    types: [submitted]
   workflow_dispatch:
 jobs:
   rich_codex:
+    if: github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo

--- a/README.md
+++ b/README.md
@@ -813,6 +813,8 @@ After you have written a minimal Nextflow script to test your module `modules/te
 <!-- RICH-CODEX
 working_dir: tmp/modules
 min_pct_diff: 15 # the tmp file path changes in the output, but that shouldn't trigger a new image.
+extra_env:
+  PROFILE: 'conda'
 -->
 
 ![`nf-core modules create-test-yml fastqc --no-prompts --force`](docs/images/nf-core-modules-create-test.svg)


### PR DESCRIPTION
This runs the rich-codex action only after an approved review (or when manually kicked-off).

Another solution for #1775.