### PR TITLE
allowing new line before description field

### DIFF
--- a/nf_core/module-template/modules/meta.yml
+++ b/nf_core/module-template/modules/meta.yml
@@ -1,7 +1,7 @@
 name: "{{ component_name_underscore }}"
 {% if not_empty_template -%}
 ## TODO nf-core: Add a description of the module and list keywords
-{%- endif -%}
+{% endif -%}
 description: write your description here
 keywords:
   - sort


### PR DESCRIPTION
Fix a typo that I introduced with #2175 

The `description` field of `meta.yml` when the flag was not provided was attached to the previous line (without a new line).

We can sneak this into the next PR as it's a tiny change, leaving it here as a reminder.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
