### PR TITLE
maintain anchors in pytest_modules.yml

### DIFF
--- a/nf_core/modules/create.py
+++ b/nf_core/modules/create.py
@@ -15,6 +15,7 @@ import subprocess
 import jinja2
 import questionary
 import rich
+import ruamel.yaml
 import yaml
 from packaging.version import parse as parse_version
 
@@ -247,7 +248,8 @@ class ModuleCreate(object):
             # Add entry to pytest_modules.yml
             try:
                 with open(os.path.join(self.directory, "tests", "config", "pytest_modules.yml"), "r") as fh:
-                    pytest_modules_yml = yaml.safe_load(fh)
+                    # ruamel.yaml is used to maintain anchors in pytest_modules.yml
+                    pytest_modules_yml = ruamel.yaml.load(fh, Loader=ruamel.yaml.RoundTripLoader)
                 if self.subtool:
                     pytest_modules_yml[self.tool_name] = [
                         f"modules/{self.tool}/{self.subtool}/**",
@@ -260,7 +262,9 @@ class ModuleCreate(object):
                     ]
                 pytest_modules_yml = dict(sorted(pytest_modules_yml.items()))
                 with open(os.path.join(self.directory, "tests", "config", "pytest_modules.yml"), "w") as fh:
-                    yaml.dump(pytest_modules_yml, fh, sort_keys=True, Dumper=nf_core.utils.custom_yaml_dumper())
+                    # ruamel.yaml is used to maintain anchors in pytest_modules.yml
+                    # Dumper=nf_core.utils.custom_yaml_dumper() was used to add indentation for Prettier YAML linting
+                    ruamel.yaml.dump(pytest_modules_yml_anchor, fh, Dumper=ruamel.yaml.RoundTripDumper)
             except FileNotFoundError as e:
                 raise UserWarning("Could not open 'tests/config/pytest_modules.yml' file!")
 

--- a/nf_core/modules/create.py
+++ b/nf_core/modules/create.py
@@ -264,7 +264,7 @@ class ModuleCreate(object):
                 with open(os.path.join(self.directory, "tests", "config", "pytest_modules.yml"), "w") as fh:
                     # ruamel.yaml is used to maintain anchors in pytest_modules.yml
                     # Dumper=nf_core.utils.custom_yaml_dumper() was used to add indentation for Prettier YAML linting
-                    ruamel.yaml.dump(pytest_modules_yml_anchor, fh, Dumper=ruamel.yaml.RoundTripDumper)
+                    ruamel.yaml.dump(pytest_modules_yml, fh, Dumper=ruamel.yaml.RoundTripDumper)
             except FileNotFoundError as e:
                 raise UserWarning("Could not open 'tests/config/pytest_modules.yml' file!")
 

--- a/nf_core/modules/create.py
+++ b/nf_core/modules/create.py
@@ -16,7 +16,6 @@ import jinja2
 import questionary
 import rich
 import ruamel.yaml
-import yaml
 from packaging.version import parse as parse_version
 
 import nf_core

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ pytest-cov
 pytest-datafiles
 Sphinx
 sphinx_rtd_theme
+ruamel.yaml

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,3 @@ pytest-cov
 pytest-datafiles
 Sphinx
 sphinx_rtd_theme
-ruamel.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ requests_cache
 rich-click>=1.0.0
 rich>=10.7.0
 tabulate
+ruamel.yaml

--- a/tests/modules/create.py
+++ b/tests/modules/create.py
@@ -46,46 +46,46 @@ def test_modules_create_nfcore_modules_subtool(self):
 
 def test_modules_create_maintain_pytestyml(self):
     """Create a new tool/subtool and check if pytest_modules.yml has the proper structure"""
-    yml = """
-    abacas:
-    - modules/abacas/**
-    - tests/modules/abacas/**
+    yml = (
+        "abacas:\n"
+        "- modules/abacas/**\n"
+        "- tests/modules/abacas/**\n\n"
+        "subworkflows/bam_stats_samtools: &subworkflows_bam_stats_samtools\n"
+        "- subworkflows/nf-core/bam_stats_samtools/**\n"
+        "- tests/subworkflows/nf-core/bam_stats_samtools/**\n\n"
+        "~anchors:\n"
+        "- *subworkflows_bam_stats_samtools\n"
+    )
 
-    subworkflows/bam_stats_samtools: &subworkflows_bam_stats_samtools
-    - subworkflows/nf-core/bam_stats_samtools/**
-    - tests/subworkflows/nf-core/bam_stats_samtools/**
+    new_yml = (
+        "abacas:\n"
+        "- modules/abacas/**\n"
+        "- tests/modules/abacas/**\n\n"
+        "fastqc:\n"
+        "- modules/fastqc/**\n"
+        "- tests/modules/fastqc/**\n\n"
+        "subworkflows/bam_stats_samtools: &subworkflows_bam_stats_samtools\n"
+        "- subworkflows/nf-core/bam_stats_samtools/**\n"
+        "- tests/subworkflows/nf-core/bam_stats_samtools/**\n\n"
+        "~anchors:\n"
+        "- *subworkflows_bam_stats_samtools\n"
+    )
 
-    __anchors__:
-    - *subworkflows_bam_stats_samtools
-    """
-
-    new_yml = """
-    abacas:
-    - modules/abacas/**
-    - tests/modules/abacas/**
-
-    fastqc:
-    - modules/fastqc/**
-    - tests/modules/fastqc/**
-
-    subworkflows/bam_stats_samtools: &subworkflows_bam_stats_samtools
-    - subworkflows/nf-core/bam_stats_samtools/**
-    - tests/subworkflows/nf-core/bam_stats_samtools/**
-
-    __anchors__:
-    - *subworkflows_bam_stats_samtools
-    """
-
-    with open(os.path.join(self.nfcore_modules, "tests", "config", "pytest_modules.yml"), "r") as fh:
+    with open(os.path.join(self.nfcore_modules, "tests", "config", "pytest_modules.yml"), "w") as fh:
         fh.write(yml)
 
