### PR TITLE
Dump template yml to file in pipeline repo after creation

### DIFF
--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -56,7 +56,7 @@ class PipelineCreate:
         plain=False,
         default_branch=None,
     ):
-        self.template_params, skip_paths_keys = self.create_param_dict(
+        self.template_params, skip_paths_keys, self.template_yaml = self.create_param_dict(
             name, description, author, version, template_yaml_path, plain
         )
 
@@ -178,7 +178,7 @@ class PipelineCreate:
             if not re.match(r"^[a-z]+$", param_dict["short_name"]):
                 raise UserWarning("[red]Invalid workflow name: must be lowercase without punctuation.")
 
-        return param_dict, skip_paths
+        return param_dict, skip_paths, template_yaml
 
     def customize_template(self, template_areas):
         """Customizes the template parameters.
@@ -347,6 +347,10 @@ class PipelineCreate:
 
             # Update the .nf-core.yml with linting configurations
             self.fix_linting()
+
+        log.debug("Dumping pipeline template yml to file")
+        with open(self.outdir / "pipeline_template.yml", "w") as fh:
+            yaml.safe_dump(self.template_yaml, fh)
 
     def update_nextflow_schema(self):
         """

--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -349,8 +349,9 @@ class PipelineCreate:
             self.fix_linting()
 
         log.debug("Dumping pipeline template yml to file")
-        with open(self.outdir / "pipeline_template.yml", "w") as fh:
-            yaml.safe_dump(self.template_yaml, fh)
+        if self.template_yaml:
+            with open(self.outdir / "pipeline_template.yml", "w") as fh:
+                yaml.safe_dump(self.template_yaml, fh)
 
     def update_nextflow_schema(self):
         """


### PR DESCRIPTION
Adds feature to solve #2143

The template yaml is now required to properly lint/sync custom pipelines. Currently if it's initially retrieved from CLI inputs when running `nf-core create` it does not get saved to file anywhere. 

This PR dumps the template yaml used to create the pipeline into a `pipeline_template.yml` file in the new repo.  

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
