### PR TITLE
Log includeConfig statement for subworkflow if needed 

### DIFF
--- a/nf_core/modules/modules_repo.py
+++ b/nf_core/modules/modules_repo.py
@@ -381,6 +381,8 @@ class ModulesRepo(object):
 
         # Copy the files from the repo to the install folder
         shutil.copytree(self.get_subworkflow_dir(subworkflow_name), Path(install_dir, subworkflow_name))
+        if Path(install_dir, subworkflow_name, 'nextflow.config').is_file():
+            log.info(f"Subworkflow config include statement: includeConfig '{Path(install_dir, subworkflow_name, 'nextflow.config')}'")
 
         # Switch back to the tip of the branch
         self.checkout_branch()


### PR DESCRIPTION
Possible solution for #1905 

Log the necessary `includeConfig` statement for a subworkflow when required (`e.g. align_bowtie2`)

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated