### PR TITLE
add a function to check if patch files contain outdated paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Modules
 
+- Update patch file paths if the modules directory has the old structure ([#1878](https://github.com/nf-core/tools/pull/1878))
+
 ## [v2.6 - Tin Octopus](https://github.com/nf-core/tools/releases/tag/2.6) - [2022-10-04]
 
 ### Template

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -195,18 +195,28 @@ class ModuleCommand:
         Check that paths in patch files are updated to the new modules path
         """
         if patch_path.exists():
+            log.info(f"Modules {module_name} contains a patch file.")
             rewrite = False
             with open(patch_path, "r") as fh:
                 lines = fh.readlines()
-                for line in lines:
+                for index, line in enumerate(lines):
                     # Check if there are old paths in the patch file and replace
                     if f"modules/{self.modules_repo.repo_path}/modules/{module_name}/" in line:
                         rewrite = True
-                        line.replace(
+                        lines[index] = line.replace(
                             f"modules/{self.modules_repo.repo_path}/modules/{module_name}/",
                             f"modules/{self.modules_repo.repo_path}/{module_name}/",
                         )
             if rewrite:
+                log.info(f"Updating paths in {patch_path}")
                 with open(patch_path, "w") as fh:
                     for line in lines:
                         fh.write(line)
+                # Update path in modules.json if the file is in the correct format
+                modules_json = ModulesJson(self.dir)
+                modules_json.load()
+                if modules_json.has_git_url_and_modules():
+                    modules_json.modules_json["repos"][self.modules_repo.remote_url]["modules"][
+                        self.modules_repo.repo_path
+                    ][module_name]["patch"] = str(patch_path.relative_to(Path(self.dir).resolve()))
+                modules_json.dump()

--- a/nf_core/modules/patch.py
+++ b/nf_core/modules/patch.py
@@ -50,7 +50,7 @@ class ModulePatch(ModuleCommand):
         module_dir = [dir for dir, m in modules if m == module][0]
         module_fullname = str(Path("modules", module_dir, module))
 
-        # Verify that the module has an entry is the modules.json file
+        # Verify that the module has an entry in the modules.json file
         if not self.modules_json.module_present(module, self.modules_repo.remote_url, module_dir):
             raise UserWarning(
                 f"The '{module_fullname}' module does not have an entry in the 'modules.json' file. Cannot compute patch"

--- a/nf_core/modules/update.py
+++ b/nf_core/modules/update.py
@@ -613,6 +613,10 @@ class ModuleUpdate(ModuleCommand):
         patch_path = Path(self.dir / patch_relpath)
         module_relpath = Path("modules", repo_path, module)
 
+        # Check that paths in patch file are updated
+        print(patch_path, module)
+        self.check_patch_paths(patch_path, module)
+
         # Copy the installed files to a new temporary directory to save them for later use
         temp_dir = Path(tempfile.mkdtemp())
         temp_module_dir = temp_dir / module

--- a/nf_core/modules/update.py
+++ b/nf_core/modules/update.py
@@ -614,7 +614,6 @@ class ModuleUpdate(ModuleCommand):
         module_relpath = Path("modules", repo_path, module)
 
         # Check that paths in patch file are updated
-        print(patch_path, module)
         self.check_patch_paths(patch_path, module)
 
         # Copy the installed files to a new temporary directory to save them for later use


### PR DESCRIPTION
Closes #1868 

The new function runs in every `nf-core modules` command, when we check if the `modules` directory structure is outdated and try to fix it.
It updates paths from patch files.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
