### PR TITLE
Modules: If something is wrong with the local repo cache, offer to delete it and try again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Schema: Remove `allOf` if no definition groups are left.
 - Use contextlib to temporarily change working directories ([#1819](https://github.com/nf-core/tools/pull/1819))
 - More helpful error messages if `nf-core download` can't parse a singularity image download
+- Modules: If something is wrong with the local repo cache, offer to delete it and try again ([#1850](https://github.com/nf-core/tools/issues/1850))
 
 ### Modules
 


### PR DESCRIPTION
It's kind of amazingly difficult to intentionally corrupt a git repo to test this. But I think it should work.

Closes nf-core/tools#1850

<img width="762" alt="image" src="https://user-images.githubusercontent.com/465550/193027190-742b2b52-571e-473b-8892-e494d9bf509d.png">



## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
