### PR TITLE
Download: Allow single or double quotes for docker container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Use contextlib to temporarily change working directories ([#1819](https://github.com/nf-core/tools/pull/1819))
 - More helpful error messages if `nf-core download` can't parse a singularity image download
 - Modules: If something is wrong with the local repo cache, offer to delete it and try again ([#1850](https://github.com/nf-core/tools/issues/1850))
+- Allow container to use double or single quotes for `nf-core download`
 
 ### Modules
 

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -459,7 +459,7 @@ class DownloadWorkflow(object):
                         # Look for any lines with `container = "xxx"`
                         this_container = None
                         contents = fh.read()
-                        matches = re.findall(r"container\s*\"([^\"]*)\"", contents, re.S)
+                        matches = re.findall(r"container\s*['\"]([^'\"]*)['\"]", contents, re.S)
                         if matches:
                             for match in matches:
                                 # Look for a http download URL.


### PR DESCRIPTION
⚠️  Untested 

Should now work with both `container 'google/deepvariant:1.3.0'` and `container "google/deepvariant:1.3.0"`

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
