### PR TITLE
schema docs correctly show required status

### DIFF
--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -495,6 +495,7 @@ class PipelineSchema:
         out += f"{self.schema['description']}\n"
         # Grouped parameters
         for definition in self.schema.get("definitions", {}).values():
+            required = definition.get("required", [])
             out += f"\n## {definition.get('title', {})}\n\n"
             out += f"{definition.get('description', '')}\n\n"
             out += "".join([f"| {column.title()} " for column in columns])
@@ -513,12 +514,15 @@ class PipelineSchema:
                             out += f"<details><summary>Help</summary><small>{help_txt}</small></details>"
                     elif column == "type":
                         out += f"| `{param.get('type', '')}` "
+                    elif column == "required":
+                        out += f"| {p_key in required or ''} "
                     else:
                         out += f"| {param.get(column, '')} "
                 out += "|\n"
 
         # Top-level ungrouped parameters
         if len(self.schema.get("properties", {})) > 0:
+            required = self.schema.get("required", [])
             out += "\n## Other parameters\n\n"
             out += "".join([f"| {column.title()} " for column in columns])
             out += "|\n"

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -495,54 +495,57 @@ class PipelineSchema:
         out += f"{self.schema['description']}\n"
         # Grouped parameters
         for definition in self.schema.get("definitions", {}).values():
-            required = definition.get("required", [])
             out += f"\n## {definition.get('title', {})}\n\n"
             out += f"{definition.get('description', '')}\n\n"
-            out += "".join([f"| {column.title()} " for column in columns])
-            out += "|\n"
-            out += "".join(["|-----------" for columns in columns])
-            out += "|\n"
-            for p_key, param in definition.get("properties", {}).items():
-                for column in columns:
-                    if column == "parameter":
-                        out += f"| `{p_key}` "
-                    elif column == "description":
-                        desc = param.get("description", "").replace("\n", "<br>")
-                        out += f"| {desc} "
-                        if param.get("help_text", "") != "":
-                            help_txt = param["help_text"].replace("\n", "<br>")
-                            out += f"<details><summary>Help</summary><small>{help_txt}</small></details>"
-                    elif column == "type":
-                        out += f"| `{param.get('type', '')}` "
-                    elif column == "required":
-                        out += f"| {p_key in required or ''} "
-                    else:
-                        out += f"| {param.get(column, '')} "
-                out += "|\n"
+            required = definition.get("required", [])
+            properties = definition.get("properties", {}).items()
+            param_table = self.markdown_param_table_content(properties, required, columns)
+            out += param_table
 
         # Top-level ungrouped parameters
         if len(self.schema.get("properties", {})) > 0:
-            required = self.schema.get("required", [])
             out += "\n## Other parameters\n\n"
-            out += "".join([f"| {column.title()} " for column in columns])
-            out += "|\n"
-            out += "".join(["|-----------" for columns in columns])
-            out += "|\n"
+            required = self.schema.get("required", [])
+            properties = self.schema.get("properties", {})
+            param_table = self.markdown_param_table_content(properties, required, columns)
+            out += param_table
 
-            for p_key, param in self.schema.get("properties", {}).items():
-                for column in columns:
-                    if column == "parameter":
-                        out += f"| `{p_key}` "
-                    elif column == "description":
-                        out += f"| {param.get('description', '')} "
-                        if param.get("help_text", "") != "":
-                            out += f"<details><summary>Help</summary><small>{param['help_text']}</small></details>"
-                    elif column == "type":
-                        out += f"| `{param.get('type', '')}` "
-                    else:
-                        out += f"| {param.get(column, '')} "
-                out += "|\n"
+        return out
 
+    def markdown_param_table(properties, required, columns):
+        """Creates a markdown table for params from jsonschema properties section
+
+        Args:
+            properties (dict): A jsonschema properties dictionary
+            required (list): A list of the required fields.
+                Should come from the same level of the jsonschema as properties
+            columns (list): A list of columns to write
+
+        Returns:
+            str: A string with the markdown table
+        """
+        out = ""
+        out += "".join([f"| {column.title()} " for column in columns])
+        out += "|\n"
+        out += "".join(["|-----------" for _ in columns])
+        out += "|\n"
+        for p_key, param in properties.items():
+            for column in columns:
+                if column == "parameter":
+                    out += f"| `{p_key}` "
+                elif column == "description":
+                    desc = param.get("description", "").replace("\n", "<br>")
+                    out += f"| {desc} "
+                    if param.get("help_text", "") != "":
+                        help_txt = param["help_text"].replace("\n", "<br>")
+                        out += f"<details><summary>Help</summary><small>{help_txt}</small></details>"
+                elif column == "type":
+                    out += f"| `{param.get('type', '')}` "
+                elif column == "required":
+                    out += f"| {p_key in required or ''} "
+                else:
+                    out += f"| {param.get(column, '')} "
+            out += "|\n"
         return out
 
     def markdown_to_html(self, markdown_str):

--- a/nf_core/schema.py
+++ b/nf_core/schema.py
@@ -498,8 +498,8 @@ class PipelineSchema:
             out += f"\n## {definition.get('title', {})}\n\n"
             out += f"{definition.get('description', '')}\n\n"
             required = definition.get("required", [])
-            properties = definition.get("properties", {}).items()
-            param_table = self.markdown_param_table_content(properties, required, columns)
+            properties = definition.get("properties", {})
+            param_table = self.markdown_param_table(properties, required, columns)
             out += param_table
 
         # Top-level ungrouped parameters
@@ -507,12 +507,12 @@ class PipelineSchema:
             out += "\n## Other parameters\n\n"
             required = self.schema.get("required", [])
             properties = self.schema.get("properties", {})
-            param_table = self.markdown_param_table_content(properties, required, columns)
+            param_table = self.markdown_param_table(properties, required, columns)
             out += param_table
 
         return out
 
-    def markdown_param_table(properties, required, columns):
+    def markdown_param_table(self, properties, required, columns):
         """Creates a markdown table for params from jsonschema properties section
 
         Args:


### PR DESCRIPTION
The code for `nf-core schema docs` assumed that `required` was a field on the `parameter` object in the `json`. It is actually an array at the level of the properties. Due to this `param.get('required')` was always false and auto-generated docs display every parameter as optional.

This PR fixes the code to check for the parameters inclusion in the `required` array.  
 
## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
