### PR TITLE
fix modules.json recreation

### DIFF
--- a/nf_core/components/install.py
+++ b/nf_core/components/install.py
@@ -56,7 +56,8 @@ class ComponentInstall(ComponentCommand):
 
         # Verify that 'modules.json' is consistent with the installed modules and subworkflows
         modules_json = ModulesJson(self.dir)
-        modules_json.check_up_to_date()
+        if not silent:
+            modules_json.check_up_to_date()
 
         # Verify SHA
         if not self.modules_repo.verify_sha(self.prompt, self.sha):

--- a/nf_core/components/update.py
+++ b/nf_core/components/update.py
@@ -96,7 +96,8 @@ class ComponentUpdate(ComponentCommand):
         self.check_modules_structure()
 
         # Verify that 'modules.json' is consistent with the installed modules
-        self.modules_json.check_up_to_date()
+        if not silent:
+            self.modules_json.check_up_to_date()
 
         if not self.update_all and component is None:
             choices = [f"All {self.component_type}", f"Named {self.component_type[:-1]}"]
@@ -342,14 +343,14 @@ class ComponentUpdate(ComponentCommand):
         # Check if there are any modules/subworkflows installed from the repo
         repo_url = self.modules_repo.remote_url
         components = self.modules_json.get_all_components(self.component_type).get(repo_url)
-        choices = [component if dir == "nf-core" else f"{dir}/{component}" for dir, component in components]
-        if repo_url not in self.modules_json.get_all_components(self.component_type):
+        if components is None:
             raise LookupError(f"No {self.component_type} installed from '{repo_url}'")
+        choices = [component if dir == "nf-core" else f"{dir}/{component}" for dir, component in components]
 
         if component is None:
             component = questionary.autocomplete(
                 f"{self.component_type[:-1].title()} name:",
-                choices=choices.sort(),
+                choices=sorted(choices),
                 style=nf_core.utils.nfcore_question_style,
             ).unsafe_ask()
 

--- a/nf_core/components/update.py
+++ b/nf_core/components/update.py
@@ -230,9 +230,7 @@ class ComponentUpdate(ComponentCommand):
                         else:
                             updated.append(component)
                     recursive_update = True
-                    modules_to_update, subworkflows_to_update = self.get_modules_subworkflows_to_update(
-                        component, modules_repo
-                    )
+                    modules_to_update, subworkflows_to_update = self.get_components_to_update(component, modules_repo)
                     if not silent and len(modules_to_update + subworkflows_to_update) > 0:
                         log.warning(
                             f"All modules and subworkflows linked to the updated {self.component_type[:-1]} will be added to the same diff file.\n"
@@ -279,9 +277,7 @@ class ComponentUpdate(ComponentCommand):
                 self.modules_json.update(self.component_type, modules_repo, component, version, self.component_type)
                 updated.append(component)
                 recursive_update = True
-                modules_to_update, subworkflows_to_update = self.get_modules_subworkflows_to_update(
-                    component, modules_repo
-                )
+                modules_to_update, subworkflows_to_update = self.get_components_to_update(component, modules_repo)
                 if not silent and not self.update_all and len(modules_to_update + subworkflows_to_update) > 0:
                     log.warning(
                         f"All modules and subworkflows linked to the updated {self.component_type[:-1]} will be {'asked for update' if self.show_diff else 'automatically updated'}.\n"
@@ -802,8 +798,13 @@ class ComponentUpdate(ComponentCommand):
 
         return True
 
-    def get_modules_subworkflows_to_update(self, component, modules_repo):
-        """Get all modules and subworkflows linked to the updated component."""
+    def get_components_to_update(self, component, modules_repo):
+        """
+        Get all modules and subworkflows linked to the updated component.
+
+        Returns:
+            (list,list): A tuple of lists with the modules and subworkflows to update
+        """
         mods_json = self.modules_json.get_modules_json()
         modules_to_update = []
         subworkflows_to_update = []

--- a/nf_core/modules/lint/__init__.py
+++ b/nf_core/modules/lint/__init__.py
@@ -90,7 +90,7 @@ class ModuleLint(ComponentCommand):
             modules_json = ModulesJson(self.dir)
             modules_json.check_up_to_date()
             all_pipeline_modules = modules_json.get_all_components(self.component_type)
-            if self.modules_repo.remote_url in all_pipeline_modules:
+            if all_pipeline_modules is not None and self.modules_repo.remote_url in all_pipeline_modules:
                 module_dir = Path(self.dir, "modules", "nf-core")
                 self.all_remote_modules = [
                     NFCoreModule(m[1], self.modules_repo.remote_url, module_dir / m[1], self.repo_type, Path(self.dir))

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -315,7 +315,7 @@ class ModulesJson:
                 repo_entry[component] = {
                     "branch": modules_repo.branch,
                     "git_sha": correct_commit_sha,
-                    "installed_by": "modules",
+                    "installed_by": [component_type],
                 }
 
         # Clean up the modules/subworkflows we were unable to find the sha for

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -537,12 +537,10 @@ class ModulesJson:
             if not self.has_git_url_and_modules():
                 raise UserWarning
         except UserWarning:
-            log.info("The 'modules.json' file is not up to date. Recreating the 'module.json' file.")
+            log.info("The 'modules.json' file is not up to date. Recreating the 'modules.json' file.")
             self.create()
-            subworkflows_dict = self.get_all_components("subworkflows")
-            for repo, subworkflows in subworkflows_dict.items():
-                for org, subworkflow in subworkflows:
-                    self.recreate_dependencies(repo, org, subworkflow)
+
+        # Get unsynced components
         (
             modules_missing_from_modules_json,
             subworkflows_missing_from_modules_json,
@@ -577,6 +575,13 @@ class ModulesJson:
                             self.modules_json["repos"][repo][component_type][install_dir][component]["installed_by"] = [
                                 component_type
                             ]
+
+        # Recreate "installed_by" entry
+        subworkflows_dict = self.get_all_components("subworkflows")
+        for repo, subworkflows in subworkflows_dict.items():
+            for org, subworkflow in subworkflows:
+                self.recreate_dependencies(repo, org, subworkflow)
+
         self.dump()
 
     def load(self):

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -1167,14 +1167,7 @@ class ModulesJson:
         dep_mods, dep_subwfs = get_components_to_install(sw_path)
 
         for dep_mod in dep_mods:
-            try:
-                installed_by = self.modules_json["repos"][repo]["modules"][org][dep_mod]["installed_by"]
-            except KeyError:
-                log.warning(
-                    f"Module '{dep_mod}' is a dependency of '{subworkflow}'\n"
-                    f"You can install it with the command 'nf-core modules install {dep_mod}'"
-                )
-                continue
+            installed_by = self.modules_json["repos"][repo]["modules"][org][dep_mod]["installed_by"]
             if installed_by == ["modules"]:
                 self.modules_json["repos"][repo]["modules"][org][dep_mod]["installed_by"] = []
             if subworkflow not in installed_by:


### PR DESCRIPTION
Correctly sets the installed_by also for subworkflows when no modules.json was found