### PR TITLE
Properly group subcommands in help text

### DIFF
--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -42,7 +42,7 @@ click.rich_click.COMMAND_GROUPS = {
         },
         {
             "name": "Commands for developers",
-            "commands": ["create", "lint", "modules", "schema", "bump-version", "sync"],
+            "commands": ["create", "lint", "modules", "subworkflows", "schema", "bump-version", "sync"],
         },
     ],
     "nf-core modules": [
@@ -58,7 +58,7 @@ click.rich_click.COMMAND_GROUPS = {
     "nf-core subworkflows": [
         {
             "name": "For pipelines",
-            "commands": ["install"],
+            "commands": ["list", "install"],
         },
         {
             "name": "Developing new subworkflows",


### PR DESCRIPTION
Fix the ungrouped subcommands.

Before (see _Commands_ at the bottom):

<img width="822" alt="image" src="https://user-images.githubusercontent.com/465550/201963672-74eb4d97-bb32-438c-873d-bd12f5b04782.png">


After:

<img width="815" alt="image" src="https://user-images.githubusercontent.com/465550/201963596-c842787f-ca92-4d50-9617-b56fc9e91ca0.png">

Also for `nf-core subworkflows`:

Before:

<img width="827" alt="image" src="https://user-images.githubusercontent.com/465550/201963498-82f93ddf-0517-433e-9220-3ec2881cc6a8.png">


After:

<img width="820" alt="image" src="https://user-images.githubusercontent.com/465550/201963820-880bd55a-9c8d-42ea-9836-57ca9a545f70.png">



## PR checklist

- [x] This comment contains a description of changes (with reason)
