### PR TITLE
Take into accout a provided remote url when linting all modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 - Add an `--empty-template` option to create a module without TODO statements or examples ([#2175](https://github.com/nf-core/tools/pull/2175) & [#2177](https://github.com/nf-core/tools/pull/2177))
 - Removed the `nf-core modules mulled` command and all its code dependencies ([2199](https://github.com/nf-core/tools/pull/2199)).
-- Take into accout the provided `--git_remote` URL when linting all modules ([]()).
+- Take into accout the provided `--git_remote` URL when linting all modules ([2243](https://github.com/nf-core/tools/pull/2243)).
 
 ### Subworkflows
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - Add an `--empty-template` option to create a module without TODO statements or examples ([#2175](https://github.com/nf-core/tools/pull/2175) & [#2177](https://github.com/nf-core/tools/pull/2177))
 - Removed the `nf-core modules mulled` command and all its code dependencies ([2199](https://github.com/nf-core/tools/pull/2199)).
+- Take into accout the provided `--git_remote` URL when linting all modules ([]()).
 
 ### Subworkflows
 

--- a/nf_core/modules/lint/__init__.py
+++ b/nf_core/modules/lint/__init__.py
@@ -91,6 +91,8 @@ class ModuleLint(ComponentCommand):
             modules_json.check_up_to_date()
             self.all_remote_modules = []
             for repo_url, components in modules_json.get_all_components(self.component_type).items():
+                if remote_url is not None and remote_url != repo_url:
+                    continue
                 for org, comp in components:
                     self.all_remote_modules.append(
                         NFCoreModule(


### PR DESCRIPTION
Thanks to tests failing in https://github.com/nf-core/tools/pull/2190 I noticed that when linting a module providing a `--git_remote` and linting all modules with `--all` or indicating so by prompt, all modules are linted independent on the remote they come from.
This takes into account the `--git_remote` param and lints only the modules from that repo.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
