### PR TITLE
Lint check for params.enable_conda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Linting
 
+- Update modules lint test to fail if enable_conda is found ([#2213](https://github.com/nf-core/tools/pull/2213))
+
 ### Modules
 
 - Add an `--empty-template` option to create a module without TODO statements or examples ([#2175](https://github.com/nf-core/tools/pull/2175) & [#2177](https://github.com/nf-core/tools/pull/2177))

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -1398,7 +1398,9 @@ def build(dir, no_prompts, web_only, url):
 
 # nf-core schema lint
 @schema.command()
-@click.argument("schema_path", type=click.Path(exists=True), default="nextflow_schema.json", metavar="<pipeline schema>")
+@click.argument(
+    "schema_path", type=click.Path(exists=True), default="nextflow_schema.json", metavar="<pipeline schema>"
+)
 def lint(schema_path):
     """
     Check that a given pipeline schema is valid.

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -265,7 +265,7 @@ def check_process_section(self, lines, fix_version, progress_bar):
                 self.passed.append(
                     (
                         "deprecated_enable_conda",
-                        f"Found deprecated parameter 'params.enable_conda' in the conda definition",
+                        f"Deprecated parameter 'params.enable_conda' correctly not found in the conda definition",
                         self.main_nf,
                     )
                 )
@@ -273,7 +273,7 @@ def check_process_section(self, lines, fix_version, progress_bar):
                 self.failed.append(
                     (
                         "deprecated_enable_conda",
-                        f"Deprecated parameter 'params.enable_conda' correctly not found in the conda definition",
+                        f"Found deprecated parameter 'params.enable_conda' in the conda definition",
                         self.main_nf,
                     )
                 )

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -261,11 +261,23 @@ def check_process_section(self, lines, fix_version, progress_bar):
         if _container_type(l) == "bioconda":
             bioconda_packages = [b for b in l.split() if "bioconda::" in b]
         if _container_type(l) == "bioconda" or _container_type(l) == "conda":
-            match = re.search(r"params\.enable_conda",l)
+            match = re.search(r"params\.enable_conda", l)
             if match is None:
-                self.passed.append(("deprecated_enable_conda", f"Found deprecated parameter 'params.enable_conda' in the conda definition", self.main_nf))
+                self.passed.append(
+                    (
+                        "deprecated_enable_conda",
+                        f"Found deprecated parameter 'params.enable_conda' in the conda definition",
+                        self.main_nf,
+                    )
+                )
             else:
-                self.failed.append(("deprecated_enable_conda", f"Deprecated parameter 'params.enable_conda' correctly not found in the conda definition", self.main_nf))
+                self.failed.append(
+                    (
+                        "deprecated_enable_conda",
+                        f"Deprecated parameter 'params.enable_conda' correctly not found in the conda definition",
+                        self.main_nf,
+                    )
+                )
         if _container_type(l) == "singularity":
             # e.g. "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img' :" -> v1.2.0_cv1
             # e.g. "https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0' :" -> 0.11.9--0

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -488,7 +488,7 @@ def _fix_module_version(self, current_version, latest_version, singularity_tag, 
     for line in lines:
         l = line.strip(" '\"")
         build_type = _container_type(l)
-        if build_type == "bioconda":
+        if build_type == "conda":
             new_lines.append(re.sub(rf"{current_version}", f"{latest_version}", line))
         elif build_type in ("singularity", "docker"):
             # Check that the new url is valid

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -258,9 +258,8 @@ def check_process_section(self, lines, fix_version, progress_bar):
     for i, l in enumerate(lines):
         url = None
         l = l.strip(" '\"")
-        if _container_type(l) == "bioconda":
+        if _container_type(l) == "conda":
             bioconda_packages = [b for b in l.split() if "bioconda::" in b]
-        if _container_type(l) == "bioconda" or _container_type(l) == "conda":
             match = re.search(r"params\.enable_conda", l)
             if match is None:
                 self.passed.append(
@@ -534,8 +533,6 @@ def _get_build(response):
 
 def _container_type(line):
     """Returns the container type of a build."""
-    if re.search("bioconda::", line):
-        return "bioconda"
     if line.startswith("conda"):
         return "conda"
     if line.startswith("https://containers") or line.startswith("https://depot"):

--- a/tests/modules/lint.py
+++ b/tests/modules/lint.py
@@ -66,7 +66,7 @@ def test_modules_lint_gitlab_modules(self):
     self.mods_install_gitlab.install("multiqc")
     module_lint = nf_core.modules.ModuleLint(dir=self.pipeline_dir, remote_url=GITLAB_URL)
     module_lint.lint(print_results=False, all_modules=True)
-    assert len(module_lint.failed) == 1
+    assert len(module_lint.failed) == 2
     assert len(module_lint.passed) > 0
     assert len(module_lint.warned) >= 0
 

--- a/tests/modules/lint.py
+++ b/tests/modules/lint.py
@@ -66,7 +66,7 @@ def test_modules_lint_gitlab_modules(self):
     self.mods_install_gitlab.install("multiqc")
     module_lint = nf_core.modules.ModuleLint(dir=self.pipeline_dir, remote_url=GITLAB_URL)
     module_lint.lint(print_results=False, all_modules=True)
-    assert len(module_lint.failed) == 0
+    assert len(module_lint.failed) == 1
     assert len(module_lint.passed) > 0
     assert len(module_lint.warned) >= 0
 
@@ -77,7 +77,7 @@ def test_modules_lint_multiple_remotes(self):
     self.mods_install_gitlab.install("multiqc")
     module_lint = nf_core.modules.ModuleLint(dir=self.pipeline_dir, remote_url=GITLAB_URL)
     module_lint.lint(print_results=False, all_modules=True)
-    assert len(module_lint.failed) == 0
+    assert len(module_lint.failed) == 1
     assert len(module_lint.passed) > 0
     assert len(module_lint.warned) >= 0
 
@@ -103,6 +103,6 @@ def test_modules_lint_patched_modules(self):
             all_modules=True,
         )
 
-    assert len(module_lint.failed) == 0
+    assert len(module_lint.failed) == 1
     assert len(module_lint.passed) > 0
     assert len(module_lint.warned) >= 0


### PR DESCRIPTION
Addresses #2187 
usage of params.enable_conda has been deprecated. Currently it is a fail condition from the pipeline linter which only checks the config file but the module linter does not.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated

Tests were updated to catch new failures.