### PR TITLE
Tag the correct gitpod docker image name

### DIFF
--- a/.github/workflows/push_dockerhub_release.yml
+++ b/.github/workflows/push_dockerhub_release.yml
@@ -38,5 +38,5 @@ jobs:
           docker tag nfcore/tools:latest nfcore/tools:${{ github.event.release.tag_name }}
           docker push nfcore/tools:${{ github.event.release.tag_name }}
           docker push nfcore/gitpod:latest
-          docker tag nfcore/gitpod:latest nfcore/tools:${{ github.event.release.tag_name }}
+          docker tag nfcore/gitpod:latest nfcore/gitpod:${{ github.event.release.tag_name }}
           docker push nfcore/gitpod:${{ github.event.release.tag_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### General
 
+- Fix error in tagging GitPod docker images during releases
+
 ### Modules
 
 ## [v2.6 - Tin Octopus](https://github.com/nf-core/tools/releases/tag/2.6) - [2022-10-04]


### PR DESCRIPTION
GitPod docker push on release was failing, as a copy+paste typo had `tools` instead of `gitpod`:

```bash
docker tag nfcore/gitpod:latest nfcore/tools:2.6
docker push nfcore/gitpod:2.6
```

Now fixed, should work next release 🤞🏻 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
