### PR TITLE
Tone down colour in successful completion but some failed processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add profile for running `docker` with the ARM chips (including Apple silicon) ([#1942](https://github.com/nf-core/tools/pull/1942) and [#2034](https://github.com/nf-core/tools/pull/2034))
 - Flip execution order of parameter summary printing and parameter validation to prevent 'hiding' of parameter errors.
 - Remove `CITATION.cff` file from pipeline template, to avoid that pipeline Zenodo entries reference the nf-core publication instead of the pipeline.
+- Change colour of 'pipeline completed successfully, but some processes failed' from red to yellow.
 
 ### Linting
 

--- a/nf_core/pipeline-template/lib/NfcoreTemplate.groovy
+++ b/nf_core/pipeline-template/lib/NfcoreTemplate.groovy
@@ -231,7 +231,7 @@ class NfcoreTemplate {
             if (workflow.stats.ignoredCount == 0) {
                 log.info "-${colors.purple}[$workflow.manifest.name]${colors.green} Pipeline completed successfully${colors.reset}-"
             } else {
-                log.info "-${colors.purple}[$workflow.manifest.name]${colors.red} Pipeline completed successfully, but with errored process(es) ${colors.reset}-"
+                log.info "-${colors.purple}[$workflow.manifest.name]${colors.yellow} Pipeline completed successfully, but with errored process(es) ${colors.reset}-"
             }
         } else {
             log.info "-${colors.purple}[$workflow.manifest.name]${colors.red} Pipeline completed with errors${colors.reset}-"


### PR DESCRIPTION
I've noted in some cases that people believe a pipeline has completely failed, even though a pipeline developer allows some processes to fail, because the final completion message is red.

This switches from Red to Yellow to make it less 'failurey'.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Documentation in `docs` is updated
