### PR TITLE
Modules lint output sorting

### DIFF
--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -732,8 +732,14 @@ def create_test_yml(ctx, tool, run_tests, output, force, no_prompts):
 @click.option("-w", "--fail-warned", is_flag=True, help="Convert warn tests to failures")
 @click.option("--local", is_flag=True, help="Run additional lint tests for local modules")
 @click.option("--passed", is_flag=True, help="Show passed tests")
+@click.option(
+    "--sort-by",
+    type=click.Choice(["module", "test"]),
+    default="test",
+    help="Sort lint output by module or test name. Default: test",
+)
 @click.option("--fix-version", is_flag=True, help="Fix the module version if a newer version is available")
-def lint(ctx, tool, dir, key, all, fail_warned, local, passed, fix_version):  # pylint: disable=redefined-outer-name
+def lint(ctx, tool, dir, key, all, fail_warned, local, passed, sort_by, fix_version):  # pylint: disable=redefined-outer-name
     """
     Lint one or more modules in a directory.
 
@@ -759,6 +765,7 @@ def lint(ctx, tool, dir, key, all, fail_warned, local, passed, fix_version):  # 
             print_results=True,
             local=local,
             show_passed=passed,
+            sort_by=sort_by,
             fix_version=fix_version,
         )
         if len(module_lint.failed) > 0:

--- a/nf_core/modules/lint/__init__.py
+++ b/nf_core/modules/lint/__init__.py
@@ -141,6 +141,7 @@ class ModuleLint(ComponentCommand):
         all_modules=False,
         print_results=True,
         show_passed=False,
+        sort_by="test",
         local=False,
         fix_version=False,
     ):
@@ -225,7 +226,7 @@ class ModuleLint(ComponentCommand):
             self.lint_modules(remote_modules, local=False, fix_version=fix_version)
 
         if print_results:
-            self._print_results(show_passed=show_passed)
+            self._print_results(show_passed=show_passed, sort_by=sort_by)
             self.print_summary()
 
     def set_up_pipeline_files(self):
@@ -327,7 +328,7 @@ class ModuleLint(ComponentCommand):
 
             self.failed += [LintResult(mod, *m) for m in mod.failed]
 
-    def _print_results(self, show_passed=False):
+    def _print_results(self, show_passed=False, sort_by="test"):
         """Print linting results to the command line.
 
         Uses the ``rich`` library to print a set of formatted tables to the command line
@@ -336,10 +337,14 @@ class ModuleLint(ComponentCommand):
 
         log.debug("Printing final results")
 
+        sort_order = ["lint_test", "module_name", "message"]
+        if sort_by == "module":
+            sort_order = ["module_name", "lint_test", "message"]
+
         # Sort the results
-        self.passed.sort(key=operator.attrgetter("message", "module_name"))
-        self.warned.sort(key=operator.attrgetter("message", "module_name"))
-        self.failed.sort(key=operator.attrgetter("message", "module_name"))
+        self.passed.sort(key=operator.attrgetter(*sort_order))
+        self.warned.sort(key=operator.attrgetter(*sort_order))
+        self.failed.sort(key=operator.attrgetter(*sort_order))
 
         # Find maximum module name length
         max_mod_name_len = 40


### PR DESCRIPTION
The current `modules lint` behaviour sorts the test messages by `message` then by `module_name` (this is done by python string-sorting i.e. alphabetically).

Personally I find this somewhat unintuitive to grok. 

Current output:
 
![Screenshot 2022-11-30 at 11 02 16](https://user-images.githubusercontent.com/24782660/204779661-12ced1e8-e5f5-44c3-a062-074697f05e2d.png)


This PR changes the default sort order to use the `lint_test` test name, then the `module_name`, then finally the `message`. 

![Screenshot 2022-11-30 at 11 01 32](https://user-images.githubusercontent.com/24782660/204779976-f8677969-0cbc-40cc-8e8f-cca71873b624.png)

It also adds the option to order by `module_name` first.

![Screenshot 2022-11-30 at 11 01 49](https://user-images.githubusercontent.com/24782660/204779950-4f6b6b1c-0e78-4291-9684-87096aa62749.png)


## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
