### PR TITLE
Fix questionary when updating `modules.json` file and commit sha is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### Modules
 
+- Fix questionary when updating `modules.json` file and commit sha is not found ([#1831](https://github.com/nf-core/tools/pull/1831))
+
 ## [v2.5.1 - Gold Otter Patch](https://github.com/nf-core/tools/releases/tag/2.5.1) - [2022-08-31]
 
 - Patch release to fix black linting in pipelines ([#1789](https://github.com/nf-core/tools/pull/1789))

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -228,8 +228,10 @@ class ModulesJson:
                 else:
                     correct_commit_sha = self.find_correct_commit_sha(module, module_path, modules_repo)
                 if correct_commit_sha is None:
-                    log.info(f"Was unable to find matching module files in the {modules_repo.branch} branch.")
-                    choices = [{"name": "No", "value": None}] + [
+                    log.info(
+                        f"Was unable to find matching module files in the {modules_repo.branch} branch for module {module}."
+                    )
+                    choices = [{"name": "No", "value": False}] + [
                         {"name": branch, "value": branch} for branch in (available_branches - tried_branches)
                     ]
                     branch = questionary.select(
@@ -237,9 +239,9 @@ class ModulesJson:
                         choices=choices,
                         style=nf_core.utils.nfcore_question_style,
                     ).unsafe_ask()
-                    if branch is None:
+                    if not branch:
                         action = questionary.select(
-                            f"Module is untracked '{module}'. Please select what action to take",
+                            f"Module '{module}' is untracked. Please select what action to take",
                             choices=[
                                 {"name": "Move the directory to 'local'", "value": 0},
                                 {"name": "Remove the files", "value": 1},


### PR DESCRIPTION
Closes #1824 

When `modules.json` was updated and a commit sha for the module was not found, a questionary asked if the module is installed in a different branch.
According to the [documentation](https://questionary.readthedocs.io/en/stable/pages/api_reference.html#api-reference) of Choices

> If this argument is None or unset, then the value of title is used.

I changed the value to False.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