-    with open(os.path.join(self.nfcore_modules, "tests", "config", "pytest_modules_updated.yml"), "r") as fh:
+    with open(os.path.join(self.nfcore_modules, "tests", "config", "pytest_modules_updated.yml"), "w") as fh:
         fh.write(new_yml)
 
     module_create = nf_core.modules.ModuleCreate(
         self.nfcore_modules, "fastqc", "@author", "process_medium", False, False
     )
     module_create.create()
+
+    with open(os.path.join(self.nfcore_modules, "tests", "config", "pytest_modules.yml"), "r") as fh:
+        print(fh.read())
+    with open(os.path.join(self.nfcore_modules, "tests", "config", "pytest_modules_updated.yml"), "r") as fh:
+        print(fh.read())
 
     assert filecmp.cmp(
         os.path.join(self.nfcore_modules, "tests", "config", "pytest_modules.yml"),

--- a/tests/modules/create.py
+++ b/tests/modules/create.py
@@ -1,3 +1,4 @@
+import filecmp
 import os
 
 import pytest
@@ -41,3 +42,52 @@ def test_modules_create_nfcore_modules_subtool(self):
     module_create.create()
     assert os.path.exists(os.path.join(self.nfcore_modules, "modules", "star", "index", "main.nf"))
     assert os.path.exists(os.path.join(self.nfcore_modules, "tests", "modules", "star", "index", "main.nf"))
+
+
+def test_modules_create_maintain_pytestyml(self):
+    """Create a new tool/subtool and check if pytest_modules.yml has the proper structure"""
+    yml = """
+    abacas:
+    - modules/abacas/**
+    - tests/modules/abacas/**
+
+    subworkflows/bam_stats_samtools: &subworkflows_bam_stats_samtools
+    - subworkflows/nf-core/bam_stats_samtools/**
+    - tests/subworkflows/nf-core/bam_stats_samtools/**
+
+    __anchors__:
+    - *subworkflows_bam_stats_samtools
+    """
+
+    new_yml = """
+    abacas:
+    - modules/abacas/**
+    - tests/modules/abacas/**
+
+    fastqc:
+    - modules/fastqc/**
+    - tests/modules/fastqc/**
+
+    subworkflows/bam_stats_samtools: &subworkflows_bam_stats_samtools
+    - subworkflows/nf-core/bam_stats_samtools/**
+    - tests/subworkflows/nf-core/bam_stats_samtools/**
+
+    __anchors__:
+    - *subworkflows_bam_stats_samtools
+    """
+
+    with open(os.path.join(self.nfcore_modules, "tests", "config", "pytest_modules.yml"), "r") as fh:
+        fh.write(yml)
+
+    with open(os.path.join(self.nfcore_modules, "tests", "config", "pytest_modules_updated.yml"), "r") as fh:
+        fh.write(new_yml)
+
+    module_create = nf_core.modules.ModuleCreate(
+        self.nfcore_modules, "fastqc", "@author", "process_medium", False, False
+    )
+    module_create.create()
+
+    assert filecmp.cmp(
+        os.path.join(self.nfcore_modules, "tests", "config", "pytest_modules.yml"),
+        os.path.join(self.nfcore_modules, "tests", "config", "pytest_modules_updated.yml"),
+    )

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -87,6 +87,7 @@ class TestModules(unittest.TestCase):
     )
     from .modules.create import (
         test_modules_create_fail_exists,
+        test_modules_create_maintain_pytestyml,
         test_modules_create_nfcore_modules,
         test_modules_create_nfcore_modules_subtool,
         test_modules_create_succeed,


### PR DESCRIPTION
When adding subworkflows, we need to add anchors in `pytest_modules.yml` to link subworkflows with their modules. 
When loading the yml file with `pyyaml` anchors are removed.
Here we change to using `ruamel.yaml` to maintain anchors. 

👀 Aliases (`*`) need to be added to `pytests_modules.yml` file

```
abacas:
  - modules/abacas/**
  - tests/modules/abacas/**

subworkflows/bam_stats_samtools: &subworkflows_bam_stats_samtools
  - subworkflows/nf-core/bam_stats_samtools/**
  - tests/subworkflows/nf-core/bam_stats_samtools/**

__anchors__:
  - *subworkflows_bam_stats_samtools
```

⚠️ Now the indenting is lost. Needs to be fixed in `nf_core.utils.custom_yaml_dumper()`

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
