### PR TITLE
expand --json flag explanation to indicate that the output is the unf…

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ or number of GitHub stars (`-s stars`).
 
 ![`nf-core list -s stars`](docs/images/nf-core-list-stars.svg)
 
-To return results as JSON output for downstream use, use the `--json` flag.
+To return the complete list, without any filtering, as JSON output for downstream use, use the `--json` flag.
 
 Archived pipelines are not returned by default. To include them, use the `--show_archived` flag.
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -146,7 +146,7 @@ def nf_core_cli(verbose, log_file):
     default="release",
     help="How to sort listed pipelines",
 )
-@click.option("--json", is_flag=True, default=False, help="Print full output as JSON")
+@click.option("--json", is_flag=True, default=False, help="Print unfiltered list as JSON")
 @click.option("--show-archived", is_flag=True, default=False, help="Print archived workflows")
 def list(keywords, sort, json, show_archived):
     """


### PR DESCRIPTION
From https://github.com/nf-core/nf-co.re/issues/234

Expand --json flag explanation for nf-core list to indicate that the output is not filtered.

