### PR TITLE
Modules Docker containers no longer includes quay.io as prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added config `docker.registry` to pipeline template for a configurable default container registry when using Docker containers. Defaults to `quay.io` ([#2133](https://github.com/nf-core/tools/pull/2133))
 - Add tower.yml file to the pipeline template ([#2251](https://github.com/nf-core/tools/pull/2251))
 - Add mastodon badge to README ([#2253](https://github.com/nf-core/tools/pull/2253))
+- Removed `quay.io` from all module Docker container references as this is now supplied at pipeline level. ([#2249](https://github.com/nf-core/tools/pull/2249))
 
 ### Linting
 

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ The Singularity image download finds containers using two methods:
 2. It scrapes any files it finds with a `.nf` file extension in the workflow `modules` directory for lines
    that look like `container = "xxx"`. This is the typical method for DSL2 pipelines, which have one container per process.
 
-Some DSL2 modules have container addresses for docker (eg. `quay.io/biocontainers/fastqc:0.11.9--0`) and also URLs for direct downloads of a Singularity continaer (eg. `https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0`).
+Some DSL2 modules have container addresses for docker (eg. `biocontainers/fastqc:0.11.9--0`) and also URLs for direct downloads of a Singularity continaer (eg. `https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0`).
 Where both are found, the download URL is preferred.
 
 Once a full list of containers is found, they are processed in the following order:

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -432,7 +432,7 @@ class DownloadWorkflow:
         Later DSL2:
             container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
                 'https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0' :
-                'quay.io/biocontainers/fastqc:0.11.9--0' }"
+                'biocontainers/fastqc:0.11.9--0' }"
 
         DSL1 / Special case DSL2:
             container "nfcore/cellranger:6.0.2"

--- a/nf_core/module-template/modules/main.nf
+++ b/nf_core/module-template/modules/main.nf
@@ -30,7 +30,7 @@ process {{ component_name_underscore|upper }} {
     conda "{{ bioconda if bioconda else 'YOUR-TOOL-HERE' }}"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         '{{ singularity_container if singularity_container else 'https://depot.galaxyproject.org/singularity/YOUR-TOOL-HERE' }}':
-        '{{ docker_container if docker_container else 'quay.io/biocontainers/YOUR-TOOL-HERE' }}' }"
+        '{{ docker_container if docker_container else 'biocontainers/YOUR-TOOL-HERE' }}' }"
 
     input:
     {% if not_empty_template -%}

--- a/nf_core/modules/bump_versions.py
+++ b/nf_core/modules/bump_versions.py
@@ -172,7 +172,7 @@ class ModuleVersionBumper(ComponentCommand):
 
             patterns = [
                 (bioconda_packages[0], f"'bioconda::{bioconda_tool_name}={last_ver}'"),
-                (rf"quay.io/biocontainers/{bioconda_tool_name}:[^'\"\s]+", docker_img),
+                (rf"biocontainers/{bioconda_tool_name}:[^'\"\s]+", docker_img),
                 (
                     rf"https://depot.galaxyproject.org/singularity/{bioconda_tool_name}:[^'\"\s]+",
                     singularity_img,

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -578,5 +578,9 @@ def _container_type(line):
         if url_match:
             return "singularity"
         return None
-    if line.startswith("biocontainers/") or line.startswith("quay.io/"):
+    if (
+        line.startswith("biocontainers/")
+        or line.startswith("quay.io/")
+        or (line.count("/") == 1 and line.count(":") == 1)
+    ):
         return "docker"

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -290,6 +290,9 @@ def check_process_section(self, lines, fix_version, progress_bar):
             else:
                 self.failed.append(("docker_tag", "Unable to parse docker tag", self.main_nf))
                 docker_tag = None
+            if l.startswith("biocontainers/"):
+                # When we think it is a biocontainer, assume we are querying quay.io/biocontainers and insert quay.io as prefix
+                l = "quay.io/" + l
             url = urlparse(l.split("'")[0])
             # lint double quotes
             if l.count('"') > 2:

--- a/nf_core/pipeline-template/modules/local/samplesheet_check.nf
+++ b/nf_core/pipeline-template/modules/local/samplesheet_check.nf
@@ -5,7 +5,7 @@ process SAMPLESHEET_CHECK {
     conda "conda-forge::python=3.8.3"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/python:3.8.3' :
-        'quay.io/biocontainers/python:3.8.3' }"
+        'biocontainers/python:3.8.3' }"
 
     input:
     path samplesheet

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -727,7 +727,8 @@ def get_biocontainer_tag(package, version):
                         docker_image = all_docker[k]["image"]
                         singularity_image = all_singularity[k]["image"]
                         current_date = date
-                return docker_image["image_name"], singularity_image["image_name"]
+                        docker_image_name = docker_image["image_name"].lstrip("quay.io/")
+                return docker_image_name, singularity_image["image_name"]
             except TypeError:
                 raise LookupError(f"Could not find docker or singularity container for {package}")
         elif response.status_code != 404:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -102,7 +102,7 @@ def mock_biocontainers_api_calls(rsps: responses.RequestsMock, module, version):
             },
             {
                 "image_type": "Docker",
-                "image_name": f"quay.io/biocontainers/{module}:{version}",
+                "image_name": f"biocontainers/{module}:{version}",
                 "updated": "2021-09-04T00:00:00Z",
             },
         ],


### PR DESCRIPTION
All modules will by default use relative Docker URI now, e.g. `biocontainers/fastqc` instead of `quay.io/biocontainers/fastqc`. Instead, `quay.io` should be set at the pipeline level (see #2233). The module creation should work as before and singularity is untouched.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
