### PR TITLE
Flip execution order of parameter summary and validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Check that the workflow name provided with a template doesn't contain dashes ([#1822](https://github.com/nf-core/tools/pull/1822))
 - `nextflow run <pipeline> --version` will now print the workflow version from the manifest and exit ([#1951](https://github.com/nf-core/tools/pull/1951))
 - Add profile for running `docker` with the ARM chips (including Apple silicon).
+- Flip execution order of parameter summary printing and parameter validation to prevent 'hiding' of parameter errors
 
 ### Linting
 

--- a/nf_core/pipeline-template/lib/WorkflowMain.groovy
+++ b/nf_core/pipeline-template/lib/WorkflowMain.groovy
@@ -63,7 +63,7 @@ class WorkflowMain {
             log.info "${workflow.manifest.name} ${workflow_version}"
             System.exit(0)
         }
-        
+
         // Print parameter summary log to screen
         log.info paramsSummaryLog(workflow, params, log)
 

--- a/nf_core/pipeline-template/lib/WorkflowMain.groovy
+++ b/nf_core/pipeline-template/lib/WorkflowMain.groovy
@@ -63,15 +63,14 @@ class WorkflowMain {
             log.info "${workflow.manifest.name} ${workflow_version}"
             System.exit(0)
         }
+        
+        // Print parameter summary log to screen
+        log.info paramsSummaryLog(workflow, params, log)
 
         // Validate workflow parameters via the JSON schema
         if (params.validate_params) {
             NfcoreSchema.validateParameters(workflow, params, log)
         }
-
-        // Print parameter summary log to screen
-
-        log.info paramsSummaryLog(workflow, params, log)
 
         // Check that a -profile or Nextflow config has been provided to run the pipeline
         NfcoreTemplate.checkConfigProvided(workflow, log)


### PR DESCRIPTION
This is to prevent 'hiding' or 'loss' of parameter errors (mainly non-failing typos in parameter names), that can come due to very long parameter summary + small terminal windows.

Originally proposed here: https://nfcore.slack.com/archives/CE4K7FEHE/p1669035465524059

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
