### PR TITLE
Track from where modules and subworkflows are installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Run tests with Python 3.11 ([#1970](https://github.com/nf-core/tools/pull/1970))
 - Bump promoted Python version from 3.7 to 3.8 ([#1971](https://github.com/nf-core/tools/pull/1971))
 - Fix incorrect file deletion in `nf-core launch` when `--params_in` has the same name as `--params_out`
+- Track from where modules and subworkflows are installed ([#1999](https://github.com/nf-core/tools/pull/1999))
 
 ### Modules
 

--- a/docs/api/make_lint_md.py
+++ b/docs/api/make_lint_md.py
@@ -21,7 +21,6 @@ def make_docs(docs_basedir, lint_tests, md_template):
         else:
             with open(fn, "w") as fh:
                 fh.write(md_template.format(test_name))
-                print(test_name)
 
     for fn in existing_docs:
         os.remove(fn)

--- a/nf_core/components/components_create.py
+++ b/nf_core/components/components_create.py
@@ -99,7 +99,6 @@ def get_component_dirs(component_type, repo_type, directory, name, supername, su
         # Check whether component file already exists
         component_file = os.path.join(local_component_dir, f"{name}.nf")
         if os.path.exists(component_file) and not force_overwrite:
-            print(f"{component_type[:-1].title()} file exists already: '{component_file}'. Use '--force' to overwrite")
             raise UserWarning(
                 f"{component_type[:-1].title()} file exists already: '{component_file}'. Use '--force' to overwrite"
             )

--- a/nf_core/components/components_install.py
+++ b/nf_core/components/components_install.py
@@ -93,11 +93,11 @@ def clean_modules_json(component, component_type, modules_repo, modules_json):
     """
     for repo_url, repo_content in modules_json.modules_json["repos"].items():
         for dir, dir_components in repo_content[component_type].items():
-            for name, _ in dir_components.items():
+            for name, component_values in dir_components.items():
                 if name == component and dir == modules_repo.repo_path:
                     repo_to_remove = repo_url
                     log.info(
                         f"Removing {component_type[:-1]} '{modules_repo.repo_path}/{component}' from repo '{repo_to_remove}' from modules.json"
                     )
                     modules_json.remove_entry(component_type, component, repo_to_remove, modules_repo.repo_path)
-                    return
+                    return component_values["installed"]

--- a/nf_core/components/components_install.py
+++ b/nf_core/components/components_install.py
@@ -1,12 +1,7 @@
-import glob
-import json
 import logging
 import os
-import re
 
-import jinja2
 import questionary
-import rich
 
 import nf_core.modules.modules_utils
 import nf_core.utils
@@ -76,7 +71,7 @@ def get_version(component, component_type, sha, prompt, current_version, modules
         version = sha
     elif prompt:
         try:
-            version = nf_core.modules.modules_utils.prompt_component_version_sha(
+            version = prompt_component_version_sha(
                 component,
                 component_type,
                 installed_sha=current_version,

--- a/nf_core/components/components_install.py
+++ b/nf_core/components/components_install.py
@@ -100,4 +100,4 @@ def clean_modules_json(component, component_type, modules_repo, modules_json):
                         f"Removing {component_type[:-1]} '{modules_repo.repo_path}/{component}' from repo '{repo_to_remove}' from modules.json"
                     )
                     modules_json.remove_entry(component_type, component, repo_to_remove, modules_repo.repo_path)
-                    return component_values["installed"]
+                    return component_values["installed_by"]

--- a/nf_core/components/components_install.py
+++ b/nf_core/components/components_install.py
@@ -99,5 +99,5 @@ def clean_modules_json(component, component_type, modules_repo, modules_json):
                     log.info(
                         f"Removing {component_type[:-1]} '{modules_repo.repo_path}/{component}' from repo '{repo_to_remove}' from modules.json"
                     )
-                    modules_json.remove_entry(component, repo_to_remove, modules_repo.repo_path)
+                    modules_json.remove_entry(component_type, component, repo_to_remove, modules_repo.repo_path)
                     return

--- a/nf_core/components/components_install.py
+++ b/nf_core/components/components_install.py
@@ -100,4 +100,4 @@ def clean_modules_json(component, component_type, modules_repo, modules_json):
                         f"Removing {component_type[:-1]} '{modules_repo.repo_path}/{component}' from repo '{repo_to_remove}' from modules.json"
                     )
                     modules_json.remove_entry(component, repo_to_remove, modules_repo.repo_path)
-                    break
+                    return

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -90,15 +90,15 @@ class ModuleInstall(ModuleCommand):
         if self.force:
             log.info(f"Removing installed version of '{self.modules_repo.repo_path}/{module}'")
             self.clear_component_dir(module, module_dir)
-            nf_core.components.components_install.clean_modules_json(
-                module, self.component_type, self.modules_repo, modules_json
-            )
 
         log.info(f"{'Rei' if self.force else 'I'}nstalling '{module}'")
         log.debug(f"Installing module '{module}' at modules hash {version} from {self.modules_repo.remote_url}")
 
         # Download module files
         if not self.install_component_files(module, version, self.modules_repo, install_folder):
+            nf_core.components.components_install.clean_modules_json(
+                module, self.component_type, self.modules_repo, modules_json
+            )
             return False
 
         if not silent:

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -73,6 +73,11 @@ class ModuleInstall(ModuleCommand):
         if not nf_core.components.components_install.check_component_installed(
             self.component_type, module, current_version, module_dir, self.modules_repo, self.force, self.prompt
         ):
+            log.debug(
+                f"Module is already installed and force is not set.\nAdding the new installation source {self.installed_by} for module {module} to 'modules.json' without installing the module."
+            )
+            modules_json.load()
+            modules_json.update(self.modules_repo, module, current_version, self.installed_by)
             return False
 
         version = nf_core.components.components_install.get_version(

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -1,15 +1,12 @@
 import logging
 import os
 
-import questionary
-
 import nf_core.components.components_install
 import nf_core.modules.modules_utils
 import nf_core.utils
 from nf_core.modules.modules_json import ModulesJson
 
 from .modules_command import ModuleCommand
-from .modules_repo import NF_CORE_MODULES_NAME
 
 log = logging.getLogger(__name__)
 

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -87,18 +87,19 @@ class ModuleInstall(ModuleCommand):
             return False
 
         # Remove module if force is set
+        install_track = None
         if self.force:
             log.info(f"Removing installed version of '{self.modules_repo.repo_path}/{module}'")
             self.clear_component_dir(module, module_dir)
+            install_track = nf_core.components.components_install.clean_modules_json(
+                module, self.component_type, self.modules_repo, modules_json
+            )
 
         log.info(f"{'Rei' if self.force else 'I'}nstalling '{module}'")
         log.debug(f"Installing module '{module}' at modules hash {version} from {self.modules_repo.remote_url}")
 
         # Download module files
         if not self.install_component_files(module, version, self.modules_repo, install_folder):
-            nf_core.components.components_install.clean_modules_json(
-                module, self.component_type, self.modules_repo, modules_json
-            )
             return False
 
         if not silent:
@@ -110,5 +111,5 @@ class ModuleInstall(ModuleCommand):
 
         # Update module.json with newly installed module
         modules_json.load()
-        modules_json.update(self.modules_repo, module, version, self.installed_by)
+        modules_json.update(self.modules_repo, module, version, self.installed_by, install_track)
         return True

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -21,11 +21,16 @@ class ModuleInstall(ModuleCommand):
         remote_url=None,
         branch=None,
         no_pull=False,
+        installed_by=False,
     ):
         super().__init__(pipeline_dir, remote_url, branch, no_pull)
         self.force = force
         self.prompt = prompt
         self.sha = sha
+        if installed_by:
+            self.installed_by = installed_by
+        else:
+            self.installed_by = self.component_type
 
     def install(self, module, silent=False):
         if self.repo_type == "modules":
@@ -100,5 +105,5 @@ class ModuleInstall(ModuleCommand):
 
         # Update module.json with newly installed module
         modules_json.load()
-        modules_json.update(self.modules_repo, module, version)
+        modules_json.update(self.modules_repo, module, version, self.installed_by)
         return True

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -373,25 +373,32 @@ class ModulesJson:
             component_in_file = False
             git_url = None
             for repo in missing_installation:
-                for dir_name in missing_installation[repo][component_type]:
-                    if component in missing_installation[repo][component_type][dir_name]:
-                        component_in_file = True
-                        git_url = repo
-                        break
+                if component_type in missing_installation[repo]:
+                    for dir_name in missing_installation[repo][component_type]:
+                        if component in missing_installation[repo][component_type][dir_name]:
+                            component_in_file = True
+                            git_url = repo
+                            break
             if not component_in_file:
-                # If it is not, add it to the list of missing subworkflow
+                # If it is not, add it to the list of missing components
                 untracked_dirs.append(component)
 
             else:
-                # If it does, remove the subworkflow from missing_installation
+                # If it does, remove the component from missing_installation
                 module_repo = missing_installation[git_url]
                 # Check if the entry has a git sha and branch before removing
                 components_dict = module_repo[component_type][install_dir]
                 if "git_sha" not in components_dict[component] or "branch" not in components_dict[component]:
                     self.determine_module_branches_and_shas(component, git_url, module_repo["base_path"], [component])
-                # Remove the subworkflow from subworkflows without installation
+                # Remove the component from components without installation
                 module_repo[component_type][install_dir].pop(component)
                 if len(module_repo[component_type][install_dir]) == 0:
+                    # If no modules/subworkflows with missing installation left, remove the install_dir from missing_installation
+                    missing_installation[git_url][component_type].pop(install_dir)
+                if len(module_repo[component_type]) == 0:
+                    # If no modules/subworkflows with missing installation left, remove the component_type from missing_installation
+                    missing_installation[git_url].pop(component_type)
+                if len(module_repo) == 0:
                     # If no modules/subworkflows with missing installation left, remove the git_url from missing_installation
                     missing_installation.pop(git_url)
 

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -518,7 +518,7 @@ class ModulesJson:
         except FileNotFoundError:
             raise UserWarning("File 'modules.json' is missing")
 
-    def update(self, modules_repo, module_name, module_version, write_file=True):
+    def update(self, modules_repo, module_name, module_version, installed_by, write_file=True):
         """
         Updates the 'module.json' file with new module info
 
@@ -540,13 +540,17 @@ class ModulesJson:
             repo_modules_entry[module_name] = {}
         repo_modules_entry[module_name]["git_sha"] = module_version
         repo_modules_entry[module_name]["branch"] = branch
+        try:
+            repo_modules_entry[module_name]["installed"].add(installed_by)
+        except KeyError:
+            repo_modules_entry[module_name]["installed"] = set(installed_by)
 
         # Sort the 'modules.json' repo entries
         self.modules_json["repos"] = nf_core.utils.sort_dictionary(self.modules_json["repos"])
         if write_file:
             self.dump()
 
-    def update_subworkflow(self, modules_repo, subworkflow_name, subworkflow_version, write_file=True):
+    def update_subworkflow(self, modules_repo, subworkflow_name, subworkflow_version, installed_by, write_file=True):
         """
         Updates the 'module.json' file with new subworkflow info
 
@@ -571,6 +575,10 @@ class ModulesJson:
             repo_subworkflows_entry[subworkflow_name] = {}
         repo_subworkflows_entry[subworkflow_name]["git_sha"] = subworkflow_version
         repo_subworkflows_entry[subworkflow_name]["branch"] = branch
+        try:
+            repo_subworkflows_entry[subworkflow_name]["installed"].add(installed_by)
+        except KeyError:
+            repo_subworkflows_entry[subworkflow_name]["installed"] = set(installed_by)
 
         # Sort the 'modules.json' repo entries
         self.modules_json["repos"] = nf_core.utils.sort_dictionary(self.modules_json["repos"])

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -597,12 +597,13 @@ class ModulesJson:
         if write_file:
             self.dump()
 
-    def remove_entry(self, module_name, repo_url, install_dir):
+    def remove_entry(self, component_type, name, repo_url, install_dir):
         """
         Removes an entry from the 'modules.json' file.
 
         Args:
-            module_name (str): Name of the module to be removed
+            component_type (Str): Type of component [modules, subworkflows]
+            name (str): Name of the module to be removed
             repo_url (str): URL of the repository containing the module
             install_dir (str): Name of the directory where modules are installed
         Returns:
@@ -612,15 +613,17 @@ class ModulesJson:
             return False
         if repo_url in self.modules_json.get("repos", {}):
             repo_entry = self.modules_json["repos"][repo_url]
-            if module_name in repo_entry["modules"].get(install_dir, {}):
-                repo_entry["modules"][install_dir].pop(module_name)
+            if name in repo_entry[component_type].get(install_dir, {}):
+                repo_entry[component_type][install_dir].pop(name)
             else:
-                log.warning(f"Module '{install_dir}/{module_name}' is missing from 'modules.json' file.")
+                log.warning(
+                    f"{component_type[:-1].title()} '{install_dir}/{name}' is missing from 'modules.json' file."
+                )
                 return False
-            if len(repo_entry["modules"][install_dir]) == 0:
+            if len(repo_entry[component_type][install_dir]) == 0:
                 self.modules_json["repos"].pop(repo_url)
         else:
-            log.warning(f"Module '{install_dir}/{module_name}' is missing from 'modules.json' file.")
+            log.warning(f"{component_type[:-1].title()} '{install_dir}/{name}' is missing from 'modules.json' file.")
             return False
 
         self.dump()

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -277,7 +277,7 @@ class ModulesJson:
                 repo_entry[module] = {
                     "branch": modules_repo.branch,
                     "git_sha": correct_commit_sha,
-                    "installed": "modules",
+                    "installed_by": "modules",
                 }
 
         # Clean up the modules we were unable to find the sha for
@@ -481,7 +481,7 @@ class ModulesJson:
         If a module/subworkflow is installed but the entry in 'modules.json' is missing we iterate through
         the commit log in the remote to try to determine the SHA.
 
-        Check that we have the "installed" value in 'modules.json', otherwise add it.
+        Check that we have the "installed_by" value in 'modules.json', otherwise add it.
         Assume that the modules/subworkflows were installed by and nf-core command (don't track installed by subworkflows).
         """
         try:
@@ -517,13 +517,13 @@ class ModulesJson:
         if len(subworkflows_missing_from_modules_json) > 0:
             self.resolve_missing_from_modules_json(subworkflows_missing_from_modules_json, "subworkflows")
 
-        # If the "installed" value is not present for modules/subworkflows, add it.
+        # If the "installed_by" value is not present for modules/subworkflows, add it.
         for repo, repo_content in self.modules_json["repos"].items():
             for component_type, dir_content in repo_content.items():
                 for install_dir, installed_components in dir_content.items():
                     for component, component_features in installed_components.items():
-                        if "installed" not in component_features:
-                            self.modules_json["repos"][repo][component_type][install_dir][component]["installed"] = [
+                        if "installed_by" not in component_features:
+                            self.modules_json["repos"][repo][component_type][install_dir][component]["installed_by"] = [
                                 component_type
                             ]
 
@@ -572,12 +572,12 @@ class ModulesJson:
         repo_modules_entry[module_name]["git_sha"] = module_version
         repo_modules_entry[module_name]["branch"] = branch
         try:
-            if installed_by not in repo_modules_entry[module_name]["installed"]:
-                repo_modules_entry[module_name]["installed"].append(installed_by)
+            if installed_by not in repo_modules_entry[module_name]["installed_by"]:
+                repo_modules_entry[module_name]["installed_by"].append(installed_by)
         except KeyError:
-            repo_modules_entry[module_name]["installed"] = [installed_by]
+            repo_modules_entry[module_name]["installed_by"] = [installed_by]
         finally:
-            repo_modules_entry[module_name]["installed"].extend(installed_by_log)
+            repo_modules_entry[module_name]["installed_by"].extend(installed_by_log)
 
         # Sort the 'modules.json' repo entries
         self.modules_json["repos"] = nf_core.utils.sort_dictionary(self.modules_json["repos"])
@@ -616,12 +616,12 @@ class ModulesJson:
         repo_subworkflows_entry[subworkflow_name]["git_sha"] = subworkflow_version
         repo_subworkflows_entry[subworkflow_name]["branch"] = branch
         try:
-            if installed_by not in repo_subworkflows_entry[subworkflow_name]["installed"]:
-                repo_subworkflows_entry[subworkflow_name]["installed"].append(installed_by)
+            if installed_by not in repo_subworkflows_entry[subworkflow_name]["installed_by"]:
+                repo_subworkflows_entry[subworkflow_name]["installed_by"].append(installed_by)
         except KeyError:
-            repo_subworkflows_entry[subworkflow_name]["installed"] = [installed_by]
+            repo_subworkflows_entry[subworkflow_name]["installed_by"] = [installed_by]
         finally:
-            repo_subworkflows_entry[subworkflow_name]["installed"].extend(installed_by_log)
+            repo_subworkflows_entry[subworkflow_name]["installed_by"].extend(installed_by_log)
 
         # Sort the 'modules.json' repo entries
         self.modules_json["repos"] = nf_core.utils.sort_dictionary(self.modules_json["repos"])

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -482,7 +482,7 @@ class ModulesJson:
         the commit log in the remote to try to determine the SHA.
 
         Check that we have the "installed_by" value in 'modules.json', otherwise add it.
-        Assume that the modules/subworkflows were installed by and nf-core command (don't track installed by subworkflows).
+        Assume that the modules/subworkflows were installed by an nf-core command (don't track installed by subworkflows).
         """
         try:
             self.load()

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -541,9 +541,10 @@ class ModulesJson:
         repo_modules_entry[module_name]["git_sha"] = module_version
         repo_modules_entry[module_name]["branch"] = branch
         try:
-            repo_modules_entry[module_name]["installed"].add(installed_by)
+            if installed_by not in repo_modules_entry[module_name]["installed"]:
+                repo_modules_entry[module_name]["installed"].append(installed_by)
         except KeyError:
-            repo_modules_entry[module_name]["installed"] = set(installed_by)
+            repo_modules_entry[module_name]["installed"] = [installed_by]
 
         # Sort the 'modules.json' repo entries
         self.modules_json["repos"] = nf_core.utils.sort_dictionary(self.modules_json["repos"])
@@ -576,9 +577,10 @@ class ModulesJson:
         repo_subworkflows_entry[subworkflow_name]["git_sha"] = subworkflow_version
         repo_subworkflows_entry[subworkflow_name]["branch"] = branch
         try:
-            repo_subworkflows_entry[subworkflow_name]["installed"].add(installed_by)
+            if installed_by not in repo_subworkflows_entry[subworkflow_name]["installed"]:
+                repo_subworkflows_entry[subworkflow_name]["installed"].append(installed_by)
         except KeyError:
-            repo_subworkflows_entry[subworkflow_name]["installed"] = set(installed_by)
+            repo_subworkflows_entry[subworkflow_name]["installed"] = [installed_by]
 
         # Sort the 'modules.json' repo entries
         self.modules_json["repos"] = nf_core.utils.sort_dictionary(self.modules_json["repos"])

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -476,6 +476,9 @@ class ModulesJson:
 
         If a module/subworkflow is installed but the entry in 'modules.json' is missing we iterate through
         the commit log in the remote to try to determine the SHA.
+
+        Check that we have the "installed" value in 'modules.json', otherwise add it.
+        Assume that the modules/subworkflows were installed by and nf-core command (don't track installed by subworkflows).
         """
         try:
             self.load()
@@ -509,6 +512,16 @@ class ModulesJson:
             self.resolve_missing_from_modules_json(modules_missing_from_modules_json, "modules")
         if len(subworkflows_missing_from_modules_json) > 0:
             self.resolve_missing_from_modules_json(subworkflows_missing_from_modules_json, "subworkflows")
+
+        # If the "installed" value is not present for modules/subworkflows, add it.
+        for repo, repo_content in self.modules_json["repos"].items():
+            for component_type, dir_content in repo_content.items():
+                for install_dir, installed_components in dir_content.items():
+                    for component, component_features in installed_components.items():
+                        if "installed" not in component_features:
+                            self.modules_json["repos"][repo][component_type][install_dir][component]["installed"] = [
+                                component_type
+                            ]
 
         self.dump()
 

--- a/nf_core/modules/remove.py
+++ b/nf_core/modules/remove.py
@@ -50,13 +50,13 @@ class ModuleRemove(ModuleCommand):
 
             if modules_json.module_present(module, self.modules_repo.remote_url, repo_path):
                 log.error(f"Found entry for '{module}' in 'modules.json'. Removing...")
-                modules_json.remove_entry(module, self.modules_repo.remote_url, repo_path)
+                modules_json.remove_entry(self.component_type, module, self.modules_repo.remote_url, repo_path)
             return False
 
         log.info(f"Removing {module}")
 
         # Remove entry from modules.json
-        modules_json.remove_entry(module, self.modules_repo.remote_url, repo_path)
+        modules_json.remove_entry(self.component_type, module, self.modules_repo.remote_url, repo_path)
 
         # Remove the module
         return self.clear_component_dir(module, module_dir)

--- a/nf_core/modules/update.py
+++ b/nf_core/modules/update.py
@@ -223,10 +223,10 @@ class ModuleUpdate(ModuleCommand):
                 # Clear the module directory and move the installed files there
                 self.move_files_from_tmp_dir(module, install_tmp_dir, modules_repo.repo_path, version)
                 # Update modules.json with newly installed module
-                self.modules_json.update(modules_repo, module, version)
+                self.modules_json.update(modules_repo, module, version, self.component_type)
             else:
                 # Don't save to a file, just iteratively update the variable
-                self.modules_json.update(modules_repo, module, version, write_file=False)
+                self.modules_json.update(modules_repo, module, version, self.component_type, write_file=False)
 
         if self.save_diff_fn:
             # Write the modules.json diff to the file

--- a/nf_core/modules/update.py
+++ b/nf_core/modules/update.py
@@ -152,7 +152,7 @@ class ModuleUpdate(ModuleCommand):
             if sha is not None:
                 version = sha
             elif self.prompt:
-                version = nf_core.modules.modules_utils.prompt_component_version_sha(
+                version = prompt_component_version_sha(
                     module, "modules", modules_repo=modules_repo, installed_sha=current_version
                 )
             else:

--- a/nf_core/pipeline-template/modules.json
+++ b/nf_core/pipeline-template/modules.json
@@ -8,17 +8,17 @@
                     "custom/dumpsoftwareversions": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed": ["modules"]
+                        "installed_by": ["modules"]
                     },
                     "fastqc": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed": ["modules"]
+                        "installed_by": ["modules"]
                     },
                     "multiqc": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed": ["modules"]
+                        "installed_by": ["modules"]
                     }
                 }
             }

--- a/nf_core/pipeline-template/modules.json
+++ b/nf_core/pipeline-template/modules.json
@@ -7,15 +7,18 @@
                 "nf-core": {
                     "custom/dumpsoftwareversions": {
                         "branch": "master",
-                        "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905"
+                        "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
+                        "installed": ["modules"]
                     },
                     "fastqc": {
                         "branch": "master",
-                        "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905"
+                        "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
+                        "installed": ["modules"]
                     },
                     "multiqc": {
                         "branch": "master",
-                        "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905"
+                        "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
+                        "installed": ["modules"]
                     }
                 }
             }

--- a/nf_core/subworkflows/install.py
+++ b/nf_core/subworkflows/install.py
@@ -79,6 +79,11 @@ class SubworkflowInstall(SubworkflowCommand):
             self.force,
             self.prompt,
         ):
+            log.debug(
+                f"Subworkflow is already installed and force is not set.\nAdding the new installation source {self.installed_by} for subworkflow {subworkflow} to 'modules.json' without installing the subworkflow."
+            )
+            modules_json.load()
+            modules_json.update(self.modules_repo, subworkflow, current_version, self.installed_by)
             return False
 
         version = nf_core.components.components_install.get_version(
@@ -89,7 +94,13 @@ class SubworkflowInstall(SubworkflowCommand):
 
         # Remove subworkflow if force is set and component is installed
         if self.force and nf_core.components.components_install.check_component_installed(
-            self.component_type, subworkflow, current_version, subworkflow_dir, self.modules_repo, self.force
+            self.component_type,
+            subworkflow,
+            current_version,
+            subworkflow_dir,
+            self.modules_repo,
+            self.force,
+            self.prompt,
         ):
             log.info(f"Removing installed version of '{self.modules_repo.repo_path}/{subworkflow}'")
             self.clear_component_dir(subworkflow, subworkflow_dir)

--- a/nf_core/subworkflows/install.py
+++ b/nf_core/subworkflows/install.py
@@ -104,15 +104,15 @@ class SubworkflowInstall(SubworkflowCommand):
         ):
             log.info(f"Removing installed version of '{self.modules_repo.repo_path}/{subworkflow}'")
             self.clear_component_dir(subworkflow, subworkflow_dir)
-            nf_core.components.components_install.clean_modules_json(
-                subworkflow, self.component_type, self.modules_repo, modules_json
-            )
 
         log.info(f"{'Rei' if self.force else 'I'}nstalling '{subworkflow}'")
         log.debug(f"Installing subworkflow '{subworkflow}' at hash {version} from {self.modules_repo.remote_url}")
 
         # Download subworkflow files
         if not self.install_component_files(subworkflow, version, self.modules_repo, install_folder):
+            nf_core.components.components_install.clean_modules_json(
+                subworkflow, self.component_type, self.modules_repo, modules_json
+            )
             return False
 
         # Install included modules and subworkflows

--- a/nf_core/subworkflows/install.py
+++ b/nf_core/subworkflows/install.py
@@ -3,14 +3,11 @@ import os
 import re
 from pathlib import Path
 
-import questionary
-
 import nf_core.components.components_install
 import nf_core.modules.modules_utils
 import nf_core.utils
 from nf_core.modules.install import ModuleInstall
 from nf_core.modules.modules_json import ModulesJson
-from nf_core.modules.modules_repo import NF_CORE_MODULES_NAME
 
 from .subworkflows_command import SubworkflowCommand
 

--- a/nf_core/subworkflows/install.py
+++ b/nf_core/subworkflows/install.py
@@ -93,6 +93,7 @@ class SubworkflowInstall(SubworkflowCommand):
             return False
 
         # Remove subworkflow if force is set and component is installed
+        install_track = None
         if self.force and nf_core.components.components_install.check_component_installed(
             self.component_type,
             subworkflow,
@@ -104,15 +105,15 @@ class SubworkflowInstall(SubworkflowCommand):
         ):
             log.info(f"Removing installed version of '{self.modules_repo.repo_path}/{subworkflow}'")
             self.clear_component_dir(subworkflow, subworkflow_dir)
+            install_track = nf_core.components.components_install.clean_modules_json(
+                subworkflow, self.component_type, self.modules_repo, modules_json
+            )
 
         log.info(f"{'Rei' if self.force else 'I'}nstalling '{subworkflow}'")
         log.debug(f"Installing subworkflow '{subworkflow}' at hash {version} from {self.modules_repo.remote_url}")
 
         # Download subworkflow files
         if not self.install_component_files(subworkflow, version, self.modules_repo, install_folder):
-            nf_core.components.components_install.clean_modules_json(
-                subworkflow, self.component_type, self.modules_repo, modules_json
-            )
             return False
 
         # Install included modules and subworkflows
@@ -130,7 +131,7 @@ class SubworkflowInstall(SubworkflowCommand):
 
         # Update module.json with newly installed subworkflow
         modules_json.load()
-        modules_json.update_subworkflow(self.modules_repo, subworkflow, version, self.installed_by)
+        modules_json.update_subworkflow(self.modules_repo, subworkflow, version, self.installed_by, install_track)
         return True
 
     def get_modules_subworkflows_to_install(self, subworkflow_dir):

--- a/tests/modules/list.py
+++ b/tests/modules/list.py
@@ -19,7 +19,6 @@ def test_modules_list_remote_gitlab(self):
     """Test listing the modules in the remote gitlab repo"""
     mods_list = nf_core.modules.ModuleList(None, remote=True, remote_url=GITLAB_URL, branch=GITLAB_DEFAULT_BRANCH)
     listed_mods = mods_list.list_components()
-    print(f"listed modules are {listed_mods}")
     console = Console(record=True)
     console.print(listed_mods)
     output = console.export_text()

--- a/tests/modules/modules_json.py
+++ b/tests/modules/modules_json.py
@@ -41,7 +41,7 @@ def test_mod_json_update(self):
         NF_CORE_MODULES_DEFAULT_BRANCH
         == mod_json["repos"][NF_CORE_MODULES_REMOTE]["modules"]["nf-core"]["MODULE_NAME"]["branch"]
     )
-    assert "modules" in mod_json["repos"][NF_CORE_MODULES_REMOTE]["modules"]["nf-core"]["MODULE_NAME"]["installed"]
+    assert "modules" in mod_json["repos"][NF_CORE_MODULES_REMOTE]["modules"]["nf-core"]["MODULE_NAME"]["installed_by"]
 
 
 def test_mod_json_create(self):

--- a/tests/modules/modules_json.py
+++ b/tests/modules/modules_json.py
@@ -41,7 +41,8 @@ def test_mod_json_update(self):
         NF_CORE_MODULES_DEFAULT_BRANCH
         == mod_json["repos"][NF_CORE_MODULES_REMOTE]["modules"]["nf-core"]["MODULE_NAME"]["branch"]
     )
-    assert "modules" == mod_json["repos"][NF_CORE_MODULES_REMOTE]["modules"]["nf-core"]["MODULE_NAME"]["installed"]
+    print(mod_json["repos"][NF_CORE_MODULES_REMOTE]["modules"]["nf-core"]["MODULE_NAME"])
+    assert "modules" in mod_json["repos"][NF_CORE_MODULES_REMOTE]["modules"]["nf-core"]["MODULE_NAME"]["installed"]
 
 
 def test_mod_json_create(self):

--- a/tests/modules/modules_json.py
+++ b/tests/modules/modules_json.py
@@ -32,7 +32,7 @@ def test_mod_json_update(self):
     mod_json_obj = ModulesJson(self.pipeline_dir)
     # Update the modules.json file
     mod_repo_obj = ModulesRepo()
-    mod_json_obj.update(mod_repo_obj, "MODULE_NAME", "GIT_SHA", "modules", False)
+    mod_json_obj.update(mod_repo_obj, "MODULE_NAME", "GIT_SHA", "modules", write_file=False)
     mod_json = mod_json_obj.get_modules_json()
     assert "MODULE_NAME" in mod_json["repos"][NF_CORE_MODULES_REMOTE]["modules"]["nf-core"]
     assert "git_sha" in mod_json["repos"][NF_CORE_MODULES_REMOTE]["modules"]["nf-core"]["MODULE_NAME"]
@@ -41,7 +41,6 @@ def test_mod_json_update(self):
         NF_CORE_MODULES_DEFAULT_BRANCH
         == mod_json["repos"][NF_CORE_MODULES_REMOTE]["modules"]["nf-core"]["MODULE_NAME"]["branch"]
     )
-    print(mod_json["repos"][NF_CORE_MODULES_REMOTE]["modules"]["nf-core"]["MODULE_NAME"])
     assert "modules" in mod_json["repos"][NF_CORE_MODULES_REMOTE]["modules"]["nf-core"]["MODULE_NAME"]["installed"]
 
 
@@ -156,7 +155,7 @@ def test_mod_json_up_to_date_reinstall_fails(self):
     mod_json_obj = ModulesJson(self.pipeline_dir)
 
     # Update the fastqc module entry to an invalid git_sha
-    mod_json_obj.update(ModulesRepo(), "fastqc", "INVALID_GIT_SHA", "modules", True)
+    mod_json_obj.update(ModulesRepo(), "fastqc", "INVALID_GIT_SHA", "modules", write_file=True)
 
     # Remove the fastqc module
     fastqc_path = os.path.join(self.pipeline_dir, "modules", NF_CORE_MODULES_NAME, "fastqc")

--- a/tests/modules/modules_json.py
+++ b/tests/modules/modules_json.py
@@ -32,7 +32,7 @@ def test_mod_json_update(self):
     mod_json_obj = ModulesJson(self.pipeline_dir)
     # Update the modules.json file
     mod_repo_obj = ModulesRepo()
-    mod_json_obj.update(mod_repo_obj, "MODULE_NAME", "GIT_SHA", False)
+    mod_json_obj.update(mod_repo_obj, "MODULE_NAME", "GIT_SHA", "modules", False)
     mod_json = mod_json_obj.get_modules_json()
     assert "MODULE_NAME" in mod_json["repos"][NF_CORE_MODULES_REMOTE]["modules"]["nf-core"]
     assert "git_sha" in mod_json["repos"][NF_CORE_MODULES_REMOTE]["modules"]["nf-core"]["MODULE_NAME"]
@@ -41,6 +41,7 @@ def test_mod_json_update(self):
         NF_CORE_MODULES_DEFAULT_BRANCH
         == mod_json["repos"][NF_CORE_MODULES_REMOTE]["modules"]["nf-core"]["MODULE_NAME"]["branch"]
     )
+    assert "modules" == mod_json["repos"][NF_CORE_MODULES_REMOTE]["modules"]["nf-core"]["MODULE_NAME"]["installed"]
 
 
 def test_mod_json_create(self):
@@ -154,7 +155,7 @@ def test_mod_json_up_to_date_reinstall_fails(self):
     mod_json_obj = ModulesJson(self.pipeline_dir)
 
     # Update the fastqc module entry to an invalid git_sha
-    mod_json_obj.update(ModulesRepo(), "fastqc", "INVALID_GIT_SHA", True)
+    mod_json_obj.update(ModulesRepo(), "fastqc", "INVALID_GIT_SHA", "modules", True)
 
     # Remove the fastqc module
     fastqc_path = os.path.join(self.pipeline_dir, "modules", NF_CORE_MODULES_NAME, "fastqc")

--- a/tests/modules/patch.py
+++ b/tests/modules/patch.py
@@ -1,4 +1,3 @@
-import json
 import os
 import tempfile
 from pathlib import Path
@@ -234,15 +233,11 @@ def test_create_patch_update_success(self):
         "modules", REPO_NAME, BISMARK_ALIGN, patch_fn
     )
 
-    with open(os.path.join(module_path, "main.nf"), "r") as fh:
-        print(fh.readlines())
     # Update the module
     update_obj = nf_core.modules.ModuleUpdate(
         self.pipeline_dir, sha=SUCCEED_SHA, show_diff=False, remote_url=GITLAB_URL, branch=PATCH_BRANCH
     )
     assert update_obj.update(BISMARK_ALIGN)
-    with open(os.path.join(module_path, "main.nf"), "r") as fh:
-        print(fh.readlines())
 
     # Check that a patch file with the correct name has been created
     assert set(os.listdir(module_path)) == {"main.nf", "meta.yml", patch_fn}
@@ -257,7 +252,6 @@ def test_create_patch_update_success(self):
     with open(module_path / patch_fn, "r") as fh:
         patch_lines = fh.readlines()
     module_relpath = module_path.relative_to(self.pipeline_dir)
-    print(patch_lines)
     assert f"--- {module_relpath / 'main.nf'}\n" in patch_lines
     assert f"+++ {module_relpath / 'main.nf'}\n" in patch_lines
     assert "-    tuple val(meta), path(reads)\n" in patch_lines

--- a/tests/modules/update.py
+++ b/tests/modules/update.py
@@ -214,7 +214,7 @@ def test_update_with_config_no_updates(self):
 
 def test_update_different_branch_single_module(self):
     """Try updating a module in a specific branch"""
-    install_obj = nf_core.modules.ModuleInstall(
+    install_obj = ModuleInstall(
         self.pipeline_dir,
         prompt=False,
         force=False,

--- a/tests/test_subworkflows.py
+++ b/tests/test_subworkflows.py
@@ -3,7 +3,6 @@
 """
 
 import os
-import shutil
 import tempfile
 import unittest
 
@@ -13,7 +12,7 @@ import nf_core.create
 import nf_core.modules
 import nf_core.subworkflows
 
-from .utils import GITLAB_URL, mock_api_calls
+from .utils import mock_api_calls
 
 
 def create_modules_repo_dummy(tmp_dir):


### PR DESCRIPTION
Track from where modules and subworkflows are installed.

- a module installed with `nf-core modules install`: "modules"
- a subworkflow installed with `nf-core subworkflows install`: "subworkflows"
- a module or subworkflow installed automatically when installing another subworkflow: "<subworkflow name>"

Updates `modules.json` file adding a new field `installed` for every module/subworkflow
💭 With previously installed modules/subworkflows, it assumes they were installed by an nf-core command, without taking into account if they are used by other subworkflows.

I also fix some small bugs that I found on the way.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
