### PR TITLE
Make `nf-core modules lint` use new config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Linting
 
+- Read module lint configuration from `.nf-core.yml`, not `.nf-core-lint.yml` ([#2221](https://github.com/nf-core/tools/pull/2221))
+
 ### Modules
 
 - Add an `--empty-template` option to create a module without TODO statements or examples ([#2175](https://github.com/nf-core/tools/pull/2175) & [#2177](https://github.com/nf-core/tools/pull/2177))

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -341,7 +341,7 @@ def lint(ctx, dir, release, fix, key, show_passed, fail_ignored, fail_warned, ma
     meets the nf-core guidelines. Documentation of all lint tests can be found
     on the nf-core website: [link=https://nf-co.re/tools-docs/]https://nf-co.re/tools-docs/[/]
 
-    You can ignore tests using a file called [blue].nf-core-lint.yaml[/] [i](if you have a good reason!)[/].
+    You can ignore tests using a file called [blue].nf-core.yml[/] [i](if you have a good reason!)[/].
     See the documentation for details.
     """
 

--- a/nf_core/components/components_command.py
+++ b/nf_core/components/components_command.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import yaml
 
+import nf_core.utils
 from nf_core.modules.modules_json import ModulesJson
 from nf_core.modules.modules_repo import ModulesRepo
 
@@ -162,24 +163,13 @@ class ComponentCommand:
     def load_lint_config(self):
         """Parse a pipeline lint config file.
 
-        Look for a file called either `.nf-core-lint.yml` or
-        `.nf-core-lint.yaml` in the pipeline root directory and parse it.
-        (`.yml` takes precedence).
+        Load the '.nf-core.yml'  config file and extract
+        the lint config from it
 
         Add parsed config to the `self.lint_config` class attribute.
         """
-        config_fn = os.path.join(self.dir, ".nf-core-lint.yml")
-
-        # Pick up the file if it's .yaml instead of .yml
-        if not os.path.isfile(config_fn):
-            config_fn = os.path.join(self.dir, ".nf-core-lint.yaml")
-
-        # Load the YAML
-        try:
-            with open(config_fn, "r") as fh:
-                self.lint_config = yaml.safe_load(fh)
-        except FileNotFoundError:
-            log.debug(f"No lint config file found: {config_fn}")
+        _, tools_config = nf_core.utils.load_tools_config(self.dir)
+        self.lint_config = tools_config.get("lint", {})
 
     def check_modules_structure(self):
         """

--- a/nf_core/lint/nextflow_config.py
+++ b/nf_core/lint/nextflow_config.py
@@ -92,20 +92,22 @@ def nextflow_config(self):
     * Process-level configuration syntax still using the old Nextflow syntax, for example: ``process.$fastqc`` instead of ``process withName:'fastqc'``.
 
     .. tip:: You can choose to ignore tests for the presence or absence of specific config variables
-             by creating a file called ``.nf-core-lint.yml`` in the root of your pipeline and creating
+             by creating a file called ``.nf-core.yml`` in the root of your pipeline and creating
              a list the config variables that should be ignored. For example:
 
              .. code-block:: yaml
 
-                nextflow_config:
-                    - params.input
+                lint:
+                    nextflow_config:
+                        - params.input
 
              The other checks in this test (depreciated syntax etc) can not be individually identified,
              but you can skip the entire test block if you wish:
 
              .. code-block:: yaml
 
-                nextflow_config: False
+                lint:
+                    nextflow_config: False
     """
     passed = []
     warned = []


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

Previously `nf-core modules lint` would use a weird mixture of `.nf-core-lint.yml` (deprecated) and `.nf-core.yml`; I believe this PR removes all references to the former, except for the code in `nf_core/utils.py` that prints a warning if only the deprecated file is present.

For example, running `nf-core modules lint fastqc` on a freshly-created repo with the `fastqc` module shows a warning about fastqc being out of date, even with the following `.nf-core.yml`:

```yaml
repository_type: pipeline
lint:
  main_nf: false
```

(if you instead put that lint config in `.nf-core-lint.yml`, you get... a weird crash "AttributeError: 'NFCoreModule' object has no attribute 'process_name'", but you do also get "INFO     Ignoring lint test: main_nf".)

With this PR, the deprecated config file is ignored (like the rest of the lint commands), and you can only ignore the lint/cause the crash by including the lint config in `.nf-core.yml`.

I'm not sure how to write a test for this – if it's worth doing so I can give it a go (I guess some relevant existing tests are probably in `tests/modules/lint.py`?)

Fixes #2212

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
