### PR TITLE
GitPod base image: Always self-update to the latest version of Nextflow.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,6 +5,7 @@ tasks:
       python -m pip install -e .
       python -m pip install -r requirements-dev.txt
       pre-commit install --install-hooks
+      nextflow self-update
 vscode:
   extensions: # based on nf-core.nf-core-extensionpack
     - codezombiech.gitignore # Language support for .gitignore files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 
 ### General
 
-- GitPod base image: Always self-update to the latest version of Nextflow.
+- GitPod base image: Always self-update to the latest version of Nextflow. Add [pre-commit](https://pre-commit.com/) dependency.
+- GitPod configs: Update Nextflow as an init task, init pre-commit in pipeline config.
 
 # [v2.8 - Ruthenium Monkey](https://github.com/nf-core/tools/releases/tag/2.8) - [2023-04-27]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### General
 
+- GitPod base image: Always self-update to the latest version of Nextflow.
+
 # [v2.8 - Ruthenium Monkey](https://github.com/nf-core/tools/releases/tag/2.8) - [2023-04-27]
 
 ### Template

--- a/nf_core/gitpod/gitpod.Dockerfile
+++ b/nf_core/gitpod/gitpod.Dockerfile
@@ -38,13 +38,16 @@ RUN conda config --add channels defaults && \
     conda config --set channel_priority strict && \
     conda install --quiet --yes --name base mamba && \
     mamba install --quiet --yes --name base \
-    nextflow=22.10.1 \
-    nf-core \
-    nf-test \
-    black \
-    prettier \
-    pytest-workflow && \
+        nextflow \
+        nf-core \
+        nf-test \
+        black \
+        prettier \
+        pytest-workflow && \
     mamba clean --all -f -y
+
+# Update Nextflow
+RUN nextflow self-update
 
 # Install nf-core
 RUN python -m pip install .

--- a/nf_core/gitpod/gitpod.Dockerfile
+++ b/nf_core/gitpod/gitpod.Dockerfile
@@ -43,6 +43,7 @@ RUN conda config --add channels defaults && \
         nf-test \
         black \
         prettier \
+        pre-commit \
         pytest-workflow && \
     mamba clean --all -f -y
 

--- a/nf_core/pipeline-template/.gitpod.yml
+++ b/nf_core/pipeline-template/.gitpod.yml
@@ -1,4 +1,9 @@
 image: nfcore/gitpod:latest
+tasks:
+  - name: Update Nextflow and setup pre-commit
+    command: |
+      pre-commit install --install-hooks
+      nextflow self-update
 
 vscode:
   extensions: # based on nf-core.nf-core-extensionpack


### PR DESCRIPTION
We've had some issues where the GitPod Nextflow version is behind the stable release, and doesn't include important bugfixes and changes. It's difficult to remember to bump the version there manually every time. This PR makes sure that the latest stable version is in the image automatically.

* Don't pin the Nextflow version in the Conda install
* Run `nextflow self-update` as part of the build process, in case bioconda is not up to date
* GitPod config: Update Nextflow as an init task. Install pre-commit hooks.