### PR TITLE
Check that the old renamed `lib` files are not still present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 ### Linting
 
+- Pipelines: Check that the old renamed `lib` files are not still present:
+  - `Checks.groovy` -> `Utils.groovy`
+  - `Completion.groovy` -> `NfcoreTemplate.groovy`
+  - `Workflow.groovy` -> `WorkflowMain.groovy`
+
 ### General
 
 - Add function to enable chat notifications on MS Teams, accompanied by `hook_url` param to enable it.

--- a/nf_core/lint/files_exist.py
+++ b/nf_core/lint/files_exist.py
@@ -75,7 +75,7 @@ def files_exist(self):
         lib/WorkflowPIPELINE.groovy
         pyproject.toml
 
-    Files that *must not* be present:
+    Files that *must not* be present, due to being renamed or removed in the template:
 
     .. code-block:: bash
 
@@ -90,6 +90,9 @@ def files_exist(self):
         docs/images/nf-core-PIPELINE_logo.png
         .markdownlint.yml
         .yamllint.yml
+        lib/Checks.groovy
+        lib/Completion.groovy
+        lib/Workflow.groovy
 
     Files that *should not* be present:
 
@@ -191,6 +194,9 @@ def files_exist(self):
         os.path.join("docs", "images", f"nf-core-{short_name}_logo.png"),
         ".markdownlint.yml",
         ".yamllint.yml",
+        os.path.join("lib", "Checks.groovy"),
+        os.path.join("lib", "Completion.groovy"),
+        os.path.join("lib", "Workflow.groovy"),
     ]
     files_warn_ifexists = [".travis.yml"]
 


### PR DESCRIPTION
Check that the old renamed `lib` files are not still present:
  - `Checks.groovy` -> `Utils.groovy`
  - `Completion.groovy` -> `NfcoreTemplate.groovy`
  - `Workflow.groovy` -> `WorkflowMain.groovy`

See also: nf-core/methylseq#246


## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
