### PR TITLE
Download: Improved container priority and resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Template
 
+### Download
+- Improved container image resolution and prioritization of http downloads over Docker URIs.
 ### Linting
 
 ### Modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 ### Template
 
 ### Download
+
 - Improved container image resolution and prioritization of http downloads over Docker URIs ([#2364](https://github.com/nf-core/tools/pull/2364)).
+
 ### Linting
 
 ### Modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Template
 
 ### Download
-- Improved container image resolution and prioritization of http downloads over Docker URIs.
+- Improved container image resolution and prioritization of http downloads over Docker URIs ([#2364](https://github.com/nf-core/tools/pull/2364)).
 ### Linting
 
 ### Modules

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -693,7 +693,7 @@ class DownloadWorkflow:
 
                 # for DSL2 syntax in process scope of configs
                 config_regex = re.compile(
-                    r"[\s{}=$]*(?P<quote>(?<![\\])[\'\"])(?P<param>(?:.(?!(?<![\\])\1))*.?)\1[\s}]*"
+                    r"[\\s{}=$]*(?P<quote>(?<![\\])[\'\"])(?P<param>(?:.(?!(?<![\\])\1))*.?)\1[\\s}]*"
                 )
                 config_findings_dsl2 = re.findall(config_regex, v)
 
@@ -724,18 +724,18 @@ class DownloadWorkflow:
                         search_space = fh.read()
                         """
                         Figure out which quotes were used and match everything until the closing quote.
-                        Since the other quote typically appears inside, a simple r"container\s*[\"\']([^\"\']*)[\"\']" unfortunately abridges the matches.
+                        Since the other quote typically appears inside, a simple r"container\\s*[\"\']([^\"\']*)[\"\']" unfortunately abridges the matches.
 
-                        container\s+[\s{}$=]* matches the literal word "container" followed by whitespace, brackets, equal or variable names.
+                        container\\s+[\\s{}$=]* matches the literal word "container" followed by whitespace, brackets, equal or variable names.
                         (?P<quote>[\'\"]) The quote character is captured into the quote group \1.
                         The pattern (?:.(?!\1))*.? is used to match any character (.) not followed by the closing quote character (?!\1).
                         This capture happens greedy *, but we add a .? to ensure that we don't match the whole file until the last occurrence
                         of the closing quote character, but rather stop at the first occurrence. \1 inserts the matched quote character into the regex, either " or '.
-                        It may be followed by whitespace or closing bracket [\s}]*
+                        It may be followed by whitespace or closing bracket [\\s}]*
                         re.DOTALL is used to account for the string to be spread out across multiple lines.
                         """
                         container_regex = re.compile(
-                            r"container\s+[\s{}=$]*(?P<quote>[\'\"])(?P<param>(?:.(?!\1))*.?)\1[\s}]*", re.DOTALL
+                            r"container\s+[\\s{}=$]*(?P<quote>[\'\"])(?P<param>(?:.(?!\1))*.?)\1[\\s}]*", re.DOTALL
                         )
 
                         local_module_findings = re.findall(container_regex, search_space)

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -917,7 +917,7 @@ class DownloadWorkflow:
         """
         return self.prioritize_direct_download(cleaned_matches)
 
-    def prioritize_direct_download(self, container_list, d={}):
+    def prioritize_direct_download(self, container_list):
         """
         Helper function that takes a list of container images (URLs and Docker URIs),
         eliminates all Docker URIs for which also a URL is contained and returns the
@@ -941,6 +941,7 @@ class DownloadWorkflow:
 
         A regex that matches http, r"^$|^http" could thus be used to prioritize the Docker URIs over http Downloads
         """
+        d = {}
         for c in container_list:
             log.info(c)
             if re.match(r"^$|(?!^http)", d.get(k := re.sub(".*/(.*)", "\\1", c), "")):

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -826,7 +826,7 @@ class DownloadWorkflow:
             Mostly, it is a nested DSL2 string, but it may also just be a plain string.
 
 
-            First check if container_value it is a plain container URI like in DSL1 pipelines
+            First, check if container_value is a plain container URI like in DSL1 pipelines
             or a plain URL like in the old DSL2 convention
 
             """
@@ -943,7 +943,6 @@ class DownloadWorkflow:
         """
         d = {}
         for c in container_list:
-            log.info(c)
             if re.match(r"^$|(?!^http)", d.get(k := re.sub(".*/(.*)", "\\1", c), "")):
                 log.debug(f"{c} matches and will be saved as {k}")
                 d[k] = c

--- a/tests/data/mock_module_containers/modules/mock_docker_single_quay_io.nf
+++ b/tests/data/mock_module_containers/modules/mock_docker_single_quay_io.nf
@@ -1,0 +1,8 @@
+process MOCK {
+    label 'process_fake'
+    
+    conda     (params.enable_conda ? "bioconda::singlequay=1.9" : null)
+    container "quay.io/biocontainers/singlequay:1.9--pyh9f0ad1d_0"
+
+    // truncated
+}

--- a/tests/data/mock_module_containers/modules/mock_docker_single_quay_io.nf
+++ b/tests/data/mock_module_containers/modules/mock_docker_single_quay_io.nf
@@ -1,6 +1,6 @@
 process MOCK {
     label 'process_fake'
-    
+
     conda     (params.enable_conda ? "bioconda::singlequay=1.9" : null)
     container "quay.io/biocontainers/singlequay:1.9--pyh9f0ad1d_0"
 

--- a/tests/data/mock_module_containers/modules/mock_dsl2_apptainer_var1.nf
+++ b/tests/data/mock_module_containers/modules/mock_dsl2_apptainer_var1.nf
@@ -1,0 +1,10 @@
+process MOCK {
+    label 'process_fake'
+
+    conda "bioconda::dsltwoapptainervarone=1.1.0"
+    container "${ (workflow.containerEngine == 'singularity' || workflow.containerEngine == 'apptainer') && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/dsltwoapptainervarone:1.1.0--py38h7be5676_2':
+        'biocontainers/dsltwoapptainervarone:1.1.0--py38h7be5676_2' }"
+
+    // truncated
+}

--- a/tests/data/mock_module_containers/modules/mock_dsl2_apptainer_var2.nf
+++ b/tests/data/mock_module_containers/modules/mock_dsl2_apptainer_var2.nf
@@ -1,0 +1,10 @@
+process MOCK {
+    label 'process_fake'
+
+    conda "bioconda::dsltwoapptainervartwo=1.1.0"
+    container "${ ['singularity', 'apptainer'].contains(workflow.containerEngine) && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/dsltwoapptainervartwo:1.1.0--hdfd78af_0':
+        'biocontainers/dsltwoapptainervartwo:1.1.0--hdfd78af_0' }"
+
+    // truncated
+}

--- a/tests/data/mock_module_containers/modules/mock_dsl2_current.nf
+++ b/tests/data/mock_module_containers/modules/mock_dsl2_current.nf
@@ -1,0 +1,10 @@
+process MOCK {
+    label 'process_fake'
+
+    conda "bioconda::dsltwocurrent=1.2.1"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/dsltwocurrent:1.2.1--pyhdfd78af_0':
+        'biocontainers/dsltwocurrent:1.2.1--pyhdfd78af_0' }"
+
+    // truncated
+}

--- a/tests/data/mock_module_containers/modules/mock_dsl2_current_inverted.nf
+++ b/tests/data/mock_module_containers/modules/mock_dsl2_current_inverted.nf
@@ -1,0 +1,10 @@
+process MOCK {
+    label 'process_fake'
+
+    conda "bioconda::dsltwocurrentinv=3.3.2"
+    container "${ !workflow.containerEngine == 'singularity' && task.ext.singularity_pull_docker_container ?
+        'biocontainers/dsltwocurrentinv:3.3.2--h1b792b2_1' :
+        'https://depot.galaxyproject.org/singularity/dsltwocurrentinv:3.3.2--h1b792b2_1' }"
+
+    // truncated
+}

--- a/tests/data/mock_module_containers/modules/mock_dsl2_old.nf
+++ b/tests/data/mock_module_containers/modules/mock_dsl2_old.nf
@@ -1,0 +1,12 @@
+process MOCK {
+    label 'process_fake'
+
+    conda (params.enable_conda ? "bioconda::dsltwoold=0.23.0" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://depot.galaxyproject.org/singularity/dsltwoold:0.23.0--0"
+    } else {
+        container "quay.io/biocontainers/dsltwoold:0.23.0--0"
+    }
+
+    // truncated
+}

--- a/tests/data/mock_module_containers/modules/mock_dsl2_variable.nf
+++ b/tests/data/mock_module_containers/modules/mock_dsl2_variable.nf
@@ -1,0 +1,19 @@
+process STAR_ALIGN {
+    // from rnaseq 3.7
+    label 'process_fake'
+
+    conda (params.enable_conda ? conda_str : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        "https://depot.galaxyproject.org/singularity/${container_id}" :
+        "quay.io/biocontainers/${container_id}" }"
+
+
+    // Note: 2.7X indices incompatible with AWS iGenomes so use older STAR version
+    conda_str = "bioconda::star=2.7.10a bioconda::samtools=1.15.1 conda-forge::gawk=5.1.0"
+    container_id = 'mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:afaaa4c6f5b308b4b6aa2dd8e99e1466b2a6b0cd-0'
+    if (is_aws_igenome) {
+        conda_str = "bioconda::star=2.6.1d bioconda::samtools=1.10 conda-forge::gawk=5.1.0"
+        container_id = 'mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:59cdd445419f14abac76b31dd0d71217994cbcc9-0'
+    }
+
+}


### PR DESCRIPTION
This PR improves the code in Download that detects and resolves container images in modules and configs. 

Previously, a loop was used to prioritize http:// downloads over docker URIs. For example, from
```
container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
   'https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0' :
   'biocontainers/fastqc:0.11.9--0' }"
```
 the strings `'singularity'`,  `'https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0'` and `'biocontainers/fastqc:0.11.9--0'` were extracted into a list. Then we iterated over this list and broke the loop as soon as a match with a URL regex or Docker regex was found.

This approach was flaky, because `'singularity'` or `'apptainer'`  are valid Docker URIs. Thus, unless it was explicitly ignored as a false positive, it prevented further evaluation and detection of the real image paths. Now, evaluation continues in any case, which should make it more resilient for further syntax updates. Furthermore, the old approach also relied on the convention that the URL would always be listed before the Docker URI.

The old approach failed entirely for early DSL2, where a separate container declaration was used:

```
  if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
      container "https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0"
  } else {
      container "quay.io/biocontainers/fastqc:0.11.9--0"
  }
```
For each container declaration, a new loop was created, such that it was not possible to prioritize the direct download over the Docker URI for early DSL2. Therefore, each image was once downloaded and once pulled.

This PR now changes the approach to first gather all Docker URIs and download URLs from all modules and configs into a joint, global list. Subsequently, a new helper function `prioritize_direct_download()` removes all Docker URIs from the list for which also direct download URLs are contained.  Consolidating container URIs/URLs from different modules is now possible for the first time.

In addition to the improved function, a new test has been devised that runs on mock modules in the tests/data directory. So any future module standard should be reflected by a mock module in that folder in the future. 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
