### PR TITLE
add versions.yml to create-test-yml but not md5sum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Improve test coverage of sync.py
 - `check_up_to_date()` function from `modules_json` also checks for subworkflows.
 - The default branch can now be specified when creating a new pipeline repo [#1959](https://github.com/nf-core/tools/pull/1959).
+- Add file `versions.yml` when generating `test.yml` with `nf-core modules create-test-yml` but don't check for md5sum [#1963](https://github.com/nf-core/tools/pull/1963)
 
 ### Modules
 

--- a/nf_core/modules/test_yml_builder.py
+++ b/nf_core/modules/test_yml_builder.py
@@ -232,9 +232,6 @@ class ModulesTestYmlBuilder(ModuleCommand):
         test_files = []
         for root, _, files in os.walk(results_dir, followlinks=True):
             for filename in files:
-                # Check that the file is not versions.yml
-                if filename == "versions.yml":
-                    continue
                 file_path = os.path.join(root, filename)
                 # add the key here so that it comes first in the dict
                 test_file = {"path": file_path}
@@ -245,8 +242,10 @@ class ModulesTestYmlBuilder(ModuleCommand):
                 # Add the md5 anyway, linting should fail later and can be manually removed if needed.
                 #  Originally we skipped this if empty, but then it's too easy to miss the warning.
                 #  Equally, if a file is legitimately empty we don't want to prevent this from working.
-                file_md5 = self._md5(file_path)
-                test_file["md5sum"] = file_md5
+                if filename != "versions.yml":
+                    # Only add md5sum if the file is not versions.yml
+                    file_md5 = self._md5(file_path)
+                    test_file["md5sum"] = file_md5
                 # Switch out the results directory path with the expected 'output' directory
                 test_file["path"] = file_path.replace(results_dir, "output")
                 test_files.append(test_file)


### PR DESCRIPTION
close #1958

The file `versions.yml` was removed from `test.yml` by mistake. 
Add the check that the file exist back, but do not print the md5sum.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
