### PR TITLE
add docs to commit new files before pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,6 +941,8 @@ before_command: sed 's/1.13a/1.10/g' modules/multiqc/main.nf > modules/multiqc/m
 
 To run unit tests of a module that you have installed or the test created by the command [`nf-core modules create-test-yml`](#create-a-module-test-config-file), you can use `nf-core modules test` command. This command runs the tests specified in `modules/tests/software/<tool>/<subtool>/test.yml` file using [pytest](https://pytest-workflow.readthedocs.io/en/stable/).
 
+> This command uses the pytest argument `--git-aware` to avoid copying the whole `.git` directory and files ignored by `git`. This means that it will only include files listed by `git ls-files`. Remember to **commit your changes** after adding a new module to add the new files to your git index.
+
 You can specify the module name in the form TOOL/SUBTOOL in command line or provide it later by prompts.
 
 <!-- RICH-CODEX
@@ -1198,6 +1200,8 @@ extra_env:
 ### Run the tests for a subworkflow using pytest
 
 To run unit tests of a subworkflow that you have installed or the test created by the command [`nf-core subworkflow create-test-yml`](#create-a-subworkflow-test-config-file), you can use `nf-core subworkflows test` command. This command runs the tests specified in `tests/subworkflows/<subworkflow_name>/test.yml` file using [pytest](https://pytest-workflow.readthedocs.io/en/stable/).
+
+> This command uses the pytest argument `--git-aware` to avoid copying the whole `.git` directory and files ignored by `git`. This means that it will only include files listed by `git ls-files`. Remember to **commit your changes** after adding a new subworkflow to add the new files to your git index.
 
 You can specify the subworkflow name in the form TOOL/SUBTOOL in command line or provide it later by prompts.
 

--- a/nf_core/components/components_test.py
+++ b/nf_core/components/components_test.py
@@ -7,7 +7,7 @@ from shutil import which
 import pytest
 import questionary
 import rich
-from git import Repo
+from git import InvalidGitRepositoryError, Repo
 
 import nf_core.modules.modules_utils
 import nf_core.utils
@@ -181,9 +181,12 @@ class ComponentsTest(ComponentCommand):
         console.rule(self.component_name, style="black")
 
         # Check uncommitted changed
-        repo = Repo(self.dir)
-        if repo.is_dirty():
-            log.warning("You have uncommitted changes. Make sure to commit last changes before running the tests.")
+        try:
+            repo = Repo(self.dir)
+            if repo.is_dirty():
+                log.warning("You have uncommitted changes. Make sure to commit last changes before running the tests.")
+        except InvalidGitRepositoryError:
+            pass
 
         # Set pytest arguments
         tag = self.component_name

--- a/nf_core/components/components_test.py
+++ b/nf_core/components/components_test.py
@@ -7,6 +7,7 @@ from shutil import which
 import pytest
 import questionary
 import rich
+from git import Repo
 
 import nf_core.modules.modules_utils
 import nf_core.utils
@@ -178,6 +179,11 @@ class ComponentsTest(ComponentCommand):
         # Print nice divider line
         console = rich.console.Console()
         console.rule(self.component_name, style="black")
+
+        # Check uncommitted changed
+        repo = Repo(self.dir)
+        if repo.is_dirty():
+            log.warning("You have uncommitted changes. Make sure to commit last changes before running the tests.")
 
         # Set pytest arguments
         tag = self.component_name


### PR DESCRIPTION
The command `nf-core modules test` runs tests using pytest. We use the pytest argument `--git-aware`.
This argument is used to avoid copying the whole `.git` directory and files ignored by git.
It will only include files listed by `git ls-files`.
In order to test a new module or subworkflow, the new files have to be committed, otherwise they will be ignored. This was reported in https://github.com/nf-core/tools/issues/2235 and nf-core Slack.
This PR adds documentation to advise committing changes before running the command, as it is better to keep the argument `--git-aware`.

It throws a warning if there are uncommitted changes:
![image](https://github.com/nf-core/tools/assets/8224255/4a333305-31ef-4f88-8945-3b7f2512c31b)



## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
