### PR TITLE
Minimal ci runs

### DIFF
--- a/.github/workflows/create-lint-wf.yml
+++ b/.github/workflows/create-lint-wf.yml
@@ -1,5 +1,11 @@
 name: Create a pipeline and run nf-core linting
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+  release:
+    types: [published]
 
 # Cancel if a newer run is started
 concurrency:

--- a/.github/workflows/create-test-wf.yml
+++ b/.github/workflows/create-test-wf.yml
@@ -1,5 +1,11 @@
 name: Create a pipeline and test it
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+  release:
+    types: [published]
 
 # Cancel if a newer run is started
 concurrency:

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -1,5 +1,11 @@
 name: Lint tools code formatting
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+  release:
+    types: [published]
 
 # Cancel if a newer run is started
 concurrency:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,7 +3,11 @@ name: Python tests
 # Only run if we changed a Python file
 on:
   push:
+    branches:
+      - dev
   pull_request:
+  release:
+    types: [published]
 
 # Cancel if a newer run is started
 concurrency:

--- a/.github/workflows/tools-api-docs-dev.yml
+++ b/.github/workflows/tools-api-docs-dev.yml
@@ -1,6 +1,12 @@
 name: nf-core/tools dev API docs
 # Run on push and PR to test that docs build
-on: [pull_request, push]
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+  release:
+    types: [published]
 
 # Cancel if a newer run is started
 concurrency:

--- a/nf_core/pipeline-template/.github/workflows/linting.yml
+++ b/nf_core/pipeline-template/.github/workflows/linting.yml
@@ -4,6 +4,8 @@ name: nf-core linting
 # that the code meets the nf-core guidelines. {%- raw %}
 on:
   push:
+    branches:
+      - dev
   pull_request:
   release:
     types: [published]


### PR DESCRIPTION
This has been floating around. What it does is:
- Run when code is merged into dev
- Run *once* when a PR is created
- Run on a release(since it doesn't happen often we might as well check)

What this prevents:
- The same CI jobs running *twice* on a PR
- CI running whenever someone pushes code they're working on that isn't
a PR

https://github.com/orgs/community/discussions/26276 full explanation