### PR TITLE
Add `d` to the pattern of max_time

### DIFF
--- a/nf_core/pipeline-template/nextflow_schema.json
+++ b/nf_core/pipeline-template/nextflow_schema.json
@@ -157,7 +157,7 @@
                     "description": "Maximum amount of time that can be requested for any single job.",
                     "default": "240.h",
                     "fa_icon": "far fa-clock",
-                    "pattern": "^(\\d+\\.?\\s*(s|m|h|day)\\s*)+$",
+                    "pattern": "^(\\d+\\.?\\s*(s|m|h|d|day)\\s*)+$",
                     "hidden": true,
                     "help_text": "Use to set an upper-limit for the time requirement for each process. Should be a string in the format integer-unit e.g. `--max_time '2.h'`"
                 }


### PR DESCRIPTION
When `params.max_time` is set to `72.h` for example, Nextflow converts that to `3d` which doesn't match the current pattern when using the `nf-validation` plugin. 

```
The following invalid input values have been detected:

* --max_time: string [3d] does not match pattern ^(\d+\.?\s*(s|m|h|day)\s*)+$ (3d)
```

This PR fixes that issue