### PR TITLE
Don't require an argument for `nf-core schema lint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Linting
 
 - Read module lint configuration from `.nf-core.yml`, not `.nf-core-lint.yml` ([#2221](https://github.com/nf-core/tools/pull/2221))
+- `nf-core schema lint` now defaults to linting `nextflow_schema.json` if no filename is provided ([#2225](https://github.com/nf-core/tools/pull/2225))
 
 ### Modules
 

--- a/README.md
+++ b/README.md
@@ -634,13 +634,13 @@ It's important to change the default value of a parameter in the `nextflow.confi
 The pipeline schema is linted as part of the main pipeline `nf-core lint` command,
 however sometimes it can be useful to quickly check the syntax of the JSONSchema without running a full lint run.
 
-Usage is `nf-core schema lint <schema>`, eg:
+Usage is `nf-core schema lint <schema>` (defaulting to `nextflow_schema.json`), eg:
 
 <!-- RICH-CODEX
 working_dir: tmp/nf-core-nextbigthing
 -->
 
-![`nf-core schema lint nextflow_schema.json`](docs/images/nf-core-schema-lint.svg)
+![`nf-core schema lint`](docs/images/nf-core-schema-lint.svg)
 
 ## Bumping a pipeline version number
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -1398,7 +1398,7 @@ def build(dir, no_prompts, web_only, url):
 
 # nf-core schema lint
 @schema.command()
-@click.argument("schema_path", type=click.Path(exists=True), required=True, metavar="<pipeline schema>")
+@click.argument("schema_path", type=click.Path(exists=True), default="nextflow_schema.json", metavar="<pipeline schema>")
 def lint(schema_path):
     """
     Check that a given pipeline schema is valid.
@@ -1408,6 +1408,8 @@ def lint(schema_path):
 
     This function runs as part of the nf-core lint command, this is a convenience
     command that does just the schema linting nice and quickly.
+
+    If no schema path is provided, "nextflow_schema.json" will be used (if it exists).
     """
     schema_obj = nf_core.schema.PipelineSchema()
     try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -350,3 +350,20 @@ class TestCli(unittest.TestCase):
         assert result.exit_code == 1
         assert error_txt in captured_logs.output[-1]
         assert captured_logs.records[-1].levelname == "ERROR"
+
+    @mock.patch("nf_core.schema.PipelineSchema.get_schema_path")
+    def test_schema_lint(self, mock_get_schema_path):
+        """Test nf-core schema lint defaults to nextflow_schema.json"""
+        cmd = ["schema", "lint"]
+        result = self.invoke_cli(cmd)
+        assert mock_get_schema_path.called_with("nextflow_schema.json")
+        assert "nextflow_schema.json" in result.output
+
+    @mock.patch("nf_core.schema.PipelineSchema.get_schema_path")
+    def test_schema_lint_filename(self, mock_get_schema_path):
+        """Test nf-core schema lint accepts a filename"""
+        cmd = ["schema", "lint", "some_other_filename"]
+        result = self.invoke_cli(cmd)
+        assert mock_get_schema_path.called_with("some_other_filename")
+        assert "some_other_filename" in result.output
+        assert "nextflow_schema.json" not in result.output


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

`nf-core lint` and `nf-core modules lint` can both be called with no arguments, but `nf-core schema lint` requires that you pass the path to the schema. Since this will often just be at `./nextflow_schema.json`, defaulting to that reduces the length of the invocation in the common case and makes the usage of all three lint commands more consistent.

I'm not 100% sure of how `click.Path` works – is just providing a string as the default here correct? should I be using some other `Path` type?

Also I don't know how the fancy images in the readme get generated, I'm hoping based on looking at the commit history for them that there's some magic github action that will kick in once I open the PR...

Fixes #1838

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated