### PR TITLE
fix deprecation warnings for python and github actions

### DIFF
--- a/.github/workflows/create-lint-wf.yml
+++ b/.github/workflows/create-lint-wf.yml
@@ -48,7 +48,7 @@ jobs:
           version: ${{ matrix.NXF_VER }}
 
       # Install the Prettier linting tools
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
 
       - name: Install Prettier
         run: npm install -g prettier

--- a/.github/workflows/create-lint-wf.yml
+++ b/.github/workflows/create-lint-wf.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload log file artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: nf-core-log-file
           path: log.txt

--- a/.github/workflows/create-test-wf.yml
+++ b/.github/workflows/create-test-wf.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Upload log file artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: nf-core-log-file
           path: log.txt

--- a/.github/workflows/fix-linting.yml
+++ b/.github/workflows/fix-linting.yml
@@ -39,7 +39,7 @@ jobs:
           options: "--color"
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: python-isort

--- a/.github/workflows/fix-linting.yml
+++ b/.github/workflows/fix-linting.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.nf_core_bot_auth_token }}
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
 
       - name: Install Prettier
         run: npm install -g prettier @prettier/plugin-php
@@ -43,7 +43,7 @@ jobs:
         with:
           python-version: 3.8
       - name: python-isort
-        uses: isort/isort-action@v0.1.0
+        uses: isort/isort-action@v1.0.0
         with:
           isortVersion: "latest"
           requirementsFiles: "requirements.txt requirements-dev.txt"

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: python-isort

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
 
       - name: Install editorconfig-checker
         run: npm install -g editorconfig-checker
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
 
       - name: Install Prettier
         run: npm install -g prettier
@@ -81,7 +81,7 @@ jobs:
         with:
           python-version: 3.8
       - name: python-isort
-        uses: isort/isort-action@v0.1.0
+        uses: isort/isort-action@v1.0.0
         with:
           isortVersion: "latest"
           requirementsFiles: "requirements.txt requirements-dev.txt"

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -27,7 +27,7 @@ jobs:
           else
             curl -O https://nf-co.re/pipeline_names.json
           fi
-          echo "::set-output name=matrix::$(cat pipeline_names.json)"
+          echo "name=matrix::$(cat pipeline_names.json)" >> $GITHUB_OUTPUT
 
   sync:
     needs: get-pipelines
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload sync log file artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: sync_log_${{ matrix.pipeline }}
           path: sync_log_${{ matrix.pipeline }}.txt

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -3,7 +3,6 @@
 organization's specification based on a template.
 """
 import configparser
-import imghdr
 import logging
 import os
 import random
@@ -13,6 +12,7 @@ import sys
 import time
 from pathlib import Path
 
+import filetype
 import git
 import jinja2
 import questionary
@@ -492,7 +492,7 @@ class PipelineCreate(object):
             with open(img_fn, "wb") as fh:
                 fh.write(r.content)
             # Check that the file looks valid
-            image_type = imghdr.what(img_fn)
+            image_type = filetype.guess(img_fn).extension
             if image_type != "png":
                 log.error(f"Logo from the website didn't look like an image: '{image_type}'")
                 continue

--- a/nf_core/pipeline-template/.github/workflows/fix-linting.yml
+++ b/nf_core/pipeline-template/.github/workflows/fix-linting.yml
@@ -34,9 +34,9 @@ jobs:
         id: prettier_status
         run: |
           if prettier --check ${GITHUB_WORKSPACE}; then
-            echo "::set-output name=result::pass"
+            echo "name=result::pass" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=result::fail"
+            echo "name=result::fail" >> $GITHUB_OUTPUT
           fi
 
       - name: Run 'prettier --write'

--- a/nf_core/pipeline-template/.github/workflows/fix-linting.yml
+++ b/nf_core/pipeline-template/.github/workflows/fix-linting.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.nf_core_bot_auth_token }}
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
 
       - name: Install Prettier
         run: npm install -g prettier @prettier/plugin-php

--- a/nf_core/pipeline-template/.github/workflows/linting.yml
+++ b/nf_core/pipeline-template/.github/workflows/linting.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload linting log file artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: linting-logs
           path: |

--- a/nf_core/pipeline-template/.github/workflows/linting.yml
+++ b/nf_core/pipeline-template/.github/workflows/linting.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
 
       - name: Install editorconfig-checker
         run: npm install -g editorconfig-checker
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
 
       - name: Install Prettier
         run: npm install -g prettier

--- a/nf_core/pipeline-template/.github/workflows/linting_comment.yml
+++ b/nf_core/pipeline-template/.github/workflows/linting_comment.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Get PR number
         id: pr_number
-        run: echo "::set-output name=pr_number::$(cat linting-logs/PR_number.txt)"
+        run: echo "name=pr_number::$(cat linting-logs/PR_number.txt)" >> $GITHUB_OUTPUT
 
       - name: Post PR comment
         uses: marocchino/sticky-pull-request-comment@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 click
+filetype
 galaxy-tool-util
 GitPython
 jinja2


### PR DESCRIPTION
Python:
imghdr -> filetype [PEP-594](https://peps.python.org/pep-0594/#imghdr

GH-Actions:
update `upload-artifact`, `isort-action`, `setup-node`, `setup-python`
switch to new style for `::set-output`
