### PR TITLE
Add code to skip deleting untracked/ignored files

### DIFF
--- a/nf_core/sync.py
+++ b/nf_core/sync.py
@@ -212,8 +212,11 @@ class PipelineSync:
         """
         # Delete everything
         log.info("Deleting all files in 'TEMPLATE' branch")
-        for the_file in os.listdir(self.pipeline_dir):
-            if the_file == ".git" or the_file == self.template_yaml_path:
+        all_files = os.listdir(self.pipeline_dir)
+        ignored = self.repo.ignored(all_files)
+        keep = [*ignored, *self.repo.untracked_files, ".git", self.template_yaml_path]
+        for the_file in all_files:
+            if the_file in keep:
                 continue
             file_path = os.path.join(self.pipeline_dir, the_file)
             log.debug(f"Deleting {file_path}")


### PR DESCRIPTION
Possible solution for #2146 

Use the `git.Repo` functionality to find ignored and untracked files and skip them when performing a delete.

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
