### PR TITLE
Add prettier to dockerimage for gitpod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Template
 
 - Add `actions/upload-artifact` step to the awstest workflows, to expose the debug log file
+- Add `prettier` as a requirement to Gitpod Dockerimage
 - Bioconda incompatible conda channel setups now result in more informative error messages ([#1812](https://github.com/nf-core/tools/pull/1812))
 - Update MultiQC module, update supplying MultiQC default and custom config and logo files to module
 - Add a 'recommend' methods description text to MultiQC to help pipeline users report pipeline usage in publications ([#1749](https://github.com/nf-core/tools/pull/1749))

--- a/nf_core/gitpod/gitpod.Dockerfile
+++ b/nf_core/gitpod/gitpod.Dockerfile
@@ -31,6 +31,7 @@ RUN conda update -n base -c defaults conda && \
         mamba=0.24.0 \
         pip=22.1.2 \
         black=22.6.0 \
+        prettier=2.7.1 \
         -n base && \
     conda clean --all -f -y
 


### PR DESCRIPTION
We had the vscode extensions there, but not prettier as a requirement in the container

![](https://th.bing.com/th/id/R.9a4e464667eafddad15040453e4f6846?rik=Y297WHqQDxqAjA&pid=ImgRaw&r=0)