### PR TITLE
fix updating modules.json with install command

### DIFF
--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -148,5 +148,6 @@ class ModuleInstall(ModuleCommand):
         log.info(f"Include statement: include {{ {module_name} }} from '.{os.path.join(install_folder, module)}/main'")
 
         # Update module.json with newly installed module
+        modules_json.load()
         modules_json.update(self.modules_repo, module, version)
         return True

--- a/nf_core/subworkflows/install.py
+++ b/nf_core/subworkflows/install.py
@@ -171,6 +171,7 @@ class SubworkflowInstall(object):
         )
 
         # Update module.json with newly installed subworkflow
+        modules_json.load()
         modules_json.update_subworkflow(self.modules_repo, subworkflow, version)
         return True
 


### PR DESCRIPTION
the recursive install command from subworkflows updates modules.json with all installed modules


## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
