### PR TITLE
Download: Add `apptainer` to the list of false positve container strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Refactored the CLI parameters related to container images. Although downloading other images than those of the Singularity/Apptainer container system is not supported for the time being, a generic name for the parameters seemed preferable. So the new parameter `--singularity-cache-index` introduced in [#2247](https://github.com/nf-core/tools/pull/2247) has been renamed to `--container-cache-index` prior to release ([#2336](https://github.com/nf-core/tools/pull/2336)).
 - To address issue [#2311](https://github.com/nf-core/tools/issues/2311), a new parameter `--container-library` was created allowing to specify the container library (registry) from which container images in OCI format (Docker) should be pulled ([#2336](https://github.com/nf-core/tools/pull/2336)).
 - Container detection in configs was improved. This allows for DSL2-like container definitions inside the container parameter value provided to process scopes [#2346](https://github.com/nf-core/tools/pull/2346).
+- Add apptainer to the list of false positve container strings ([#2353](https://github.com/nf-core/tools/pull/2353)).
 
 #### Updated CLI parameters
 

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -733,8 +733,7 @@ class DownloadWorkflow:
                         re.DOTALL is used to account for the string to be spread out across multiple lines.
                         """
                         container_regex = re.compile(
-                            r"container\s+[\s{}=$]*(?P<quote>[\'\"])(?P<param>(?:.(?!\1))*.?)\1[\s}]*",
-                            re.DOTALL,
+                            r"container\s+[\s{}=$]*(?P<quote>[\'\"])(?P<param>(?:.(?!\1))*.?)\1[\s}]*", re.DOTALL
                         )
 
                         local_module_findings = re.findall(container_regex, search_space)
@@ -850,7 +849,7 @@ class DownloadWorkflow:
 
             for _, capture in container_value_defs:
                 # common false positive(s)
-                if capture in ["singularity"]:
+                if capture in ["singularity", "apptainer"]:
                     continue
 
                 # Look for a http download URL.


### PR DESCRIPTION
Add apptainer keyword to the list of false positive matches. Bare minimum to possibly support a future `apptainer.registry` notation in the container specifications ?

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
