### PR TITLE
speed up git clones with treeless clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### General
 
+- Replace full clone with treeless clone of the modules repository for speed gains ([#2162](https://github.com/nf-core/tools/pull/2162)).
+
 ## [v2.7.2 - Mercury Eagle Patch](https://github.com/nf-core/tools/releases/tag/2.7.2) - [2022-12-19]
 
 ### Template

--- a/nf_core/modules/modules_repo.py
+++ b/nf_core/modules/modules_repo.py
@@ -192,6 +192,7 @@ class ModulesRepo:
                         self.repo = git.Repo.clone_from(
                             remote,
                             self.local_repo_dir,
+                            filter=["tree:0"],
                             progress=RemoteProgressbar(pbar, self.fullname, self.remote_url, "Cloning"),
                         )
                     ModulesRepo.update_local_repo_status(self.fullname, True)

--- a/nf_core/modules/modules_repo.py
+++ b/nf_core/modules/modules_repo.py
@@ -192,7 +192,7 @@ class ModulesRepo:
                         self.repo = git.Repo.clone_from(
                             remote,
                             self.local_repo_dir,
-                            filter=["tree:0"],
+                            filter=["tree:0"],  # don't clone the whole history, might influence other git commands
                             progress=RemoteProgressbar(pbar, self.fullname, self.remote_url, "Cloning"),
                         )
                     ModulesRepo.update_local_repo_status(self.fullname, True)


### PR DESCRIPTION
based on this recommendation: https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/

Have to be careful with any downstream effects, because it might influence the cost of other git commands.

Bonus points if we can use `depth=1` when running tests, but I don't know how to best detect that inside the code.