### PR TITLE
Don't pin nf-validation plugin version

### DIFF
--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -185,7 +185,7 @@ podman.registry      = 'quay.io'
 
 // Nextflow plugins
 plugins {
-    id 'nf-validation@0.2.1' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-validation' // Validation of pipeline parameters and creation of an input channel from a sample sheet
 }
 
 {% if igenomes %}


### PR DESCRIPTION
Don't pin nf-validation plugin version, based on discussion in https://github.com/nextflow-io/nextflow/issues/4036
Will leave it as draft until we know if we can pin a major version.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
