### PR TITLE
Don't skip `base.config` when skipping nf-core/configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add a 'recommend' methods description text to MultiQC to help pipeline users report pipeline usage in publications ([#1749](https://github.com/nf-core/tools/pull/1749))
 - Fix template spacing modified by JINJA ([#1830](https://github.com/nf-core/tools/pull/1830))
 - Fix MultiQC execution on template [#1855](https://github.com/nf-core/tools/pull/1855)
+- Don't skip including `base.config` when skipping nf-core/configs
 
 ### Linting
 

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -59,10 +59,11 @@ params {
     max_time                   = '240.h'
 
 }
-{% if nf_core_configs %}
+
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
 
+{% if nf_core_configs -%}
 // Load nf-core custom profiles from different Institutions
 try {
     includeConfig "${params.custom_config_base}/nfcore_custom.config"
@@ -77,9 +78,8 @@ try {
 // } catch (Exception e) {
 //   System.err.println("WARNING: Could not load nf-core/config/{{ short_name }} profiles: ${params.custom_config_base}/pipeline/{{ short_name }}.config")
 // }
-
-
 {% endif %}
+
 profiles {
     debug { process.beforeScript = 'echo $HOSTNAME' }
     conda {


### PR DESCRIPTION
Jinja templating was a little too aggressive when skipping nf-core/configs.