### PR TITLE
only check pipeline name without dashes if the name is provided by prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### General
 
+- Only check that a pipeline name doesn't contain dashes if the name is provided by prompt of `--name`. Don't check if a template file is used. ([#2123](https://github.com/nf-core/tools/pull/2123))
+
 ## [v2.7.1 - Mercury Eagle Patch](https://github.com/nf-core/tools/releases/tag/2.7.1) - [2022-12-08]
 
 - Patch release to fix pipeline sync ([#2110](https://github.com/nf-core/tools/pull/2110))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Linting
 
+- Allow specifying containers in less than three lines ([#2121](https://github.com/nf-core/tools/pull/2121))
+
 ### Modules
 
 ### Subworkflows

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -173,9 +173,10 @@ class PipelineCreate:
             and "manifest.name" in config_yml["lint"]["nextflow_config"]
         ):
             return param_dict, skip_paths
-        # Check that the pipeline name matches the requirements
-        if not re.match(r"^[a-z]+$", param_dict["short_name"]):
-            raise UserWarning("[red]Invalid workflow name: must be lowercase without punctuation.")
+        if param_dict["prefix"] == "nf-core":
+            # Check that the pipeline name matches the requirements
+            if not re.match(r"^[a-z]+$", param_dict["short_name"]):
+                raise UserWarning("[red]Invalid workflow name: must be lowercase without punctuation.")
 
         return param_dict, skip_paths
 

--- a/nf_core/sync.py
+++ b/nf_core/sync.py
@@ -252,8 +252,9 @@ class PipelineSync:
                 plain=True,
             ).init_pipeline()
         except Exception as err:
-            # If sync fails, remove template_yaml_path before raising error.
-            os.remove(self.template_yaml_path)
+            if self.template_yaml_path:
+                # If sync fails, remove template_yaml_path before raising error.
+                os.remove(self.template_yaml_path)
             # Reset to where you were to prevent git getting messed up.
             self.repo.git.reset("--hard")
             raise SyncException(f"Failed to rebuild pipeline from template with error:\n{err}")


### PR DESCRIPTION
Related to #2117  and [slack discussion](https://nfcore.slack.com/archives/CE5LG7WMB/p1670591325094329)

The code will check that the pipeline name doesn't contain dashes if the name if provided by prompt. With `nf-core create` or `nf-core create --name my-name`.
It won't be checked if the pipeline name is provided with a template `nf-core create -t template.yml` where `template.yml` contains:
```
name: my-name
description: A test pipeline
author: me
prefix: my-org
```
If `template.yml` doesn't provide a custom prefix or the prefix is set to `nf-core`, dashes won't be allowed.

To sync a pipeline created with dashes, the template must be used: `nf-core sync -t template.yml`

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
