### PR TITLE
Extended the hook_url functionality to Slack

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 email_template.html
 adaptivecard.json
+slackreport.json
 docs/api/_build
 testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Track from where modules and subworkflows are installed ([#1999](https://github.com/nf-core/tools/pull/1999))
 - Substitute ModulesCommand and SubworkflowsCommand by ComponentsCommand ([#2000](https://github.com/nf-core/tools/pull/2000))
 - Don't print source file + line number on logging messages (except when verbose) ([#2015](https://github.com/nf-core/tools/pull/2015))
+- Extended the chat notifications to Slack ([#1829](https://github.com/nf-core/tools/pull/1829))
 
 ### Modules
 

--- a/nf_core/pipeline-template/.prettierignore
+++ b/nf_core/pipeline-template/.prettierignore
@@ -1,5 +1,6 @@
 email_template.html
 adaptivecard.json
+slackreport.json
 .nextflow*
 work/
 data/

--- a/nf_core/pipeline-template/assets/slackreport.json
+++ b/nf_core/pipeline-template/assets/slackreport.json
@@ -1,0 +1,34 @@
+{
+    "attachments": [
+        {
+            "fallback": "Plain-text summary of the attachment.",
+            "color": "<% if (success) { %>good<% } else { %>danger<%} %>",
+            "author_name": "sanger-tol/readmapping v${version} - ${runName}",
+            "author_icon": "https://www.nextflow.io/docs/latest/_static/favicon.ico",
+            "text": "<% if (success) { %>Pipeline completed successfully!<% } else { %>Pipeline completed with errors<% } %>",
+            "fields": [
+                {
+                    "title": "Command used to launch the workflow",
+                    "value": "```${commandLine}```",
+                    "short": false
+                }
+                <%
+                    if (!success) { %>
+                    ,
+                    {
+                        "title": "Full error message",
+                        "value": "```${errorReport}```",
+                        "short": false
+                    },
+                    {
+                        "title": "Pipeline configuration",
+                        "value": "<% out << summary.collect{ k,v -> k == "hook_url" ? "_${k}_: (_hidden_)" : ( ( v.class.toString().contains('Path') || ( v.class.toString().contains('String') && v.contains('/') ) ) ? "_${k}_: `${v}`" : (v.class.toString().contains('DateTime') ? ("_${k}_: " + v.format(java.time.format.DateTimeFormatter.ofLocalizedDateTime(java.time.format.FormatStyle.MEDIUM))) : "_${k}_: ${v}") ) }.join(",\n") %>",
+                        "short": false
+                    }
+                    <% }
+                %>
+            ],
+            "footer": "Completed at <% out << dateComplete.format(java.time.format.DateTimeFormatter.ofLocalizedDateTime(java.time.format.FormatStyle.MEDIUM)) %> (duration: ${duration})"
+        }
+    ]
+}

--- a/nf_core/pipeline-template/lib/NfcoreTemplate.groovy
+++ b/nf_core/pipeline-template/lib/NfcoreTemplate.groovy
@@ -146,9 +146,10 @@ class NfcoreTemplate {
     }
 
     //
-    // Construct and send a web report as JSON
+    // Construct and send a notification to a web server as JSON
+    // e.g. Microsoft Teams and Slack
     //
-    public static void webreport(workflow, params, summary_params, projectDir, log) {
+    public static void IM_notification(workflow, params, summary_params, projectDir, log) {
         def hook_url = params.hook_url
 
         def summary = [:]

--- a/nf_core/pipeline-template/lib/NfcoreTemplate.groovy
+++ b/nf_core/pipeline-template/lib/NfcoreTemplate.groovy
@@ -146,10 +146,9 @@ class NfcoreTemplate {
     }
 
     //
-    // Construct and send adaptive card
-    // https://adaptivecards.io
+    // Construct and send a web report as JSON
     //
-    public static void adaptivecard(workflow, params, summary_params, projectDir, log) {
+    public static void webreport(workflow, params, summary_params, projectDir, log) {
         def hook_url = params.hook_url
 
         def summary = [:]
@@ -184,7 +183,10 @@ class NfcoreTemplate {
 
         // Render the JSON template
         def engine       = new groovy.text.GStringTemplateEngine()
-        def hf = new File("$projectDir/assets/adaptivecard.json")
+        // Different JSON depending on the service provider
+        // Defaults to "Adaptive Cards" (https://adaptivecards.io), except Slack which has its own format
+        def json_path     = hook_url.contains("hooks.slack.com") ? "slackreport.json" : "adaptivecard.json"
+        def hf            = new File("$projectDir/assets/${json_path}")
         def json_template = engine.createTemplate(hf).make(msg_fields)
         def json_message  = json_template.toString()
 

--- a/nf_core/pipeline-template/lib/NfcoreTemplate.groovy
+++ b/nf_core/pipeline-template/lib/NfcoreTemplate.groovy
@@ -178,7 +178,7 @@ class NfcoreTemplate {
         msg_fields['exitStatus']   = workflow.exitStatus
         msg_fields['errorMessage'] = (workflow.errorMessage ?: 'None')
         msg_fields['errorReport']  = (workflow.errorReport ?: 'None')
-        msg_fields['commandLine']  = workflow.commandLine
+        msg_fields['commandLine']  = workflow.commandLine.replaceFirst(/ +--hook_url +[^ ]+/, "")
         msg_fields['projectDir']   = workflow.projectDir
         msg_fields['summary']      = summary << misc_fields
 

--- a/nf_core/pipeline-template/nextflow_schema.json
+++ b/nf_core/pipeline-template/nextflow_schema.json
@@ -217,7 +217,7 @@
                     "type": "string",
                     "description": "Incoming hook URL for messaging service",
                     "fa_icon": "fas fa-people-group",
-                    "help_text": "Incoming hook URL for messaging service. Currently, only MS Teams is supported.",
+                    "help_text": "Incoming hook URL for messaging service. Currently, MS Teams and Slack are supported.",
                     "hidden": true
                 },
                 "multiqc_config": {

--- a/nf_core/pipeline-template/workflows/pipeline.nf
+++ b/nf_core/pipeline-template/workflows/pipeline.nf
@@ -121,7 +121,7 @@ workflow.onComplete {
     }
     NfcoreTemplate.summary(workflow, params, log)
     if (params.hook_url) {
-        NfcoreTemplate.webreport(workflow, params, summary_params, projectDir, log)
+        NfcoreTemplate.IM_notification(workflow, params, summary_params, projectDir, log)
     }
 }
 

--- a/nf_core/pipeline-template/workflows/pipeline.nf
+++ b/nf_core/pipeline-template/workflows/pipeline.nf
@@ -121,7 +121,7 @@ workflow.onComplete {
     }
     NfcoreTemplate.summary(workflow, params, log)
     if (params.hook_url) {
-        NfcoreTemplate.adaptivecard(workflow, params, summary_params, projectDir, log)
+        NfcoreTemplate.webreport(workflow, params, summary_params, projectDir, log)
     }
 }
 


### PR DESCRIPTION
Hello,

Got very interested in what @matthdsm did in #1798 . This is a small extension to support Slack as well, since Slack doesn't understand adaptive cards.

Here is how the notifications look like:

<img width="678" alt="Screenshot 2022-09-16 at 11 16 27" src="https://user-images.githubusercontent.com/623458/190623291-02e9be70-edc5-4ef5-8e0f-7d8c156fc0d6.png">

<img width="530" alt="Screenshot 2022-09-16 at 11 38 18" src="https://user-images.githubusercontent.com/623458/190623264-bc35dc03-7c7a-4cf9-aece-c4e60944800d.png">

The JSON has a very long and tricky line where I try to improve the look-and-feel of the pipeline configuration:
- paths are printed as code
- dates are formatted according to the locale settings
- the hook_url itself is hidden

Note: I am using the legacy "attachments" method of the Slack API, rather than the now-recommended Block Kit method, because I couldn't find how to make the latter put some colour. I think one has to immediately know whether it failed or not, and the colour is faster to recognise than the text itself.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
