### PR TITLE
Run tests with a realistic version of git

### DIFF
--- a/.github/workflows/pytest-frozen-ubuntu-20.04.yml
+++ b/.github/workflows/pytest-frozen-ubuntu-20.04.yml
@@ -1,0 +1,52 @@
+name: Python tests Ubuntu-20.04 (frozen)
+# This workflow is triggered on pushes and PRs to the repository.
+# Only run if we changed a Python file
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+  release:
+    types: [published]
+
+# Cancel if a newer run is started
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        name: Check out source-code repository
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.8"
+
+      - name: Install python dependencies
+        run: |
+          python -m pip install --upgrade pip -r requirements-dev.txt
+          pip install -e .
+
+      - name: Downgrade git to the Ubuntu official repository's version
+        run: |
+          sudo apt remove git git-man
+          sudo add-apt-repository --remove ppa:git-core/ppa
+          sudo apt install git
+
+      - name: Install Nextflow
+        uses: nf-core/setup-nextflow@v1
+        with:
+          version: "latest-everything"
+
+      - name: Test with pytest
+        run: python3 -m pytest tests/ --color=yes --cov-report=xml --cov-config=.github/.coveragerc --cov=nf_core
+
+      - uses: codecov/codecov-action@v1
+        name: Upload code coverage report
+        with:
+          if: success()
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Add file `versions.yml` when generating `test.yml` with `nf-core modules create-test-yml` but don't check for md5sum [#1963](https://github.com/nf-core/tools/pull/1963)
 - Mock biocontainers and anaconda api calls in modules and subworkflows tests [#1967](https://github.com/nf-core/tools/pull/1967)
 - Run tests with Python 3.11 ([#1970](https://github.com/nf-core/tools/pull/1970))
+- Run test with a realistic version of git ([#2043](https://github.com/nf-core/tools/pull/2043))
 - Bump promoted Python version from 3.7 to 3.8 ([#1971](https://github.com/nf-core/tools/pull/1971))
 - Fix incorrect file deletion in `nf-core launch` when `--params_in` has the same name as `--params_out`
 - Updated GitHub actions ([#1998](https://github.com/nf-core/tools/pull/1998), [#2001](https://github.com/nf-core/tools/pull/2001))

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -528,10 +528,10 @@ class PipelineCreate:
 
         log.info("Initialising pipeline git repository")
         repo = git.Repo.init(self.outdir)
-        if default_branch:
-            repo.active_branch.rename(default_branch)
         repo.git.add(A=True)
         repo.index.commit(f"initial template build from nf-core/tools, version {nf_core.__version__}")
+        if default_branch:
+            repo.active_branch.rename(default_branch)
         repo.git.branch("TEMPLATE")
         repo.git.branch("dev")
         log.info(

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -32,7 +32,9 @@ class TestModules(unittest.TestCase):
         self.create_obj.init_pipeline()
         self.remote_path = os.path.join(self.tmp_dir, "remote_repo")
         self.remote_repo = git.Repo.init(self.remote_path, bare=True)
-        self.remote_repo.active_branch.rename(default_branch)
+
+        if self.remote_repo.active_branch.name != "master":
+            self.remote_repo.active_branch.rename(default_branch)
 
     def tearDown(self):
         if os.path.exists(self.tmp_dir):


### PR DESCRIPTION
This PR fixes the following issues:
- Github's Ubuntu images use the very latest version of git (i.e. v2.38.1, see [here](https://github.com/actions/runner-images/blob/ubuntu20/20221119.2/images/linux/Ubuntu2004-Readme.md)). More specifically, this is different from the version available on the image that is used for the tests (Ubuntu 20.04, git 2.25.1).  Since nf-core/tools heavily depends on the git version available to the user, this PR downgrades git so that the testing environment is more similar to what a typical user would have.
- Consequently, some failed tests have been going under the radar in `test_create` and `test_sync`. This PR also fixes these tests.

Additionally, this is at least the second time we encounter bugs that are specific to the version of git being used so maybe we should consider testing with older and newer LTS Ubuntu versions (and their respective versions of git)?

## PR checklist

- [X] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [X] If you've fixed a bug or added code that should be tested, add tests!

