### PR TITLE
Linting error if quay.io found in biocontainer name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Linting
 
 - Warn if container access is denied ([#2270](https://github.com/nf-core/tools/pull/2270))
+- Error if module container specification has quay.io as prefix when it shouldn't have.
 
 ### Modules
 

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -282,16 +282,16 @@ def check_process_section(self, lines, fix_version, progress_bar):
             else:
                 self.failed.append(("docker_tag", "Unable to parse docker tag", self.main_nf))
                 docker_tag = NoneD
-            if l.startswith("quay.io/biocontainers") and not l.startswith("quay.io/biocontainers/mulled"):
+            if l.startswith("quay.io/"):
                 self.failed.append(
                     (
                         "container_links",
-                        "'quay.io/biocontainers/' container prefix found, please use just 'biocontainers/' instead",
+                        f"'quay.io/<org>/<container>:<tag>' container name found, please use just '<org>/<container>:<tag>' instead. Offending container name: {l}",
                         self.main_nf,
                     )
                 )
             else:
-                self.passed.append(("container_links", "Container prefix is correct", self.main_nf))
+                self.passed.append(("container_links", f"Container prefix is correct", self.main_nf))
 
             # Guess if container name is simple one (e.g. nfcore/ubuntu:20.04)
             # If so, add quay.io as default container prefix

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -294,7 +294,7 @@ def check_process_section(self, lines, fix_version, progress_bar):
                 self.failed.append(
                     (
                         "container_links",
-                        "quay.io/biocontainers prefix found, please use biocontainers instead",
+                        "'quay.io/biocontainers/' container prefix found, please use just 'biocontainers/' instead",
                         self.main_nf,
                     )
                 )

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -298,6 +298,8 @@ def check_process_section(self, lines, fix_version, progress_bar):
                         self.main_nf,
                     )
                 )
+            else:
+                self.passed.append(("container_links", "Container prefix is correct", self.main_nf))
             if l.startswith("biocontainers/"):
                 # When we think it is a biocontainer, assume we are querying quay.io/biocontainers and insert quay.io as prefix
                 l = "quay.io/" + l

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -283,10 +283,11 @@ def check_process_section(self, lines, fix_version, progress_bar):
                 self.failed.append(("docker_tag", "Unable to parse docker tag", self.main_nf))
                 docker_tag = NoneD
             if l.startswith("quay.io/"):
+                l_stripped = re.sub("\W+$", "", l)
                 self.failed.append(
                     (
                         "container_links",
-                        f"'quay.io/<org>/<container>:<tag>' container name found, please use just '<org>/<container>:<tag>' instead. Offending container name: {l}",
+                        f"{l_stripped} container name found, please use just 'organisation/container:tag' instead.",
                         self.main_nf,
                     )
                 )

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -290,6 +290,14 @@ def check_process_section(self, lines, fix_version, progress_bar):
             else:
                 self.failed.append(("docker_tag", "Unable to parse docker tag", self.main_nf))
                 docker_tag = None
+            if l.startswith("quay.io/biocontainers") and not l.startswith("quay.io/biocontainers/mulled"):
+                self.failed.append(
+                    (
+                        "container_links",
+                        "quay.io/biocontainers prefix found, please use biocontainers instead",
+                        self.main_nf,
+                    )
+                )
             if l.startswith("biocontainers/"):
                 # When we think it is a biocontainer, assume we are querying quay.io/biocontainers and insert quay.io as prefix
                 l = "quay.io/" + l

--- a/tests/modules/patch.py
+++ b/tests/modules/patch.py
@@ -18,7 +18,7 @@ testing if the update commands works correctly with patch files
 """
 
 ORG_SHA = "002623ccc88a3b0cb302c7d8f13792a95354d9f2"
-CORRECT_SHA = "0245a9277d51a47c8aa68d264d294cf45312fab8"
+CORRECT_SHA = "1dff30bfca2d98eb7ac7b09269a15e822451d99f"
 SUCCEED_SHA = "ba15c20c032c549d77c5773659f19c2927daf48e"
 FAIL_SHA = "67b642d4471c4005220a342cad3818d5ba2b5a73"
 BISMARK_ALIGN = "bismark/align"


### PR DESCRIPTION
Changes:
 - Linting error if container starts with quay.io/biocontainers but not quay.io/biocontainers/mulled

Fixes #2276


## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
