### PR TITLE
Fix hide-progress bug

### DIFF
--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -738,17 +738,16 @@ def lint(ctx, tool, dir, key, all, fail_warned, local, passed, fix_version):  # 
     try:
         module_lint = nf_core.modules.ModuleLint(
             dir,
-            fail_warned,
-            ctx.obj["modules_repo_url"],
-            ctx.obj["modules_repo_branch"],
-            ctx.obj["modules_repo_no_pull"],
-            ctx.obj["hide_progress"],
+            fail_warned=fail_warned,
+            remote_url=ctx.obj["modules_repo_url"],
+            branch=ctx.obj["modules_repo_branch"],
+            no_pull=ctx.obj["modules_repo_no_pull"],
+            hide_progress=ctx.obj["hide_progress"],
         )
         module_lint.lint(
             module=tool,
             key=key,
             all_modules=all,
-            hide_progress=ctx.obj["hide_progress"],
             print_results=True,
             local=local,
             show_passed=passed,

--- a/nf_core/modules/lint/__init__.py
+++ b/nf_core/modules/lint/__init__.py
@@ -72,7 +72,12 @@ class ModuleLint(ComponentCommand):
         hide_progress=False,
     ):
         super().__init__(
-            "modules", dir=dir, remote_url=remote_url, branch=branch, no_pull=no_pull, hide_progress=hide_progress
+            "modules",
+            dir=dir,
+            remote_url=remote_url,
+            branch=branch,
+            no_pull=no_pull,
+            hide_progress=hide_progress,
         )
 
         self.fail_warned = fail_warned


### PR DESCRIPTION
Follow on from PR nf-core/tools#2016

Reported on Slack [here](https://nfcore.slack.com/archives/CJRH30T6V/p1668520998214899).

Failing action run [here](https://github.com/nf-core/modules/actions/runs/3470901919/jobs/5800144255).

Messed up the function keywords in #2016, this fixes it. Bug replicated locally and fixed locally.

To replicate with current dev in the modules repo, checked out with PR https://github.com/nf-core/modules/pull/2512:

```bash
nf-core --hide-progress modules lint gatk4/preprocessintervals
```


<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
