### PR TITLE
require minimum supported Python version for installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Don't print source file + line number on logging messages (except when verbose) ([#2015](https://github.com/nf-core/tools/pull/2015))
 - Extended the chat notifications to Slack ([#1829](https://github.com/nf-core/tools/pull/1829))
 - Allow other remote URLs not starting with `http` ([#2061](https://github.com/nf-core/tools/pull/2061))
+- Prevent installation with unsupported Python versions ([#2075](https://github.com/nf-core/tools/pull/2075))
 
 ### Modules
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "console_scripts": ["nf-core=nf_core.__main__:run_nf_core"],
         "refgenie.hooks.post_update": ["nf-core-refgenie=nf_core.refgenie:update_config"],
     },
-    python_requires='>=3.7, <4',
+    python_requires=">=3.7, <4",
     install_requires=required,
     packages=find_packages(exclude=("docs")),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "console_scripts": ["nf-core=nf_core.__main__:run_nf_core"],
         "refgenie.hooks.post_update": ["nf-core-refgenie=nf_core.refgenie:update_config"],
     },
+    python_requires='>=3.7, <4',
     install_requires=required,
     packages=find_packages(exclude=("docs")),
     include_package_data=True,


### PR DESCRIPTION
It is hitherto possible to install nf-core tools with pip and unsupported older Python versions. This PR prevents that.

Closes #1876

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
