### PR TITLE
Add --version to NfCoreTemplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix lint warnings for `samplesheet_check.nf` module
 - Add codespaces template ([#1957](https://github.com/nf-core/tools/pull/1957))
 - Check that the workflow name provided with a template doesn't contain dashes ([#1822](https://github.com/nf-core/tools/pull/1822))
+- `nextflow run <pipeline> --version` will now print the workflow version from the manifest and exit ([#1951](https://github.com/nf-core/tools/pull/1951))
 
 ### Linting
 

--- a/nf_core/lint/nextflow_config.py
+++ b/nf_core/lint/nextflow_config.py
@@ -141,7 +141,6 @@ def nextflow_config(self):
     ]
     # Old depreciated vars - fail if present
     config_fail_ifdefined = [
-        "params.version",
         "params.nf_required_version",
         "params.container",
         "params.singleEnd",

--- a/nf_core/pipeline-template/lib/NfcoreSchema.groovy
+++ b/nf_core/pipeline-template/lib/NfcoreSchema.groovy
@@ -46,7 +46,6 @@ class NfcoreSchema {
             'quiet',
             'syslog',
             'v',
-            'version',
 
             // Options for `nextflow run` command
             'ansi',

--- a/nf_core/pipeline-template/lib/NfcoreTemplate.groovy
+++ b/nf_core/pipeline-template/lib/NfcoreTemplate.groovy
@@ -33,6 +33,25 @@ class NfcoreTemplate {
     }
 
     //
+    // Generate version string
+    //
+    public static String version(workflow) {
+        String version_string = ""
+
+        if (workflow.manifest.version) {
+            def prefix_v = workflow.manifest.version[0] != 'v' ? 'v' : ''
+            version_string += "${prefix_v}${workflow.manifest.version}"
+        }
+
+        if (workflow.commitId) {
+            def git_shortsha = workflow.commitId.substring(0, 7)
+            version_string += "-g${git_shortsha}"
+        }
+
+        return version_string
+    }
+
+    //
     // Construct and send completion email
     //
     public static void email(workflow, params, summary_params, projectDir, log, multiqc_report=[]) {
@@ -61,7 +80,7 @@ class NfcoreTemplate {
         misc_fields['Nextflow Compile Timestamp'] = workflow.nextflow.timestamp
 
         def email_fields = [:]
-        email_fields['version']      = workflow.manifest.version
+        email_fields['version']      = NfcoreTemplate.version(workflow)
         email_fields['runName']      = workflow.runName
         email_fields['success']      = workflow.success
         email_fields['dateComplete'] = workflow.complete
@@ -170,7 +189,7 @@ class NfcoreTemplate {
         misc_fields['nxf_timestamp']                        = workflow.nextflow.timestamp
 
         def msg_fields = [:]
-        msg_fields['version']      = workflow.manifest.version
+        msg_fields['version']      = NfcoreTemplate.version(workflow)
         msg_fields['runName']      = workflow.runName
         msg_fields['success']      = workflow.success
         msg_fields['dateComplete'] = workflow.complete
@@ -300,6 +319,7 @@ class NfcoreTemplate {
     //
     public static String logo(workflow, monochrome_logs) {
         Map colors = logColours(monochrome_logs)
+        String workflow_version = NfcoreTemplate.version(workflow)
         String.format(
             """\n
             ${dashedLine(monochrome_logs)}{% if branded %}
@@ -308,7 +328,7 @@ class NfcoreTemplate {
             ${colors.blue}  |\\ | |__  __ /  ` /  \\ |__) |__         ${colors.yellow}}  {${colors.reset}
             ${colors.blue}  | \\| |       \\__, \\__/ |  \\ |___     ${colors.green}\\`-._,-`-,${colors.reset}
                                                     ${colors.green}`._,._,\'${colors.reset}{% endif %}
-            ${colors.purple}  ${workflow.manifest.name} v${workflow.manifest.version}${colors.reset}
+            ${colors.purple}  ${workflow.manifest.name} ${workflow_version}${colors.reset}
             ${dashedLine(monochrome_logs)}
             """.stripIndent()
         )

--- a/nf_core/pipeline-template/lib/WorkflowMain.groovy
+++ b/nf_core/pipeline-template/lib/WorkflowMain.groovy
@@ -19,7 +19,7 @@ class WorkflowMain {
     }
 
     //
-    // Print help to screen if required
+    // Generate help string
     //
     public static String help(workflow, params, log) {
         {% if igenomes -%}
@@ -36,7 +36,7 @@ class WorkflowMain {
     }
 
     //
-    // Print parameter summary log to screen
+    // Generate parameter summary log string
     //
     public static String paramsSummaryLog(workflow, params, log) {
         def summary_log = ''
@@ -54,6 +54,13 @@ class WorkflowMain {
         // Print help to screen if required
         if (params.help) {
             log.info help(workflow, params, log)
+            System.exit(0)
+        }
+
+        // Print workflow version and exit on --version
+        if (params.version) {
+            String workflow_version = NfcoreTemplate.version(workflow)
+            log.info "${workflow.manifest.name} ${workflow_version}"
             System.exit(0)
         }
 

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -37,6 +37,7 @@ params {
     monochrome_logs            = false
     hook_url                   = null
     help                       = false
+    version                    = false
     validate_params            = true
     show_hidden_params         = false
     schema_ignore_params       = 'genomes'

--- a/nf_core/pipeline-template/nextflow_schema.json
+++ b/nf_core/pipeline-template/nextflow_schema.json
@@ -176,6 +176,12 @@
                     "fa_icon": "fas fa-question-circle",
                     "hidden": true
                 },
+                "version": {
+                    "type": "boolean",
+                    "description": "Display version and exit.",
+                    "fa_icon": "fas fa-question-circle",
+                    "hidden": true
+                },
                 "publish_dir_mode": {
                     "type": "string",
                     "default": "copy",


### PR DESCRIPTION
As briefly discussed in the nf-core Slack, I was recently asked by a user "how do I know what version I have of your workflow?" which seemed like a simple question!

I was surprised to find that `nextflow info <workflow>` does not provide this (but I can imagine why). `nextflow info` does list and show the current revision, which is fine if you've checked out a specific tag but not useful for users who have just pulled with `nextflow run <workflow>` without `-r`.

The `workflow.manifest.version` is used by nf-core's template to [populate an email message](https://github.com/nf-core/tools/blob/3db6e4be703a5ca0b4a747c030f5848e4b8d2304/nf_core/pipeline-template/lib/NfcoreTemplate.groovy#L64), and [the logo function](https://github.com/nf-core/tools/blob/3db6e4be703a5ca0b4a747c030f5848e4b8d2304/nf_core/pipeline-template/lib/NfcoreTemplate.groovy#L308); but I wonder whether a more familiar `--version`-like invocation of a pipeline to print out version information might also be useful?

The WorkflowMain.version function definition in this PR will cook up a version identifier using both the manifest, and the workflow commitId (if available), it might be that this function should move to NfcoreTemplate instead to allow it to be used in the message and logo functions too.

Notably this would prevent any pipeline from using `version` as a parameter, so might be one to think about...! Thoughts welcome!

Examples below:

```
nf-core-hoot % nextflow run main.nf --version
N E X T F L O W  ~  version 22.04.3
Launching `main.nf` [cranky_koch] DSL2 - revision: c8865a20a8
nf-core/hoot v1.0dev
```

```
% nextflow run local/nf-core-hoot --version
N E X T F L O W  ~  version 22.04.3
Launching `/Users/Sam.Nicholls/git/tools/nf-core-hoot` [disturbed_becquerel] DSL2 - revision: d8f596bdf1 [master]
nf-core/hoot v1.0dev-gd8f596b
```

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
