### PR TITLE
when pipeline dir doesn't contain `main.nf` or `nextflow.config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Improve test coverage of sync.py
 - `check_up_to_date()` function from `modules_json` also checks for subworkflows.
 - The default branch can now be specified when creating a new pipeline repo [#1959](https://github.com/nf-core/tools/pull/1959).
+- Only warn when checking that the pipeline directory contains a `main.nf` and a `nextflow.config` file if the pipeline is not an nf-core pipeline [#1964](https://github.com/nf-core/tools/pull/1964)
 
 ### Modules
 

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -64,7 +64,9 @@ class ModuleCommand:
         main_nf = os.path.join(self.dir, "main.nf")
         nf_config = os.path.join(self.dir, "nextflow.config")
         if not os.path.exists(main_nf) and not os.path.exists(nf_config):
-            raise UserWarning(f"Could not find a 'main.nf' or 'nextflow.config' file in '{self.dir}'")
+            if Path(self.dir).resolve().parts[-1].startswith("nf-core"):
+                raise UserWarning(f"Could not find a 'main.nf' or 'nextflow.config' file in '{self.dir}'")
+            log.warning(f"Could not find a 'main.nf' or 'nextflow.config' file in '{self.dir}'")
         return True
 
     def has_modules_file(self):

--- a/nf_core/modules/modules_command.py
+++ b/nf_core/modules/modules_command.py
@@ -64,9 +64,7 @@ class ModuleCommand:
         main_nf = os.path.join(self.dir, "main.nf")
         nf_config = os.path.join(self.dir, "nextflow.config")
         if not os.path.exists(main_nf) and not os.path.exists(nf_config):
-            if Path(self.dir).resolve().parts[-1].startswith("nf-core"):
-                raise UserWarning(f"Could not find a 'main.nf' or 'nextflow.config' file in '{self.dir}'")
-            log.warning(f"Could not find a 'main.nf' or 'nextflow.config' file in '{self.dir}'")
+            raise UserWarning(f"Could not find a 'main.nf' or 'nextflow.config' file in '{self.dir}'")
         return True
 
     def has_modules_file(self):

--- a/tests/modules/install.py
+++ b/tests/modules/install.py
@@ -22,7 +22,8 @@ def test_modules_install_nopipeline(self):
 @with_temporary_folder
 def test_modules_install_emptypipeline(self, tmpdir):
     """Test installing a module - empty dir given"""
-    self.mods_install.dir = tmpdir
+    os.mkdir(os.path.join(tmpdir, "nf-core-pipe"))
+    self.mods_install.dir = os.path.join(tmpdir, "nf-core-pipe")
     with pytest.raises(UserWarning) as excinfo:
         self.mods_install.install("foo")
     assert "Could not find a 'main.nf' or 'nextflow.config' file" in str(excinfo.value)


### PR DESCRIPTION
Close #1941 

Only warn when checking that the pipeline directory contains a `main.nf` and a `nextflow.config` file if the pipeline is not an nf-core pipeline

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
