### PR TITLE
lint pyproject.toml file exists and content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Patch release to fix black linting in pipelines ([#1789](https://github.com/nf-core/tools/pull/1789))
 - Add isort options to pyproject.toml ([#1792](https://github.com/nf-core/tools/pull/1792))
+- Lint pyproject.toml file exists and content ([#1795](https://github.com/nf-core/tools/pull/1795))
 - Update GitHub PyPI package release action to v1 ([#1785](https://github.com/nf-core/tools/pull/1785))
 
 ## [v2.5 - Gold Otter](https://github.com/nf-core/tools/releases/tag/2.5) - [2022-08-30]

--- a/nf_core/lint/files_exist.py
+++ b/nf_core/lint/files_exist.py
@@ -73,6 +73,7 @@ def files_exist(self):
         .github/workflows/awstest.yml
         .github/workflows/awsfulltest.yml
         lib/WorkflowPIPELINE.groovy
+        pyproject.toml
 
     Files that *must not* be present:
 
@@ -174,6 +175,7 @@ def files_exist(self):
         [os.path.join(".github", "workflows", "awsfulltest.yml")],
         [os.path.join("lib", f"Workflow{short_name[0].upper()}{short_name[1:]}.groovy")],
         ["modules.json"],
+        ["pyproject.toml"],
     ]
 
     # List of strings. Fails / warns if any of the strings exist.

--- a/nf_core/lint/files_unchanged.py
+++ b/nf_core/lint/files_unchanged.py
@@ -50,6 +50,7 @@ def files_unchanged(self):
 
         .gitignore
         .prettierignore
+        pyproject.toml
 
     .. tip:: You can configure the ``nf-core lint`` tests to ignore any of these checks by setting
              the ``files_unchanged`` key as follows in your ``.nf-core.yml`` config file. For example:
@@ -110,7 +111,7 @@ def files_unchanged(self):
         [os.path.join("lib", "NfcoreTemplate.groovy")],
     ]
     files_partial = [
-        [".gitignore", ".prettierignore"],
+        [".gitignore", ".prettierignore", "pyproject.toml"],
     ]
 
     # Only show error messages from pipeline creation


### PR DESCRIPTION
`nf-core lint` will WARN if file `pyproject.toml` doesn't exist. 
The file must contain the same lines as the template, and more lines can be added.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
