### PR TITLE
Avoid blocking requests when checking for new version

### DIFF
--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -81,13 +81,13 @@ def check_if_outdated(current_version=None, remote_version=None, source_url="htt
     source_url = f"{source_url}?v={current_version}"
     # check if we have a newer version without blocking the rest of the script
     is_outdated = False
-    remote_version = None
-    try:
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            future = executor.submit(fetch_remote_version, source_url)
-            remote_version = future.result()
-    except Exception as e:
-        log.debug(f"Could not check for nf-core updates: {e}")
+    if remote_version is None:  # we set it manually for tests
+        try:
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                future = executor.submit(fetch_remote_version, source_url)
+                remote_version = future.result()
+        except Exception as e:
+            log.debug(f"Could not check for nf-core updates: {e}")
     if remote_version is not None:
         if Version(remote_version) > Version(current_version):
             is_outdated = True


### PR DESCRIPTION
Trying to put the html request into the background, so it doesn't block the rest of the calls.

Difficult to test, because I can't seem to get rid of all the caches, but it makes it at least not slower...