### PR TITLE
Better download logging when errors with container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add function to enable chat notifications on MS Teams, accompanied by `hook_url` param to enable it.
 - Schema: Remove `allOf` if no definition groups are left.
 - Use contextlib to temporarily change working directories ([#1819](https://github.com/nf-core/tools/pull/1819))
+- More helpful error messages if `nf-core download` can't parse a singularity image download
 
 ### Modules
 

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -12,6 +12,7 @@ import shutil
 import subprocess
 import sys
 import tarfile
+import textwrap
 from zipfile import ZipFile
 
 import questionary
@@ -453,7 +454,8 @@ class DownloadWorkflow(object):
         for subdir, _, files in os.walk(os.path.join(self.outdir, "workflow", "modules")):
             for file in files:
                 if file.endswith(".nf"):
-                    with open(os.path.join(subdir, file), "r") as fh:
+                    file_path = os.path.join(subdir, file)
+                    with open(file_path, "r") as fh:
                         # Look for any lines with `container = "xxx"`
                         this_container = None
                         contents = fh.read()
@@ -478,7 +480,9 @@ class DownloadWorkflow(object):
 
                                     # Don't recognise this, throw a warning
                                     else:
-                                        log.error(f"[red]Cannot parse container string, skipping: [green]'{file}'")
+                                        log.error(
+                                            f"[red]Cannot parse container string in '{file_path}':\n\n{textwrap.indent(match, '    ')}\n\n:warning: Skipping this singularity image.."
+                                        )
 
                         if this_container:
                             containers_raw.append(this_container)


### PR DESCRIPTION
More helpful error messages if `nf-core download` can't parse a singularity image download

Before:
```
ERROR    Cannot parse container string, skipping: 'main.nf'      
```

After:
```
ERROR    Cannot parse container string in 'nf-core-sarek-3.0.2/workflow/modules/nf-core/modules/deepvariant/main.nf':

             ${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
                     'google/deepvariant:1.3.0' :
                     'google/deepvariant:1.3.0' }

         ⚠ Skipping this singularity image..
```

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
