### PR TITLE
Explicitly disable conda container profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Fix the syntax of github_output in GitHub actions ([#2114](https://github.com/nf-core/tools/pull/2114))
 - Fix a bug introduced in 2.7 that made pipelines hang ([#2132](https://github.com/nf-core/tools/issues/2132))
+- Explicitly disable `conda` when using container profiles ([#2140](https://github.com/nf-core/tools/pull/2140))
 
 ### Linting
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 - Fix the syntax of github_output in GitHub actions ([#2114](https://github.com/nf-core/tools/pull/2114))
 - Fix a bug introduced in 2.7 that made pipelines hang ([#2132](https://github.com/nf-core/tools/issues/2132))
-- Explicitly disable `conda` when using container profiles ([#2140](https://github.com/nf-core/tools/pull/2140))
+- Explicitly disable `conda` when a container profile ([#2140](https://github.com/nf-core/tools/pull/2140))
 
 ### Linting
 

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -102,6 +102,7 @@ profiles {
     docker {
         docker.enabled         = true
         docker.userEmulation   = true
+        conda.enabled          = false
         singularity.enabled    = false
         podman.enabled         = false
         shifter.enabled        = false
@@ -113,6 +114,7 @@ profiles {
     singularity {
         singularity.enabled    = true
         singularity.autoMounts = true
+        conda.enabled          = false
         docker.enabled         = false
         podman.enabled         = false
         shifter.enabled        = false
@@ -120,6 +122,7 @@ profiles {
     }
     podman {
         podman.enabled         = true
+        conda.enabled          = false
         docker.enabled         = false
         singularity.enabled    = false
         shifter.enabled        = false
@@ -127,6 +130,7 @@ profiles {
     }
     shifter {
         shifter.enabled        = true
+        conda.enabled          = false
         docker.enabled         = false
         singularity.enabled    = false
         podman.enabled         = false
@@ -134,6 +138,7 @@ profiles {
     }
     charliecloud {
         charliecloud.enabled   = true
+        conda.enabled          = false
         docker.enabled         = false
         singularity.enabled    = false
         podman.enabled         = false


### PR DESCRIPTION
This ensures consistency across all profiles that only one software environment system is selected at any one time.

This also allows complete 'evaluation' of what container system is being used within a given pipeline run. 

This was motivated by: https://github.com/nf-core/modules/pull/2688/files where we have to check if conda is enabled with `session.config.conda.enabled`.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
