### PR TITLE
Move docker.registry definition out of docker profile

### DIFF
--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -130,7 +130,6 @@ profiles {
     }
     podman {
         podman.enabled         = true
-        podman.registry        = 'quay.io'
         conda.enabled          = false
         docker.enabled         = false
         singularity.enabled    = false
@@ -174,6 +173,12 @@ profiles {
     test_full { includeConfig 'conf/test_full.config' }
 }
 
+// Set default registry for Docker and Podman independent of -profile
+// Will not be used unless Docker / Podman are enabled
+// Set to your registry if you have a mirror of containers
+docker.registry = 'quay.io'
+podman.registry = 'quay.io'
+
 {% if igenomes %}
 // Load igenomes.config if required
 if (!params.igenomes_ignore) {
@@ -196,9 +201,6 @@ env {
 
 // Capture exit codes from upstream processes when piping
 process.shell = ['/bin/bash', '-euo', 'pipefail']
-
-// Set default docker registry (will not be used unless pulling docker images)
-docker.registry = 'quay.io'
 
 def trace_timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
 timeline {

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -107,7 +107,6 @@ profiles {
     }
     docker {
         docker.enabled         = true
-        docker.registry        = 'quay.io'
         docker.userEmulation   = true
         conda.enabled          = false
         singularity.enabled    = false
@@ -197,6 +196,9 @@ env {
 
 // Capture exit codes from upstream processes when piping
 process.shell = ['/bin/bash', '-euo', 'pipefail']
+
+// Set default docker registry (will not be used unless pulling docker images)
+docker.registry = 'quay.io'
 
 def trace_timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
 timeline {


### PR DESCRIPTION
The `docker.registry` configuration should always be set, as running on cloud executors will need to pull docker images but will not necessarily use the `docker` profile.