### PR TITLE
remove useless shebang lines

### DIFF
--- a/nf_core/__init__.py
+++ b/nf_core/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """ Main nf_core module file.
 
 Shouldn't do much, as everything is under subcommands.

--- a/nf_core/bump_version.py
+++ b/nf_core/bump_version.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Bumps the version number in all appropriate files for
 a nf-core pipeline.
 """

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Creates a nf-core pipeline matching the current
 organization's specification based on a template.
 """

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Downloads a nf-core pipeline to the local file system."""
 
 from __future__ import print_function

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """ Launch a pipeline, interactively collecting params """
 
 from __future__ import print_function

--- a/nf_core/licences.py
+++ b/nf_core/licences.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Lists software licences for a given workflow."""
 
 from __future__ import print_function

--- a/nf_core/lint/__init__.py
+++ b/nf_core/lint/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Linting policy for nf-core pipeline projects.
 
 Tests Nextflow-based pipelines to check that they adhere to

--- a/nf_core/lint/actions_awsfulltest.py
+++ b/nf_core/lint/actions_awsfulltest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 
 import yaml

--- a/nf_core/lint/actions_awstest.py
+++ b/nf_core/lint/actions_awstest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 
 import yaml

--- a/nf_core/lint/actions_ci.py
+++ b/nf_core/lint/actions_ci.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 import re
 

--- a/nf_core/lint/actions_schema_validation.py
+++ b/nf_core/lint/actions_schema_validation.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import glob
 import logging
 import os

--- a/nf_core/lint/files_exist.py
+++ b/nf_core/lint/files_exist.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import logging
 import os
 

--- a/nf_core/lint/files_unchanged.py
+++ b/nf_core/lint/files_unchanged.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import filecmp
 import logging
 import os

--- a/nf_core/lint/merge_markers.py
+++ b/nf_core/lint/merge_markers.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import fnmatch
 import io
 import logging

--- a/nf_core/lint/modules_json.py
+++ b/nf_core/lint/modules_json.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from pathlib import Path
 
 from nf_core.modules.modules_json import ModulesJson

--- a/nf_core/lint/modules_structure.py
+++ b/nf_core/lint/modules_structure.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import logging
 import os
 from pathlib import Path

--- a/nf_core/lint/multiqc_config.py
+++ b/nf_core/lint/multiqc_config.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 
 import yaml

--- a/nf_core/lint/nextflow_config.py
+++ b/nf_core/lint/nextflow_config.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import logging
 import os
 import re

--- a/nf_core/lint/pipeline_name_conventions.py
+++ b/nf_core/lint/pipeline_name_conventions.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-
-
 def pipeline_name_conventions(self):
     """Checks that the pipeline name adheres to nf-core conventions.
 

--- a/nf_core/lint/pipeline_todos.py
+++ b/nf_core/lint/pipeline_todos.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import fnmatch
 import io
 import logging

--- a/nf_core/lint/readme.py
+++ b/nf_core/lint/readme.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 import re
 

--- a/nf_core/lint/schema_description.py
+++ b/nf_core/lint/schema_description.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import nf_core.schema
 
 

--- a/nf_core/lint/schema_lint.py
+++ b/nf_core/lint/schema_lint.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import logging
 
 import nf_core.schema

--- a/nf_core/lint/schema_params.py
+++ b/nf_core/lint/schema_params.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import nf_core.schema
 
 

--- a/nf_core/lint/template_strings.py
+++ b/nf_core/lint/template_strings.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import io
 import mimetypes
 import re

--- a/nf_core/lint/version_consistency.py
+++ b/nf_core/lint/version_consistency.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 
 

--- a/nf_core/list.py
+++ b/nf_core/list.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Lists available nf-core pipelines and versions."""
 
 from __future__ import print_function

--- a/nf_core/modules/create.py
+++ b/nf_core/modules/create.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 The ModuleCreate class handles generating of module templates
 """

--- a/nf_core/modules/lint/__init__.py
+++ b/nf_core/modules/lint/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Code for linting modules in the nf-core/modules repository and
 in nf-core pipelines

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Lint the main.nf file of a module
 """

--- a/nf_core/modules/lint/meta_yml.py
+++ b/nf_core/modules/lint/meta_yml.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from pathlib import Path
 
 import yaml

--- a/nf_core/modules/lint/module_deprecations.py
+++ b/nf_core/modules/lint/module_deprecations.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import logging
 import os
 

--- a/nf_core/modules/lint/module_todos.py
+++ b/nf_core/modules/lint/module_todos.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import logging
 
 from nf_core.lint.pipeline_todos import pipeline_todos

--- a/nf_core/modules/lint/module_version.py
+++ b/nf_core/modules/lint/module_version.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Verify that a module has a correct entry in the modules.json file
 """

--- a/nf_core/modules/modules_test.py
+++ b/nf_core/modules/modules_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 The ModulesTest class runs the tests locally
 """

--- a/nf_core/modules/test_yml_builder.py
+++ b/nf_core/modules/test_yml_builder.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 The ModulesTestYmlBuilder class handles automatic generation of the modules test.yml file
 along with running the tests and creating md5 sums

--- a/nf_core/refgenie.py
+++ b/nf_core/refgenie.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Update a nextflow.config file with refgenie genomes
 """

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """ Code to deal with pipeline JSON Schema """
 
 from __future__ import print_function

--- a/nf_core/subworkflows/create.py
+++ b/nf_core/subworkflows/create.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 The SubworkflowCreate class handles generating of subworkflow templates
 """

--- a/nf_core/subworkflows/test_yml_builder.py
+++ b/nf_core/subworkflows/test_yml_builder.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 The ModulesTestYmlBuilder class handles automatic generation of the modules test.yml file
 along with running the tests and creating md5 sums

--- a/nf_core/sync.py
+++ b/nf_core/sync.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Synchronise a pipeline TEMPLATE branch with the template.
 """
 

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Common utility functions for the nf-core python package.
 """

--- a/tests/lint/actions_awsfulltest.py
+++ b/tests/lint/actions_awsfulltest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 
 import yaml

--- a/tests/lint/actions_awstest.py
+++ b/tests/lint/actions_awstest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 
 import yaml

--- a/tests/lint/actions_ci.py
+++ b/tests/lint/actions_ci.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 
 import yaml

--- a/tests/lint/actions_schema_validation.py
+++ b/tests/lint/actions_schema_validation.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 
 import yaml

--- a/tests/lint/files_exist.py
+++ b/tests/lint/files_exist.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 
 import nf_core.lint

--- a/tests/lint/merge_markers.py
+++ b/tests/lint/merge_markers.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 
 import nf_core.lint

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Some tests covering the bump_version code.
 """
 import os

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """ Tests covering the command-line code.
 
 Most tests check the cli arguments are passed along and that some action is

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Some tests covering the pipeline creation sub command.
 """
 import os

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Tests for the download subcommand of nf-core tools
 """
 

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """ Tests covering the pipeline launch code.
 """
 

--- a/tests/test_licenses.py
+++ b/tests/test_licenses.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Some tests covering the pipeline creation sub command.
 """
 # import json

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Some tests covering the linting code.
 """
 import fnmatch

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """ Tests covering the workflow listing code.
 """
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """ Tests covering the modules commands
 """
 

--- a/tests/test_refgenie.py
+++ b/tests/test_refgenie.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """ Tests covering the refgenie integration code
 """
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """ Tests covering the pipeline schema code.
 """
 

--- a/tests/test_subworkflows.py
+++ b/tests/test_subworkflows.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """ Tests covering the subworkflows commands
 """
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """ Tests covering the sync command
 """
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """ Tests covering for utility functions.
 """
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 Helper functions for tests
 """


### PR DESCRIPTION
The shebang lines are useful for python files which are run as scripts in the console. Many of the files in a package are not. This PR removes the shebang line from the files that do not serve as scripts.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
