### PR TITLE
Improve test coverage of `__main__.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Don't remove local copy of modules repo, only update it with fetch ([#1881](https://github.com/nf-core/tools/pull/1881))
 - Add subworkflow commands create-test-yml, create and install ([#1897](https://github.com/nf-core/tools/pull/1897))
 - Update subworkflows install so it installs also imported modules and subworkflows ([#1904](https://github.com/nf-core/tools/pull/1904))
-- Improve test coverage of sync.py
+- Improve test coverage of `sync.py` and `__main__.py` ([#1936](https://github.com/nf-core/tools/pull/1936), [#1965](https://github.com/nf-core/tools/pull/1965))
 - `check_up_to_date()` function from `modules_json` also checks for subworkflows.
 - The default branch can now be specified when creating a new pipeline repo [#1959](https://github.com/nf-core/tools/pull/1959).
 - Only warn when checking that the pipeline directory contains a `main.nf` and a `nextflow.config` file if the pipeline is not an nf-core pipeline [#1964](https://github.com/nf-core/tools/pull/1964)

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -253,13 +253,12 @@ def download(pipeline, revision, outdir, compress, force, container, singularity
 @click.option("--json", is_flag=True, default=False, help="Print output in JSON")
 def licences(pipeline, json):
     """
-    List software licences for a given workflow (deprecated).
+    List software licences for a given workflow (DSL1 only).
 
-    Checks the pipeline environment.yml file which lists all conda software packages.
+    Checks the pipeline environment.yml file which lists all conda software packages, which is not available for DSL2 workflows. Therefore, this command only supports DSL1 workflows (for now).
     Each of these is queried against the anaconda.org API to find the licence.
     Package name, version and licence is printed to the command line.
     """
-    log.warning("`nf-core licences` does not support DSL2 pipelines and is being deprecated.")
 
     lic = nf_core.licences.WorkflowLicences(pipeline)
     lic.as_json = json

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -253,12 +253,14 @@ def download(pipeline, revision, outdir, compress, force, container, singularity
 @click.option("--json", is_flag=True, default=False, help="Print output in JSON")
 def licences(pipeline, json):
     """
-    List software licences for a given workflow.
+    List software licences for a given workflow (deprecated).
 
     Checks the pipeline environment.yml file which lists all conda software packages.
     Each of these is queried against the anaconda.org API to find the licence.
     Package name, version and licence is printed to the command line.
     """
+    log.warning("`nf-core licences` does not support DSL2 pipelines and is being deprecated.")
+
     lic = nf_core.licences.WorkflowLicences(pipeline)
     lic.as_json = json
     try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,3 +39,14 @@ def test_cli_bad_subcommand():
     assert result.exit_code == 2
     # Checks that -v was considered valid
     assert "No such command" in result.output
+
+
+@mock.patch("nf_core.list.list_workflows", return_value="pipeline test list")
+def test_cli_list(mock_list_workflows):
+    """Test nf-core pipelines are listed and cli parameters are passed on."""
+    runner = CliRunner()
+    result = runner.invoke(
+        nf_core.__main__.nf_core_cli, ["list", "--sort", "name", "--json", "--show-archived", "kw1", "kw2"]
+    )
+    mock_list_workflows.assert_called_once_with(("kw1", "kw2"), "name", True, True)
+    assert "pipeline test list" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -142,3 +142,34 @@ class TestCli(unittest.TestCase):
         cmd = ["launch", "pipeline_name"]
         result = self.invoke_cli(cmd)
         assert result.exit_code == 1
+
+    @mock.patch("nf_core.download.DownloadWorkflow")
+    def test_cli_download(self, mock_dl):
+        """Test nf-core pipeline is downloaded and cli parameters are passed on."""
+        params = {
+            "revision": "abcdef",
+            "outdir": "/path/outdir",
+            "compress": "tar.gz",
+            "force": None,
+            "container": "singularity",
+            "singularity-cache-only": None,
+            "parallel-downloads": 2,
+        }
+
+        cmd = ["download"] + self.assemble_params(params) + ["pipeline_name"]
+        result = self.invoke_cli(cmd)
+
+        assert result.exit_code == 0
+
+        mock_dl.assert_called_once_with(
+            cmd[-1],
+            params["revision"],
+            params["outdir"],
+            params["compress"],
+            "force" in params,
+            params["container"],
+            "singularity-cache-only" in params,
+            params["parallel-downloads"],
+        )
+
+        mock_dl.return_value.download_workflow.assert_called_once()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,11 +63,15 @@ class TestCli(unittest.TestCase):
         assert "Show the version and exit." in result.output
 
     def test_cli_bad_subcommand(self):
-        """Test the main launch function with verbose flag and an unrecognised argument"""
-        result = self.invoke_cli(["-v", "foo"])
+        """Test the main launch function with an unrecognised argument"""
+        result = self.invoke_cli(["foo"])
         assert result.exit_code == 2
+
+    def test_cli_verbose(self):
+        """Test the main launch function with verbose flag"""
+        result = self.invoke_cli(["-v"])
         # Checks that -v was considered valid
-        assert "No such command" in result.output
+        assert "No such option: -v" not in nf_core.utils.strip_ansi_codes(result.output)
 
     @mock.patch("nf_core.list.list_workflows", return_value="pipeline test list")
     def test_cli_list(self, mock_list_workflows):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,8 +45,14 @@ class TestCli(unittest.TestCase):
 
         Args:
             params (dict): dict of parameters to assemble"""
-        arg_list = [[f"--{key}"] + ([value] if value is not None else []) for key, value in params.items()]
-        return [item for arg in arg_list for item in arg]
+        arg_list = []
+        for key, value in params.items():
+            if value is not None:
+                arg_list += [f"--{key}", value]
+            else:
+                arg_list += [f"--{key}"]
+
+        return arg_list
 
     def invoke_cli(self, cmd):
         """Invoke the commandline interface using a list of parameters

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -78,6 +78,7 @@ class TestCli(unittest.TestCase):
         mock_list_workflows.assert_called_once_with(
             tuple(cmd[-2:]), params["sort"], "json" in params, "show-archived" in params
         )
+        assert result.exit_code == 0
         assert "pipeline test list" in result.output
 
     @mock.patch("nf_core.launch.Launch")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 """ Tests covering the command-line code.
+
+Most tests check the cli arguments are passed along and that some action is
+taken.
 """
 
 import tempfile

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,15 @@ def test_header(mock_cli):
     nf_core.__main__.run_nf_core()
 
 
+@mock.patch("nf_core.__main__.nf_core_cli")
+@mock.patch("nf_core.utils.check_if_outdated", return_value=(True, None, "dummy_version"))
+def test_header_outdated(mock_check_outdated, mock_nf_core_cli, capsys):
+    """Check cli notifies the user when nf_core is outdated"""
+    nf_core.__main__.run_nf_core()
+    captured = capsys.readouterr()
+    assert "There is a new version of nf-core/tools available! (dummy_version)" in captured.err
+
+
 def test_cli_help():
     """Test the main launch function with --help"""
     runner = CliRunner()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ from unittest import mock
 from click.testing import CliRunner
 
 import nf_core.__main__
+import nf_core.utils
 
 
 @mock.patch("nf_core.__main__.nf_core_cli")
@@ -132,7 +133,10 @@ class TestCli(unittest.TestCase):
         result = self.invoke_cli(cmd)
 
         assert result.exit_code == 2
-        assert f"Invalid value for '-p' / '--params-in': Path '{params['params-in']}' does not exist." in result.output
+        assert (
+            f"Invalid value for '-p' / '--params-in': Path '{params['params-in']}' does not exist."
+            in nf_core.utils.strip_ansi_codes(result.output)
+        )
 
         mock_launcher.assert_not_called()
 
@@ -289,7 +293,10 @@ class TestCli(unittest.TestCase):
         result = self.invoke_cli(cmd)
 
         assert result.exit_code == 2
-        assert f"Invalid value for '-d' / '--dir': Path '{params['dir']}' does not exist." in result.output
+        assert (
+            f"Invalid value for '-d' / '--dir': Path '{params['dir']}' does not exist."
+            in nf_core.utils.strip_ansi_codes(result.output)
+        )
 
     @mock.patch("nf_core.utils.is_pipeline_directory")
     def test_lint_dir_is_not_pipeline(self, mock_is_pipeline):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -329,7 +329,7 @@ class TestCli(unittest.TestCase):
 
     @mock.patch("nf_core.utils.is_pipeline_directory")
     @mock.patch("nf_core.lint.run_linting")
-    def test_lint_log_assert_error(self, mock_lint, mock_is_pipeline):
+    def test_lint_log_user_warning(self, mock_lint, mock_is_pipeline):
         """Test nf-core lint logs assertion errors"""
         error_txt = "AssertionError has been raised"
         mock_lint.side_effect = UserWarning(error_txt)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,8 @@
 """ Tests covering the command-line code.
 """
 
+import tempfile
+import unittest
 from unittest import mock
 
 from click.testing import CliRunner
@@ -24,29 +26,56 @@ def test_header_outdated(mock_check_outdated, mock_nf_core_cli, capsys):
     assert "There is a new version of nf-core/tools available! (dummy_version)" in captured.err
 
 
-def test_cli_help():
-    """Test the main launch function with --help"""
-    runner = CliRunner()
-    result = runner.invoke(nf_core.__main__.nf_core_cli, ["--help"])
-    assert result.exit_code == 0
-    assert "Show the version and exit." in result.output
+class TestCli(unittest.TestCase):
+    """Class for testing the commandline interface"""
 
+    def setUp(self):
+        self.runner = CliRunner()
 
-def test_cli_bad_subcommand():
-    """Test the main launch function with verbose flag and an unrecognised argument"""
-    runner = CliRunner()
-    result = runner.invoke(nf_core.__main__.nf_core_cli, ["-v", "foo"])
-    assert result.exit_code == 2
-    # Checks that -v was considered valid
-    assert "No such command" in result.output
+    def assemble_params(self, params):
+        """Assemble a dictionnary of parameters into a list of arguments for the cli
 
+        Note:
+            if the value of a parameter is None, it will be considered a flag
 
-@mock.patch("nf_core.list.list_workflows", return_value="pipeline test list")
-def test_cli_list(mock_list_workflows):
-    """Test nf-core pipelines are listed and cli parameters are passed on."""
-    runner = CliRunner()
-    result = runner.invoke(
-        nf_core.__main__.nf_core_cli, ["list", "--sort", "name", "--json", "--show-archived", "kw1", "kw2"]
-    )
-    mock_list_workflows.assert_called_once_with(("kw1", "kw2"), "name", True, True)
-    assert "pipeline test list" in result.output
+        Args:
+            params (dict): dict of parameters to assemble"""
+        arg_list = [[f"--{key}"] + ([value] if value is not None else []) for key, value in params.items()]
+        return [item for arg in arg_list for item in arg]
+
+    def invoke_cli(self, cmd):
+        """Invoke the commandline interface using a list of parameters
+
+        Args:
+            cmd (list): commandline to execute
+        """
+        return self.runner.invoke(nf_core.__main__.nf_core_cli, cmd)
+
+    def test_cli_help(self):
+        """Test the main launch function with --help"""
+        result = self.invoke_cli(["--help"])
+        assert result.exit_code == 0
+        assert "Show the version and exit." in result.output
+
+    def test_cli_bad_subcommand(self):
+        """Test the main launch function with verbose flag and an unrecognised argument"""
+        result = self.invoke_cli(["-v", "foo"])
+        assert result.exit_code == 2
+        # Checks that -v was considered valid
+        assert "No such command" in result.output
+
+    @mock.patch("nf_core.list.list_workflows", return_value="pipeline test list")
+    def test_cli_list(self, mock_list_workflows):
+        """Test nf-core pipelines are listed and cli parameters are passed on."""
+        params = {
+            "sort": "name",
+            "json": None,
+            "show-archived": None,
+        }
+        cmd = ["list"] + self.assemble_params(params) + ["kw1", "kw2"]
+        result = self.invoke_cli(cmd)
+
+        mock_list_workflows.assert_called_once_with(
+            tuple(cmd[-2:]), params["sort"], "json" in params, "show-archived" in params
+        )
+        assert "pipeline test list" in result.output


### PR DESCRIPTION
This PR adds unit test for the following commands: `list`, `launch`, `download`, `create` and `lint`.

The code of these commands is quite simple so what the tests do is mostly check that  no cli arguments are forgotten and that they are passed along to the correct function.

Related to #1937 

## PR checklist

- [X] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [X] If you've fixed a bug or added code that should be tested, add tests!

