### PR TITLE
enable setting defaulBranch for pipeline repo creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Update subworkflows install so it installs also imported modules and subworkflows ([#1904](https://github.com/nf-core/tools/pull/1904))
 - Improve test coverage of sync.py
 - `check_up_to_date()` function from `modules_json` also checks for subworkflows.
+- The default branch can now be specified when creating a new pipeline repo [#1959](https://github.com/nf-core/tools/pull/1959).
 
 ### Modules
 

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -527,10 +527,10 @@ class PipelineCreate(object):
         Raises:
             UserWarning: if Git default branch is set to 'dev' or 'TEMPLATE'.
         """
+        default_branch = self.default_branch
         try:
-            default_branch = self.default_branch or git.config.GitConfigParser().get_value("init", "defaultBranch")
+            default_branch = git.config.GitConfigParser().get_value("init", "defaultBranch")
         except configparser.Error:
-            default_branch = None
             log.debug("Could not read init.defaultBranch")
         if default_branch in ["dev", "TEMPLATE"]:
             raise UserWarning(

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -535,6 +535,7 @@ class PipelineCreate(object):
         if default_branch in ["dev", "TEMPLATE"]:
             raise UserWarning(
                 f"Your Git defaultBranch '{default_branch}' is incompatible with nf-core.\n"
+                "'dev' and 'TEMPLATE' can not be used as default branch name.\n"
                 "Set the default branch name with "
                 "[white on grey23] git config --global init.defaultBranch <NAME> [/]\n"
                 "Or set the default_branch parameter in this class.\n"

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -529,7 +529,7 @@ class PipelineCreate(object):
         """
         default_branch = self.default_branch
         try:
-            default_branch = git.config.GitConfigParser().get_value("init", "defaultBranch")
+            default_branch = default_branch or git.config.GitConfigParser().get_value("init", "defaultBranch")
         except configparser.Error:
             log.debug("Could not read init.defaultBranch")
         if default_branch in ["dev", "TEMPLATE"]:

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -49,11 +49,11 @@ class PipelineCreate(object):
         author,
         version="1.0dev",
         no_git=False,
-        default_branch=None,
         force=False,
         outdir=None,
         template_yaml_path=None,
         plain=False,
+        default_branch=None,
     ):
         self.template_params, skip_paths_keys = self.create_param_dict(
             name, description, author, version, template_yaml_path, plain

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -541,7 +541,8 @@ class PipelineCreate(object):
             )
         # Initialise pipeline
         log.info("Initialising pipeline git repository")
-        repo = git.Repo.init(self.outdir, initial_branch=default_branch)
+        init_kwargs = {"initial_branch": default_branch} if default_branch is not None else {}
+        repo = git.Repo.init(self.outdir, **init_kwargs)
         repo.git.add(A=True)
         repo.index.commit(f"initial template build from nf-core/tools, version {nf_core.__version__}")
         # Add TEMPLATE branch to git repository

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -40,6 +40,8 @@ class PipelineCreate(object):
             May the force be with you.
         outdir (str): Path to the local output directory.
         template_yaml (str): Path to template.yml file for pipeline creation settings.
+        plain (bool): If true the Git repository will be initialized plain.
+        default_branch (str): Specifies the --initial-branch name.
     """
 
     def __init__(

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -527,7 +527,6 @@ class PipelineCreate(object):
         Raises:
             UserWarning: if Git default branch is set to 'dev' or 'TEMPLATE'.
         """
-        # Check that the default branch is not dev
         try:
             default_branch = self.default_branch or git.config.GitConfigParser().get_value("init", "defaultBranch")
         except configparser.Error:
@@ -538,17 +537,16 @@ class PipelineCreate(object):
                 f"Your Git defaultBranch '{default_branch}' is incompatible with nf-core.\n"
                 "Set the default branch name with "
                 "[white on grey23] git config --global init.defaultBranch <NAME> [/]\n"
-                # Or set the default_branch parameter in this class
+                "Or set the default_branch parameter in this class.\n"
                 "Pipeline git repository will not be initialised."
             )
-        # Initialise pipeline
+
         log.info("Initialising pipeline git repository")
         repo = git.Repo.init(self.outdir)
         if default_branch:
             repo.active_branch.rename(default_branch)
         repo.git.add(A=True)
         repo.index.commit(f"initial template build from nf-core/tools, version {nf_core.__version__}")
-        # Add TEMPLATE branch to git repository
         repo.git.branch("TEMPLATE")
         repo.git.branch("dev")
         log.info(

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -543,8 +543,9 @@ class PipelineCreate(object):
             )
         # Initialise pipeline
         log.info("Initialising pipeline git repository")
-        init_kwargs = {"initial_branch": default_branch} if default_branch is not None else {}
-        repo = git.Repo.init(self.outdir, **init_kwargs)
+        repo = git.Repo.init(self.outdir)
+        if default_branch:
+            repo.active_branch.rename(default_branch)
         repo.git.add(A=True)
         repo.index.commit(f"initial template build from nf-core/tools, version {nf_core.__version__}")
         # Add TEMPLATE branch to git repository

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -4,6 +4,8 @@
 import os
 import unittest
 
+import git
+
 import nf_core.create
 
 from .utils import with_temporary_folder
@@ -16,6 +18,7 @@ class NfcoreCreateTest(unittest.TestCase):
         self.pipeline_description = "just for 4w3s0m3 tests"
         self.pipeline_author = "Chuck Norris"
         self.pipeline_version = "1.0.0"
+        self.default_branch = "default"
 
         self.pipeline = nf_core.create.PipelineCreate(
             name=self.pipeline_name,
@@ -26,6 +29,7 @@ class NfcoreCreateTest(unittest.TestCase):
             force=True,
             outdir=tmp_path,
             plain=True,
+            default_branch=self.default_branch,
         )
 
     def test_pipeline_creation(self):
@@ -37,3 +41,4 @@ class NfcoreCreateTest(unittest.TestCase):
     def test_pipeline_creation_initiation(self):
         self.pipeline.init_pipeline()
         assert os.path.isdir(os.path.join(self.pipeline.outdir, ".git"))
+        assert f" {self.default_branch}\n" in git.Repo.init(self.pipeline.outdir).git.branch()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -32,7 +32,8 @@ class TestModules(unittest.TestCase):
         )
         self.create_obj.init_pipeline()
         self.remote_path = os.path.join(self.tmp_dir, "remote_repo")
