### PR TITLE
Some modifications in subworkflows lint

### DIFF
--- a/docs/api/_src/index.md
+++ b/docs/api/_src/index.md
@@ -17,6 +17,7 @@ This documentation is for the `nf-core/tools` package.
 
 - [Pipeline code lint tests](pipeline_lint_tests/index.md) (run by `nf-core lint`)
 - [Module code lint tests](module_lint_tests/index.md) (run by `nf-core modules lint`)
+- [Subworkflow code lint tests](subworkflow_lint_test/index.mf) (run by `nf-core subworkflows lint`)
 - [nf-core/tools Python package API reference](api/index.md)
 - {ref}`genindex`
 - {ref}`modindex`

--- a/docs/api/_src/subworkflow_lint_tests/index.md
+++ b/docs/api/_src/subworkflow_lint_tests/index.md
@@ -1,0 +1,9 @@
+# Subworkflow lint tests
+
+```{toctree}
+:caption: 'Tests:'
+:glob: true
+:maxdepth: 2
+
+*
+```

--- a/docs/api/_src/subworkflow_lint_tests/main_nf.md
+++ b/docs/api/_src/subworkflow_lint_tests/main_nf.md
@@ -1,0 +1,5 @@
+# main_nf
+
+```{eval-rst}
+.. automethod:: nf_core.subworkflows.lint.SubworkflowLint.main_nf
+```

--- a/docs/api/_src/subworkflow_lint_tests/meta_yml.md
+++ b/docs/api/_src/subworkflow_lint_tests/meta_yml.md
@@ -1,0 +1,5 @@
+# meta_yml
+
+```{eval-rst}
+.. automethod:: nf_core.subworkflows.lint.SubworkflowLint.meta_yml
+```

--- a/docs/api/_src/subworkflow_lint_tests/module_changes.md
+++ b/docs/api/_src/subworkflow_lint_tests/module_changes.md
@@ -1,0 +1,5 @@
+# module_changes
+
+```{eval-rst}
+.. automethod:: nf_core.subworkflows.lint.SubworkflowLint.module_changes
+```

--- a/docs/api/_src/subworkflow_lint_tests/module_tests.md
+++ b/docs/api/_src/subworkflow_lint_tests/module_tests.md
@@ -1,0 +1,5 @@
+# module_tests
+
+```{eval-rst}
+.. automethod:: nf_core.subworkflows.lint.SubworkflowLint.module_tests
+```

--- a/docs/api/_src/subworkflow_lint_tests/module_todos.md
+++ b/docs/api/_src/subworkflow_lint_tests/module_todos.md
@@ -1,0 +1,5 @@
+# module_todos
+
+```{eval-rst}
+.. automethod:: nf_core.subworkflows.lint.SubworkflowLint.module_todos
+```

--- a/docs/api/_src/subworkflow_lint_tests/module_version.md
+++ b/docs/api/_src/subworkflow_lint_tests/module_version.md
@@ -1,0 +1,5 @@
+# module_version
+
+```{eval-rst}
+.. automethod:: nf_core.subworkflows.lint.SubworkflowLint.module_version
+```

--- a/nf_core/subworkflows/lint/meta_yml.py
+++ b/nf_core/subworkflows/lint/meta_yml.py
@@ -95,9 +95,9 @@ def meta_yml(subworkflow_lint_object, subworkflow):
         included_components = (
             included_components[0] + included_components[1]
         )  # join included modules and included subworkflows in a single list
-        if "modules" in meta_yaml:
-            meta_components = [x for x in meta_yaml["modules"]]
-            for component in included_components:
+        if "components" in meta_yaml:
+            meta_components = [x for x in meta_yaml["components"]]
+            for component in set(included_components):
                 if component in meta_components:
                     subworkflow.passed.append(
                         (
@@ -114,3 +114,19 @@ def meta_yml(subworkflow_lint_object, subworkflow):
                             subworkflow.meta_yml,
                         )
                     )
+        if "modules" in meta_yaml:
+            subworkflow.failed.append(
+                (
+                    "meta_modules_deprecated",
+                    f"Deprecated section 'modules' found in `meta.yml`, use 'components' instead",
+                    subworkflow.meta_yml,
+                )
+            )
+        else:
+            subworkflow.failed.append(
+                (
+                    "meta_modules_deprecated",
+                    f"Deprecated section 'modules' not found in `meta.yml`",
+                    subworkflow.meta_yml,
+                )
+            )

--- a/nf_core/subworkflows/lint/subworkflow_tests.py
+++ b/nf_core/subworkflows/lint/subworkflow_tests.py
@@ -59,7 +59,7 @@ def subworkflow_tests(_, subworkflow):
                 subworkflow, subworkflow.component_dir
             )
             for test in test_yml:
-                for component in included_components:
+                for component in set(included_components):
                     if component in test["tags"]:
                         subworkflow.passed.append(
                             (


### PR DESCRIPTION
- Add a test to ensure that `meta.yml` does not contain the deprecated "modules" section and uses "components" instead.
- If a module was used in the subworkflow and another imported subworkflow, the error was printed twice -> that is fixed here


## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
