### PR TITLE
Add warning block to readme about singularity image downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,9 +385,9 @@ The Singularity image download finds containers using two methods:
 2. It scrapes any files it finds with a `.nf` file extension in the workflow `modules` directory for lines
    that look like `container "xxx"`. This is the typical method for DSL2 pipelines, which have one container per process.
 
-> ⚠️ Containers specified with single quotes (container 'xxx') will not be picked up by `nf-core download`. 
+> ⚠️ Containers specified within lines that look like `container 'xxx'` will not be picked up by `nf-core download`. 
 
-Some DSL2 modules have container addresses for docker (eg. `biocontainers/fastqc:0.11.9--0`) and also URLs for direct downloads of a Singularity continaer (eg. `https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0`).
+Some DSL2 modules have container addresses for docker (eg. `biocontainers/fastqc:0.11.9--0`) and also URLs for direct downloads of a Singularity container (eg. `https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0`).
 Where both are found, the download URL is preferred.
 
 Once a full list of containers is found, they are processed in the following order:

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ The Singularity image download finds containers using two methods:
 2. It scrapes any files it finds with a `.nf` file extension in the workflow `modules` directory for lines
    that look like `container "xxx"`. This is the typical method for DSL2 pipelines, which have one container per process.
 
-> ⚠️ Containers specified within lines that look like `container 'xxx'` will not be picked up by `nf-core download`. 
+> ⚠️ Containers specified within lines that look like `container 'xxx'` will not be picked up by `nf-core download`.
 
 Some DSL2 modules have container addresses for docker (eg. `biocontainers/fastqc:0.11.9--0`) and also URLs for direct downloads of a Singularity container (eg. `https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0`).
 Where both are found, the download URL is preferred.

--- a/README.md
+++ b/README.md
@@ -383,7 +383,9 @@ The Singularity image download finds containers using two methods:
 1. It runs `nextflow config` on the downloaded workflow to look for a `process.container` statement for the whole pipeline.
    This is the typical method used for DSL1 pipelines.
 2. It scrapes any files it finds with a `.nf` file extension in the workflow `modules` directory for lines
-   that look like `container = "xxx"`. This is the typical method for DSL2 pipelines, which have one container per process.
+   that look like `container "xxx"`. This is the typical method for DSL2 pipelines, which have one container per process.
+
+> ⚠️ Containers specified with single quotes (container 'xxx') will not be picked up by `nf-core download`. 
 
 Some DSL2 modules have container addresses for docker (eg. `biocontainers/fastqc:0.11.9--0`) and also URLs for direct downloads of a Singularity continaer (eg. `https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0`).
 Where both are found, the download URL is preferred.

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -699,7 +699,7 @@ class DownloadWorkflow:
                 if file.endswith(".nf"):
                     file_path = os.path.join(subdir, file)
                     with open(file_path, "r") as fh:
-                        # Look for any lines with `container = "xxx"`
+                        # Look for any lines with `container "xxx"`
                         this_container = None
                         contents = fh.read()
                         matches = re.findall(r"container\s*\"([^\"]*)\"", contents, re.S)


### PR DESCRIPTION
Since this only affects nf-core download it can give a person headache when everything else works. 

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
