### PR TITLE
Update Gitpod dockerfile

### DIFF
--- a/nf_core/gitpod/gitpod.Dockerfile
+++ b/nf_core/gitpod/gitpod.Dockerfile
@@ -27,6 +27,7 @@ RUN conda update -n base -c defaults conda && \
     conda install \
         openjdk=11.0.15 \
         nextflow=22.10.0 \
+        nf-test=0.7.0 \
         pytest-workflow=1.6.0 \
         mamba=0.27.0 \
         pip=22.3 \

--- a/nf_core/gitpod/gitpod.Dockerfile
+++ b/nf_core/gitpod/gitpod.Dockerfile
@@ -25,7 +25,7 @@ RUN conda update -n base -c defaults conda && \
     conda config --add channels bioconda && \
     conda config --add channels conda-forge && \
     conda install \
-        openjdk=11.0.15 \
+        openjdk=17.0.3 \
         nextflow=22.10.0 \
         nf-test=0.7.0 \
         pytest-workflow=1.6.0 \

--- a/nf_core/gitpod/gitpod.Dockerfile
+++ b/nf_core/gitpod/gitpod.Dockerfile
@@ -26,7 +26,7 @@ RUN conda update -n base -c defaults conda && \
     conda config --add channels conda-forge && \
     conda install \
         openjdk=11.0.15 \
-        nextflow=22.04.0 \
+        nextflow=22.10.0 \
         pytest-workflow=1.6.0 \
         mamba=0.24.0 \
         pip=22.1.2 \

--- a/nf_core/gitpod/gitpod.Dockerfile
+++ b/nf_core/gitpod/gitpod.Dockerfile
@@ -30,7 +30,7 @@ RUN conda update -n base -c defaults conda && \
         pytest-workflow=1.6.0 \
         mamba=0.27.0 \
         pip=22.3 \
-        black=22.6.0 \
+        black=22.10.0 \
         prettier=2.7.1 \
         -n base && \
     conda clean --all -f -y

--- a/nf_core/gitpod/gitpod.Dockerfile
+++ b/nf_core/gitpod/gitpod.Dockerfile
@@ -29,7 +29,7 @@ RUN conda update -n base -c defaults conda && \
         nextflow=22.10.0 \
         pytest-workflow=1.6.0 \
         mamba=0.27.0 \
-        pip=22.1.2 \
+        pip=22.3 \
         black=22.6.0 \
         prettier=2.7.1 \
         -n base && \

--- a/nf_core/gitpod/gitpod.Dockerfile
+++ b/nf_core/gitpod/gitpod.Dockerfile
@@ -28,7 +28,7 @@ RUN conda update -n base -c defaults conda && \
         openjdk=11.0.15 \
         nextflow=22.10.0 \
         pytest-workflow=1.6.0 \
-        mamba=0.24.0 \
+        mamba=0.27.0 \
         pip=22.1.2 \
         black=22.6.0 \
         prettier=2.7.1 \


### PR DESCRIPTION
Update's Gitpod dockerfile
- openjdk: 11.0.15 -> 17.0.3
- nextflow: 22.04.0 -> 22.10.0
- add nf-test
- mamba: 0.24.0 -> 0.27.0
- pip: 22.1.2 -> 22.3
- black: 22.6.0 -> 22.10.0

Container builds successfully inside Gitpod.
`nf-core create` works inside the container as does `nextflow run main.nf -profile test,mamba,gitpod`. 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