-        self.remote_repo = git.Repo.init(self.remote_path, bare=True, initial_branch=default_branch)
+        self.remote_repo = git.Repo.init(self.remote_path, bare=True)
+        self.remote_repo.active_branch.rename(default_branch)
 
     def tearDown(self):
         if os.path.exists(self.tmp_dir):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -26,12 +26,13 @@ class TestModules(unittest.TestCase):
         """Create a new pipeline to test"""
         self.tmp_dir = tempfile.mkdtemp()
         self.pipeline_dir = os.path.join(self.tmp_dir, "test_pipeline")
+        default_branch = "master"
         self.create_obj = nf_core.create.PipelineCreate(
-            "testing", "test pipeline", "tester", outdir=self.pipeline_dir, plain=True
+            "testing", "test pipeline", "tester", outdir=self.pipeline_dir, plain=True, default_branch=default_branch
         )
         self.create_obj.init_pipeline()
         self.remote_path = os.path.join(self.tmp_dir, "remote_repo")
-        self.remote_repo = git.Repo.init(self.remote_path, bare=True)
+        self.remote_repo = git.Repo.init(self.remote_path, bare=True, initial_branch=default_branch)
 
     def tearDown(self):
         if os.path.exists(self.tmp_dir):


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

For reference: https://nfcore.slack.com/archives/CE5LG7WMB/p1665850093986309

When a local `.gitconfig` specified the `init.defaultBranch` to anything else than `master` one sync test would fail.

To make the tests system config agnostic, it is necessary to have a different way of telling nf-core tools what it should use as a default branch when creating new pipeline repositories. This PR implements just that in the internals and uses the feature to make tests pass on systems with `init.defaultBranch` not set to `master`. It does not expose this feature to the CLI - this should maybe be the topic of another PR that then also updates the docs.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
