### PR TITLE
Add specific prettier-commit config for prettier check, improve log message

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,4 @@ graft nf_core/module-template
 graft nf_core/pipeline-template
 graft nf_core/subworkflow-template
 include requirements.txt
-include .pre-commit-config.yaml
+include nf_core/.pre-commit-prettier-config.yaml

--- a/nf_core/.pre-commit-prettier-config.yaml
+++ b/nf_core/.pre-commit-prettier-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v2.6.2"
+    hooks:
+      - id: prettier

--- a/nf_core/lint_utils.py
+++ b/nf_core/lint_utils.py
@@ -73,11 +73,11 @@ def run_prettier_on_file(file):
     except subprocess.CalledProcessError as e:
         if ": SyntaxError: " in e.stdout.decode():
             log.critical(f"Can't format {file} because it has a syntax error.\n{e.stdout.decode()}")
-        if "files were modified by this hook" in e.stdout.decode():
+        elif "files were modified by this hook" in e.stdout.decode():
             all_lines = [line for line in e.stdout.decode().split("\n")]
             files = "\n".join(all_lines[3:])
             log.debug(f"The following files were modified by prettier:\n {files}")
-        else:
+        elif e.stderr.decode():
             log.warning(
                 "There was an error running the prettier pre-commit hook.\n"
                 f"STDOUT: {e.stdout.decode()}\nSTDERR: {e.stderr.decode()}"

--- a/nf_core/lint_utils.py
+++ b/nf_core/lint_utils.py
@@ -63,7 +63,7 @@ def run_prettier_on_file(file):
         If Prettier is not installed, a warning is logged.
     """
 
-    nf_core_pre_commit_config = Path(nf_core.__file__).parent.parent / ".pre-commit-config.yaml"
+    nf_core_pre_commit_config = Path(nf_core.__file__).parent / ".pre-commit-prettier-config.yaml"
     try:
         subprocess.run(
             ["pre-commit", "run", "--config", nf_core_pre_commit_config, "prettier", "--files", file],

--- a/nf_core/lint_utils.py
+++ b/nf_core/lint_utils.py
@@ -74,9 +74,9 @@ def run_prettier_on_file(file):
         if ": SyntaxError: " in e.stdout.decode():
             log.critical(f"Can't format {file} because it has a syntax error.\n{e.stdout.decode()}")
         if "files were modified by this hook" in e.stdout.decode():
-            log.info(
-                f"The following files were modified by prettier:\n {e.stdout.decode().lstrip('- files were modified by this hook')}"
-            )
+            all_lines = [line for line in e.stdout.decode().readlines()]
+            files = "\n".join(all_lines[3:])
+            log.info(f"The following files were modified by prettier:\n {files}")
         else:
             log.warning(
                 "There was an error running the prettier pre-commit hook.\n"

--- a/nf_core/lint_utils.py
+++ b/nf_core/lint_utils.py
@@ -73,6 +73,10 @@ def run_prettier_on_file(file):
     except subprocess.CalledProcessError as e:
         if ": SyntaxError: " in e.stdout.decode():
             log.critical(f"Can't format {file} because it has a syntax error.\n{e.stdout.decode()}")
+        if "files were modified by this hook" in e.stdout.decode():
+            log.info(
+                f"The following files were modified by prettier:\n {e.stdout.decode().lstrip('- files were modified by this hook')}"
+            )
         else:
             log.warning(
                 "There was an error running the prettier pre-commit hook.\n"

--- a/nf_core/lint_utils.py
+++ b/nf_core/lint_utils.py
@@ -74,7 +74,7 @@ def run_prettier_on_file(file):
         if ": SyntaxError: " in e.stdout.decode():
             log.critical(f"Can't format {file} because it has a syntax error.\n{e.stdout.decode()}")
         if "files were modified by this hook" in e.stdout.decode():
-            all_lines = [line for line in e.stdout.decode().readlines()]
+            all_lines = [line for line in e.stdout.decode().split("\n")]
             files = "\n".join(all_lines[3:])
             log.info(f"The following files were modified by prettier:\n {files}")
         else:

--- a/nf_core/lint_utils.py
+++ b/nf_core/lint_utils.py
@@ -76,7 +76,7 @@ def run_prettier_on_file(file):
         if "files were modified by this hook" in e.stdout.decode():
             all_lines = [line for line in e.stdout.decode().split("\n")]
             files = "\n".join(all_lines[3:])
-            log.info(f"The following files were modified by prettier:\n {files}")
+            log.debug(f"The following files were modified by prettier:\n {files}")
         else:
             log.warning(
                 "There was an error running the prettier pre-commit hook.\n"


### PR DESCRIPTION
Probably preferred to #2099.

Not sure that is the best way to handle the `stdout` from pre-commit, which is a bit confusing when you don't know that we run pre-commit. It just removes:
```
  prettier.................................................................Failed
 - hook id: prettier
 - files were modified by this hook
```