### PR TITLE
Autocanceling previous tests when pushing changes

### DIFF
--- a/nf_core/pipeline-template/.github/workflows/ci.yml
+++ b/nf_core/pipeline-template/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
 env:
   NXF_ANSI_LOG: false
 
+concurrency: 
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Run pipeline with test data

--- a/nf_core/pipeline-template/.github/workflows/ci.yml
+++ b/nf_core/pipeline-template/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   NXF_ANSI_LOG: false
 
 concurrency: 
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
The changes I added will cancel all the workflows (that share the same concurrency group) related to the current PR when new changes are pushed. I've added it only to the CI pipeline which is the most resource intensive one.


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
