### PR TITLE
Fix params-in functionality in `nf-core launch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Mock biocontainers and anaconda api calls in modules and subworkflows tests [#1967](https://github.com/nf-core/tools/pull/1967)
 - Run tests with Python 3.11 ([#1970](https://github.com/nf-core/tools/pull/1970))
 - Bump promoted Python version from 3.7 to 3.8 ([#1971](https://github.com/nf-core/tools/pull/1971))
+- Fix incorrect file deletion in `nf-core launch` when `--params_in` has the same name as `--params_out`
 
 ### Modules
 

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -120,13 +120,19 @@ class Launch(object):
 
         # Check if the output file exists already
         if os.path.exists(self.params_out):
-            log.warning(f"Parameter output file already exists! {os.path.relpath(self.params_out)}")
-            if Confirm.ask("[yellow]Do you want to overwrite this file?"):
-                os.remove(self.params_out)
-                log.info(f"Deleted {self.params_out}\n")
+            # if params_in has the same name as params_out, don't ask to overwrite
+            if self.params_in and os.path.abspath(self.params_in) == os.path.abspath(self.params_out):
+                log.warning(
+                    f"The parameter input file has the same name as the output file! {os.path.relpath(self.params_out)} will be overwritten."
+                )
             else:
-                log.info("Exiting. Use --params-out to specify a custom filename.")
-                return False
+                log.warning(f"Parameter output file already exists! {os.path.relpath(self.params_out)}")
+                if Confirm.ask("[yellow]Do you want to overwrite this file?"):
+                    os.remove(self.params_out)
+                    log.info(f"Deleted {self.params_out}\n")
+                else:
+                    log.info("Exiting. Use --params-out to specify a custom filename.")
+                    return False
 
         log.info(
             "NOTE: This tool ignores any pipeline parameter defaults overwritten by Nextflow config files or profiles\n"
@@ -716,6 +722,6 @@ class Launch(object):
         """Launch nextflow if required"""
         log.info(f"[bold underline]Nextflow command:[/]\n[magenta]{self.nextflow_cmd}\n\n")
 
-        if Confirm.ask("Do you want to run this command now? "):
+        if Confirm.ask("Do you want to run this command now? ", default=True):
             log.info("Launching workflow! :rocket:")
             subprocess.call(self.nextflow_cmd, shell=True)

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -127,12 +127,13 @@ class Launch(object):
                 )
             else:
                 log.warning(f"Parameter output file already exists! {os.path.relpath(self.params_out)}")
-                if Confirm.ask("[yellow]Do you want to overwrite this file?"):
+            if Confirm.ask("[yellow]Do you want to overwrite this file?"):
+                if not (self.params_in and os.path.abspath(self.params_in) == os.path.abspath(self.params_out)):
                     os.remove(self.params_out)
                     log.info(f"Deleted {self.params_out}\n")
-                else:
-                    log.info("Exiting. Use --params-out to specify a custom filename.")
-                    return False
+            else:
+                log.info("Exiting. Use --params-out to specify a custom output filename.")
+                return False
 
         log.info(
             "NOTE: This tool ignores any pipeline parameter defaults overwritten by Nextflow config files or profiles\n"


### PR DESCRIPTION
Skip the deletion step of `--params_in`, if `--params_in` == `--params_out`.

Fixes #1969.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
