### PR TITLE
update subworkflows install so it installs also imported modules and subworkflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fix error in tagging GitPod docker images during releases
 - Don't remove local copy of modules repo, only update it with fetch ([#1879](https://github.com/nf-core/tools/pull/1879))
+- Update subworkflows install so it installs also imported modules and subworkflows ([#1904](https://github.com/nf-core/tools/pull/1904))
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 ### General
 
 - Fix error in tagging GitPod docker images during releases
-- Don't remove local copy of modules repo, only update it with fetch ([#1879](https://github.com/nf-core/tools/pull/1879))
+- Don't remove local copy of modules repo, only update it with fetch ([#1881](https://github.com/nf-core/tools/pull/1881))
+- Add subworkflow commands create-test-yml, create and install ([#1897](https://github.com/nf-core/tools/pull/1897))
 - Update subworkflows install so it installs also imported modules and subworkflows ([#1904](https://github.com/nf-core/tools/pull/1904))
 
 ### Modules

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -86,17 +86,25 @@ class ModuleInstall(ModuleCommand):
 
         # Check that the module is not already installed
         if (current_version is not None and os.path.exists(module_dir)) and not self.force:
+            log.info("Module is already installed.")
+            print(f"Module {module} is already installed.")
 
-            log.error("Module is already installed.")
-            repo_flag = (
-                "" if self.modules_repo.repo_path == NF_CORE_MODULES_NAME else f"-g {self.modules_repo.remote_url} "
-            )
-            branch_flag = "" if self.modules_repo.branch == "master" else f"-b {self.modules_repo.branch} "
+            self.force = questionary.confirm(
+                f"Module {module} is already installed. Do you want to force the reinstallation?",
+                style=nf_core.utils.nfcore_question_style,
+                default=False,
+            ).unsafe_ask()
 
-            log.info(
-                f"To update '{module}' run 'nf-core modules {repo_flag}{branch_flag}update {module}'. To force reinstallation use '--force'"
-            )
-            return False
+            if not self.force:
+                repo_flag = (
+                    "" if self.modules_repo.repo_path == NF_CORE_MODULES_NAME else f"-g {self.modules_repo.remote_url} "
+                )
+                branch_flag = "" if self.modules_repo.branch == "master" else f"-b {self.modules_repo.branch} "
+
+                log.info(
+                    f"To update '{module}' run 'nf-core modules {repo_flag}{branch_flag}update {module}'. To force reinstallation use '--force'"
+                )
+                return False
 
         if self.sha:
             version = self.sha


### PR DESCRIPTION
The command `nf-core subworkflows install` installs also the modules and subworkflows imported in the subworkflow. 

To deal with already installed modules, I had to add a question asking if the modules should be re-installed with `--force`. Because subworkflows will need to work with the last version of the modules, the modules must be re-installed (aka. updated), otherwise the installation fails.

🧠 what will happen when installing an older version of a subworkflow?

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
