### PR TITLE
Add Apptainer (Singularity) to Gitpod nf-core base image

### DIFF
--- a/nf_core/gitpod/gitpod.Dockerfile
+++ b/nf_core/gitpod/gitpod.Dockerfile
@@ -45,13 +45,13 @@ RUN conda config --add channels defaults && \
     conda config --set channel_priority strict && \
     conda install --quiet --yes --name base mamba && \
     mamba install --quiet --yes --name base \
-    nextflow \
-    nf-core \
-    nf-test \
-    black \
-    prettier \
-    pre-commit \
-    pytest-workflow && \
+        nextflow \
+        nf-core \
+        nf-test \
+        black \
+        prettier \
+        pre-commit \
+        pytest-workflow && \
     mamba clean --all -f -y
 
 # Update Nextflow

--- a/nf_core/gitpod/gitpod.Dockerfile
+++ b/nf_core/gitpod/gitpod.Dockerfile
@@ -3,6 +3,7 @@ FROM gitpod/workspace-base
 USER root
 
 # Install util tools.
+# software-properties-common is needed to add ppa support for Apptainer installation
 RUN apt-get update --quiet && \
     apt-get install --quiet --yes \
     apt-transport-https \
@@ -13,7 +14,13 @@ RUN apt-get update --quiet && \
     wget \
     curl \
     tree \
-    graphviz
+    graphviz \
+    software-properties-common
+
+# Install Apptainer (Singularity)
+RUN add-apt-repository -y ppa:apptainer/ppa && \
+    apt-get update --quiet && \
+    apt install -y apptainer
 
 # Install Conda
 RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
@@ -38,13 +45,13 @@ RUN conda config --add channels defaults && \
     conda config --set channel_priority strict && \
     conda install --quiet --yes --name base mamba && \
     mamba install --quiet --yes --name base \
-        nextflow \
-        nf-core \
-        nf-test \
-        black \
-        prettier \
-        pre-commit \
-        pytest-workflow && \
+    nextflow \
+    nf-core \
+    nf-test \
+    black \
+    prettier \
+    pre-commit \
+    pytest-workflow && \
     mamba clean --all -f -y
 
 # Update Nextflow


### PR DESCRIPTION
To test and develop the respective features for #2336, I had to install Apptainer in Gitpod several times a day.

Although I am not sure how often other people will need it, I see little harm in adding Apptainer by default to the Gitpod image. The image is already quite bloated with conda, so the additional 80MB-100MB will barely matter?

Unfortunately, I could not test the new image. I tried to build it locally, but the `RUN nextflow self-update` step seems to get stuck at  `Downloading dependency org.pf4j:pf4j-update:jar:2.3.0`. That one step is running now since 5h and the whole build so far is taking a little over 7h, which I think might be a MacM1 issue? 

So whoever will review this PR should please clone this, navigate to the folder `cd tools` and run

`docker build . -f nf_core/gitpod/gitpod.Dockerfile -t testgitpodwithapptainer`

to see if the image builds successfully and how big the new image will be.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
