### PR TITLE
Replace requests_mock with responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - `nf-core modules/subworkflows info` now prints the include statement for the module/subworkflow ([#2182](https://github.com/nf-core/tools/pull/2182)).
 - Add the Nextflow version to Gitpod container matching the minimal Nextflow version for nf-core (according to `nextflow.config`) ([#2196](https://github.com/nf-core/tools/pull/2196))
 - Use `nfcore/gitpod:dev` container in the dev branch ([#2196](https://github.com/nf-core/tools/pull/2196))
+- Replace requests_mock with responses in test mocks ([#2165](https://github.com/nf-core/tools/pull/2165)).
 
 ## [v2.7.2 - Mercury Eagle Patch](https://github.com/nf-core/tools/releases/tag/2.7.2) - [2022-12-19]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@ isort
 myst_parser
 pytest-cov
 pytest-datafiles
-requests-mock
+responses
 Sphinx
 sphinx-rtd-theme
-requests_mock

--- a/tests/modules/create.py
+++ b/tests/modules/create.py
@@ -4,13 +4,14 @@ import pytest
 import responses
 
 import nf_core.modules
-from tests.utils import mock_api_calls
+from tests.utils import mock_anaconda_api_calls, mock_biocontainers_api_calls
 
 
 def test_modules_create_succeed(self):
     """Succeed at creating the TrimGalore! module"""
     with responses.RequestsMock() as rsps:
-        mock_api_calls(rsps, "trim-galore", "0.6.7")
+        mock_anaconda_api_calls(rsps, "trim-galore", "0.6.7")
+        mock_biocontainers_api_calls(rsps, "trim-galore", "0.6.7")
         module_create = nf_core.modules.ModuleCreate(
             self.pipeline_dir, "trimgalore", "@author", "process_single", True, True, conda_name="trim-galore"
         )
@@ -21,7 +22,8 @@ def test_modules_create_succeed(self):
 def test_modules_create_fail_exists(self):
     """Fail at creating the same module twice"""
     with responses.RequestsMock() as rsps:
-        mock_api_calls(rsps, "trim-galore", "0.6.7")
+        mock_anaconda_api_calls(rsps, "trim-galore", "0.6.7")
+        mock_biocontainers_api_calls(rsps, "trim-galore", "0.6.7")
         module_create = nf_core.modules.ModuleCreate(
             self.pipeline_dir, "trimgalore", "@author", "process_single", False, False, conda_name="trim-galore"
         )
@@ -34,7 +36,8 @@ def test_modules_create_fail_exists(self):
 def test_modules_create_nfcore_modules(self):
     """Create a module in nf-core/modules clone"""
     with responses.RequestsMock() as rsps:
-        mock_api_calls(rsps, "fastqc", "0.11.9")
+        mock_anaconda_api_calls(rsps, "fastqc", "0.11.9")
+        mock_biocontainers_api_calls(rsps, "fastqc", "0.11.9")
         module_create = nf_core.modules.ModuleCreate(
             self.nfcore_modules, "fastqc", "@author", "process_low", False, False
         )
@@ -46,7 +49,8 @@ def test_modules_create_nfcore_modules(self):
 def test_modules_create_nfcore_modules_subtool(self):
     """Create a tool/subtool module in a nf-core/modules clone"""
     with responses.RequestsMock() as rsps:
-        mock_api_calls(rsps, "star", "2.8.10a")
+        mock_anaconda_api_calls(rsps, "star", "2.8.10a")
+        mock_biocontainers_api_calls(rsps, "star", "2.8.10a")
         module_create = nf_core.modules.ModuleCreate(
             self.nfcore_modules, "star/index", "@author", "process_medium", False, False
         )

--- a/tests/modules/create.py
+++ b/tests/modules/create.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+import requests_cache
 import responses
 
 import nf_core.modules
@@ -15,7 +16,8 @@ def test_modules_create_succeed(self):
         module_create = nf_core.modules.ModuleCreate(
             self.pipeline_dir, "trimgalore", "@author", "process_single", True, True, conda_name="trim-galore"
         )
-        module_create.create()
+        with requests_cache.disabled():
+            module_create.create()
     assert os.path.exists(os.path.join(self.pipeline_dir, "modules", "local", "trimgalore.nf"))
 
 
@@ -27,9 +29,11 @@ def test_modules_create_fail_exists(self):
         module_create = nf_core.modules.ModuleCreate(
             self.pipeline_dir, "trimgalore", "@author", "process_single", False, False, conda_name="trim-galore"
         )
-        module_create.create()
-        with pytest.raises(UserWarning) as excinfo:
+        with requests_cache.disabled():
             module_create.create()
+        with pytest.raises(UserWarning) as excinfo:
+            with requests_cache.disabled():
+                module_create.create()
     assert "Module file exists already" in str(excinfo.value)
 
 
@@ -41,7 +45,8 @@ def test_modules_create_nfcore_modules(self):
         module_create = nf_core.modules.ModuleCreate(
             self.nfcore_modules, "fastqc", "@author", "process_low", False, False
         )
-        module_create.create()
+        with requests_cache.disabled():
+            module_create.create()
     assert os.path.exists(os.path.join(self.nfcore_modules, "modules", "nf-core", "fastqc", "main.nf"))
     assert os.path.exists(os.path.join(self.nfcore_modules, "tests", "modules", "nf-core", "fastqc", "main.nf"))
 
@@ -54,6 +59,7 @@ def test_modules_create_nfcore_modules_subtool(self):
         module_create = nf_core.modules.ModuleCreate(
             self.nfcore_modules, "star/index", "@author", "process_medium", False, False
         )
-        module_create.create()
+        with requests_cache.disabled():
+            module_create.create()
     assert os.path.exists(os.path.join(self.nfcore_modules, "modules", "nf-core", "star", "index", "main.nf"))
     assert os.path.exists(os.path.join(self.nfcore_modules, "tests", "modules", "nf-core", "star", "index", "main.nf"))

--- a/tests/modules/create.py
+++ b/tests/modules/create.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-import requests_mock
+import responses
 
 import nf_core.modules
 from tests.utils import mock_api_calls
@@ -9,8 +9,8 @@ from tests.utils import mock_api_calls
 
 def test_modules_create_succeed(self):
     """Succeed at creating the TrimGalore! module"""
-    with requests_mock.Mocker() as mock:
-        mock_api_calls(mock, "trim-galore", "0.6.7")
+    with responses.RequestsMock() as rsps:
+        mock_api_calls(rsps, "trim-galore", "0.6.7")
         module_create = nf_core.modules.ModuleCreate(
             self.pipeline_dir, "trimgalore", "@author", "process_single", True, True, conda_name="trim-galore"
         )
@@ -20,8 +20,8 @@ def test_modules_create_succeed(self):
 
 def test_modules_create_fail_exists(self):
     """Fail at creating the same module twice"""
-    with requests_mock.Mocker() as mock:
-        mock_api_calls(mock, "trim-galore", "0.6.7")
+    with responses.RequestsMock() as rsps:
+        mock_api_calls(rsps, "trim-galore", "0.6.7")
         module_create = nf_core.modules.ModuleCreate(
             self.pipeline_dir, "trimgalore", "@author", "process_single", False, False, conda_name="trim-galore"
         )
@@ -33,8 +33,8 @@ def test_modules_create_fail_exists(self):
 
 def test_modules_create_nfcore_modules(self):
     """Create a module in nf-core/modules clone"""
-    with requests_mock.Mocker() as mock:
-        mock_api_calls(mock, "fastqc", "0.11.9")
+    with responses.RequestsMock() as rsps:
+        mock_api_calls(rsps, "fastqc", "0.11.9")
         module_create = nf_core.modules.ModuleCreate(
             self.nfcore_modules, "fastqc", "@author", "process_low", False, False
         )
@@ -45,8 +45,8 @@ def test_modules_create_nfcore_modules(self):
 
 def test_modules_create_nfcore_modules_subtool(self):
     """Create a tool/subtool module in a nf-core/modules clone"""
-    with requests_mock.Mocker() as mock:
-        mock_api_calls(mock, "star", "2.8.10a")
+    with responses.RequestsMock() as rsps:
+        mock_api_calls(rsps, "star", "2.8.10a")
         module_create = nf_core.modules.ModuleCreate(
             self.nfcore_modules, "star/index", "@author", "process_medium", False, False
         )

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -18,7 +18,6 @@ from .utils import (
     GITLAB_URL,
     OLD_TRIMGALORE_BRANCH,
     OLD_TRIMGALORE_SHA,
-    mock_api_calls,
 )
 
 
@@ -34,12 +33,10 @@ def create_modules_repo_dummy(tmp_dir):
     with open(os.path.join(root_dir, ".nf-core.yml"), "w") as fh:
         fh.writelines(["repository_type: modules", "\n", "org_path: nf-core", "\n"])
 
-    # mock biocontainers and anaconda response
-    with responses.RequestsMock() as rsps:
-        mock_api_calls(rsps, "bpipe", "0.9.11--hdfd78af_0")
-        # bpipe is a valid package on bioconda that is very unlikely to ever be added to nf-core/modules
-        module_create = nf_core.modules.ModuleCreate(root_dir, "bpipe/test", "@author", "process_single", False, False)
-        module_create.create()
+    # FIXME Should use mock?
+    # bpipe is a valid package on bioconda that is very unlikely to ever be added to nf-core/modules
+    module_create = nf_core.modules.ModuleCreate(root_dir, "bpipe/test", "@author", "process_single", False, False)
+    module_create.create()
 
     return root_dir
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -6,7 +6,7 @@ import shutil
 import tempfile
 import unittest
 
-import requests_mock
+import responses
 
 import nf_core.create
 import nf_core.modules
@@ -35,8 +35,8 @@ def create_modules_repo_dummy(tmp_dir):
         fh.writelines(["repository_type: modules", "\n", "org_path: nf-core", "\n"])
 
     # mock biocontainers and anaconda response
-    with requests_mock.Mocker() as mock:
-        mock_api_calls(mock, "bpipe", "0.9.11--hdfd78af_0")
+    with responses.RequestsMock() as rsps:
+        mock_api_calls(rsps, "bpipe", "0.9.11--hdfd78af_0")
         # bpipe is a valid package on bioconda that is very unlikely to ever be added to nf-core/modules
         module_create = nf_core.modules.ModuleCreate(root_dir, "bpipe/test", "@author", "process_single", False, False)
         module_create.create()

--- a/tests/test_subworkflows.py
+++ b/tests/test_subworkflows.py
@@ -6,7 +6,7 @@ import shutil
 import tempfile
 import unittest
 
-import requests_mock
+import responses
 
 import nf_core.create
 import nf_core.modules
@@ -30,7 +30,8 @@ def create_modules_repo_dummy(tmp_dir):
     with open(os.path.join(root_dir, ".nf-core.yml"), "w") as fh:
         fh.writelines(["repository_type: modules", "\n", "org_path: nf-core", "\n"])
 
-    with requests_mock.Mocker() as mock:
+    # FIXME This mock isn't used
+    with responses.RequestsMock() as rsps:
         subworkflow_create = nf_core.subworkflows.SubworkflowCreate(root_dir, "test_subworkflow", "@author", True)
         subworkflow_create.create()
 

--- a/tests/test_subworkflows.py
+++ b/tests/test_subworkflows.py
@@ -30,10 +30,9 @@ def create_modules_repo_dummy(tmp_dir):
     with open(os.path.join(root_dir, ".nf-core.yml"), "w") as fh:
         fh.writelines(["repository_type: modules", "\n", "org_path: nf-core", "\n"])
 
-    # FIXME This mock isn't used
-    with responses.RequestsMock() as rsps:
-        subworkflow_create = nf_core.subworkflows.SubworkflowCreate(root_dir, "test_subworkflow", "@author", True)
-        subworkflow_create.create()
+    # TODO Add a mock here
+    subworkflow_create = nf_core.subworkflows.SubworkflowCreate(root_dir, "test_subworkflow", "@author", True)
+    subworkflow_create.create()
 
     return root_dir
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -70,11 +70,8 @@ def set_wd(path: Path):
         os.chdir(start_wd)
 
 
-def mock_api_calls(rsps: responses.RequestsMock, module, version):
-    """Mock biocontainers and anaconda api calls for module"""
-    biocontainers_api_url = (
-        f"https://api.biocontainers.pro/ga4gh/trs/v2/tools/{module}/versions/{module}-{version.split('--')[0]}"
-    )
+def mock_anaconda_api_calls(rsps: responses.RequestsMock, module, version):
+    """Mock anaconda api calls for module"""
     anaconda_api_url = f"https://api.anaconda.org/package/bioconda/{module}"
     anaconda_mock = {
         "latest_version": version.split("--")[0],
@@ -84,6 +81,14 @@ def mock_api_calls(rsps: responses.RequestsMock, module, version):
         "files": [{"version": version.split("--")[0]}],
         "license": "",
     }
+    rsps.get(anaconda_api_url, json=anaconda_mock, status=200)
+
+
+def mock_biocontainers_api_calls(rsps: responses.RequestsMock, module, version):
+    """Mock biocontainers api calls for module"""
+    biocontainers_api_url = (
+        f"https://api.biocontainers.pro/ga4gh/trs/v2/tools/{module}/versions/{module}-{version.split('--')[0]}"
+    )
     biocontainers_mock = {
         "images": [
             {
@@ -98,5 +103,4 @@ def mock_api_calls(rsps: responses.RequestsMock, module, version):
             },
         ],
     }
-    rsps.get(anaconda_api_url, json=anaconda_mock, status=200)
     rsps.get(biocontainers_api_url, json=biocontainers_mock, status=200)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,6 +8,8 @@ import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 
+import responses
+
 OLD_TRIMGALORE_SHA = "06348dffce2a732fc9e656bdc5c64c3e02d302cb"
 OLD_TRIMGALORE_BRANCH = "mimic-old-trimgalore"
 GITLAB_URL = "https://gitlab.com/nf-core/modules-test.git"
@@ -68,14 +70,13 @@ def set_wd(path: Path):
         os.chdir(start_wd)
 
 
-def mock_api_calls(mock, module, version):
+def mock_api_calls(rsps: responses.RequestsMock, module, version):
     """Mock biocontainers and anaconda api calls for module"""
     biocontainers_api_url = (
         f"https://api.biocontainers.pro/ga4gh/trs/v2/tools/{module}/versions/{module}-{version.split('--')[0]}"
     )
     anaconda_api_url = f"https://api.anaconda.org/package/bioconda/{module}"
     anaconda_mock = {
-        "status_code": 200,
         "latest_version": version.split("--")[0],
         "summary": "",
         "doc_url": "",
@@ -84,7 +85,6 @@ def mock_api_calls(mock, module, version):
         "license": "",
     }
     biocontainers_mock = {
-        "status_code": 200,
         "images": [
             {
                 "image_type": "Singularity",
@@ -98,5 +98,5 @@ def mock_api_calls(mock, module, version):
             },
         ],
     }
-    mock.register_uri("GET", anaconda_api_url, json=anaconda_mock)
-    mock.register_uri("GET", biocontainers_api_url, json=biocontainers_mock)
+    rsps.get(anaconda_api_url, json=anaconda_mock, status=200)
+    rsps.get(biocontainers_api_url, json=biocontainers_mock, status=200)


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated

Just some yak shaving, `responses` has some nice features that might improve testing in the future such as [recording responses to files](https://github.com/getsentry/responses#record-responses-to-files).

