### PR TITLE
Schema: Remove `allOf` if no definition groups are left.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### General
 
 - Add function to enable chat notifications on MS Teams, accompanied by `hook_url` param to enable it.
+- Schema: Remove `allOf` if no definition groups are left.
 
 ### Modules
 

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -667,6 +667,15 @@ class PipelineSchema(object):
             if allOf in self.schema.get("allOf", []):
                 self.schema["allOf"].remove(allOf)
 
+        # If we don't have anything left in "allOf", remove it
+        if self.schema.get("allOf") == []:
+            del self.schema["allOf"]
+
+        # If we don't have anything left in "definitions", remove it
+        if self.schema.get("definitions") == {}:
+            del self.schema["definitions"]
+
+
     def remove_schema_notfound_configs(self):
         """
         Go through top-level schema and all definitions sub-schemas to remove

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -228,7 +228,7 @@ class PipelineSchema(object):
             schema_no_required = copy.deepcopy(self.schema)
             if "required" in schema_no_required:
                 schema_no_required.pop("required")
-            for group_key, group in schema_no_required["definitions"].items():
+            for group_key, group in schema_no_required.get("definitions", {}).items():
                 if "required" in group:
                     schema_no_required["definitions"][group_key].pop("required")
             jsonschema.validate(self.schema_defaults, schema_no_required)
@@ -247,7 +247,7 @@ class PipelineSchema(object):
             params_ignore = []
 
         # Go over group keys
-        for group_key, group in schema_no_required["definitions"].items():
+        for group_key, group in schema_no_required.get("definitions", {}).items():
             group_properties = group.get("properties")
             for param in group_properties:
                 if param in params_ignore:
@@ -343,7 +343,7 @@ class PipelineSchema(object):
             if "allOf" not in schema:
                 raise AssertionError("Schema has definitions, but no allOf key")
             in_allOf = False
-            for allOf in schema["allOf"]:
+            for allOf in schema.get("allOf", []):
                 if allOf["$ref"] == f"#/definitions/{d_key}":
                     in_allOf = True
             if not in_allOf:
@@ -361,7 +361,7 @@ class PipelineSchema(object):
             if "definitions" not in schema:
                 raise AssertionError("Schema has allOf, but no definitions")
             def_key = allOf["$ref"][14:]
-            if def_key not in schema["definitions"]:
+            if def_key not in schema.get("definitions", {}):
                 raise AssertionError(f"Subschema `{def_key}` found in `allOf` but not `definitions`")
 
         # Check that the schema describes at least one parameter
@@ -674,7 +674,6 @@ class PipelineSchema(object):
         # If we don't have anything left in "definitions", remove it
         if self.schema.get("definitions") == {}:
             del self.schema["definitions"]
-
 
     def remove_schema_notfound_configs(self):
         """


### PR DESCRIPTION
Fixing bug reported by @robsyme [on Slack](https://nfcore.slack.com/archives/CE5LG7WMB/p1664200940775769).

```console
$ nf-core schema build

                                          ,--./,-.
          ___     __   __   __   ___     /,-._.--~\
    |\ | |__  __ /  ` /  \ |__) |__         }  {
    | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                          `._,._,'

    nf-core/tools version 2.5.1 - https://nf-co.re/


ERROR    Could not find pipeline schema for '.':                       schema.py:73
         ./nextflow_schema.json                                                    
INFO     No existing schema found - creating a new one from the       schema.py:568
         nf-core template                                                          
WARNING  Removing empty group: 'input_output_options'                 schema.py:662
WARNING  Removing empty group: 'reference_genome_options'             schema.py:662
WARNING  Removing empty group: 'institutional_config_options'         schema.py:662
WARNING  Removing empty group: 'max_job_request_options'              schema.py:662
WARNING  Removing empty group: 'generic_options'                      schema.py:662
ERROR    Something went wrong when building a new schema: Schema does schema.py:577
         not validate as Draft 7 JSON Schema:                                      
          [] is too short                                                          
                                                                                   
         Failed validating 'minItems' in                                           
         metaschema['properties']['allOf']:                                        
             {'items': {'$ref': '#'}, 'minItems': 1, 'type': 'array'}              
                                                                                   
         On schema['allOf']:                                                       
             []                                                                    
INFO     Please ask for help on the nf-core Slack                     schema.py:578
```

Happens when all params are removed from the default schema. All definition groups are also then removed leaving an empty `allOf` schema entry, which is invalid.

PR adds a check for an empty list and removes it.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
