### PR TITLE
process_single changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Linting
 
+- The `process_single` label is now allowed
+
 ### General
 
 - Add function to enable chat notifications on MS Teams, accompanied by `hook_url` param to enable it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   - `Checks.groovy` -> `Utils.groovy`
   - `Completion.groovy` -> `NfcoreTemplate.groovy`
   - `Workflow.groovy` -> `WorkflowMain.groovy`
-- The `process_single` label is now allowed
+- Modules using a `process_single` label will not throw a warning
 
 ### General
 

--- a/nf_core/modules/create.py
+++ b/nf_core/modules/create.py
@@ -213,7 +213,7 @@ class ModuleCreate(object):
                 default=author_default,
             )
 
-        process_label_defaults = ["process_low", "process_medium", "process_high", "process_long"]
+        process_label_defaults = ["process_single", "process_low", "process_medium", "process_high", "process_long"]
         if self.process_label is None:
             log.info(
                 "Provide an appropriate resource label for the process, taken from the "

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -235,7 +235,7 @@ def check_process_section(self, lines, fix_version, progress_bar):
         self.failed.append(("process_capitals", "Process name is not in capital letters", self.main_nf))
 
     # Check that process labels are correct
-    correct_process_labels = ["process_low", "process_medium", "process_high", "process_long"]
+    correct_process_labels = ["process_single", "process_low", "process_medium", "process_high", "process_long"]
     process_label = [l for l in lines if l.lstrip().startswith("label")]
     if len(process_label) > 0:
         try:

--- a/nf_core/pipeline-template/modules/nf-core/modules/custom/dumpsoftwareversions/main.nf
+++ b/nf_core/pipeline-template/modules/nf-core/modules/custom/dumpsoftwareversions/main.nf
@@ -1,5 +1,5 @@
 process CUSTOM_DUMPSOFTWAREVERSIONS {
-    label 'process_low'
+    label 'process_single'
 
     // Requires `pyyaml` which does not have a dedicated container but is in the MultiQC container
     conda (params.enable_conda ? "bioconda::multiqc=1.11" : null)


### PR DESCRIPTION
`nf-core lint` complains that it doesn't know `process_single`:
1. Added `process_single` to the list of standard labels
2. `custom/dumpsoftwareversions/main.nf` is a `process_single` in nf-core/modules

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
