### PR TITLE
Save pipeline template info to `.nf-core.yml`

### DIFF
--- a/nf_core/create.py
+++ b/nf_core/create.py
@@ -187,9 +187,7 @@ class PipelineCreate:
         """Customizes the template parameters.
 
         Args:
-            name (str): Name for the pipeline.
-            description (str): Description for the pipeline.
-            author (str): Authors name of the pipeline.
+            template_areas (list<str>): List of available template areas to skip.
         """
         template_yaml = {}
         prefix = questionary.text("Pipeline prefix", style=nf_core.utils.nfcore_question_style).unsafe_ask()
@@ -351,11 +349,13 @@ class PipelineCreate:
             # Update the .nf-core.yml with linting configurations
             self.fix_linting()
 
-        log.debug("Dumping pipeline template yml to file")
         if self.template_yaml:
-            with open(self.outdir / "pipeline_template.yml", "w") as fh:
-                yaml.safe_dump(self.template_yaml, fh)
-            run_prettier_on_file(self.outdir / "pipeline_template.yml")
+            config_fn, config_yml = nf_core.utils.load_tools_config(self.outdir)
+            with open(self.outdir / config_fn, "w") as fh:
+                config_yml.update(template=self.template_yaml)
+                yaml.safe_dump(config_yml, fh)
+                log.debug(f"Dumping pipeline template yml to pipeline config file '{config_fn.name}'")
+                run_prettier_on_file(self.outdir / config_fn)
 
     def update_nextflow_schema(self):
         """

--- a/nf_core/lint/files_exist.py
+++ b/nf_core/lint/files_exist.py
@@ -78,6 +78,7 @@ def files_exist(self):
 
         Singularity
         parameters.settings.json
+        pipeline_template.yml # saving information in .nf-core.yml
         .nf-core.yaml  # NB: Should be yml, not yaml
         bin/markdown_to_html.r
         conf/aws.config
@@ -181,6 +182,7 @@ def files_exist(self):
     files_fail_ifexists = [
         "Singularity",
         "parameters.settings.json",
+        "pipeline_template.yml",  # saving information in .nf-core.yml
         ".nf-core.yaml",  # yml not yaml
         os.path.join("bin", "markdown_to_html.r"),
         os.path.join("conf", "aws.config"),

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest import mock
 
 import git
+import yaml
 
 import nf_core.create
 
@@ -58,6 +59,8 @@ class NfcoreCreateTest(unittest.TestCase):
         assert os.path.isdir(os.path.join(pipeline.outdir, ".git"))
         assert f" {self.default_branch}\n" in git.Repo.init(pipeline.outdir).git.branch()
         assert not os.path.exists(os.path.join(pipeline.outdir, "pipeline_template.yml"))
+        with open(os.path.join(pipeline.outdir, ".nf-core.yml")) as fh:
+            assert "template" not in fh.read()
 
     @with_temporary_folder
     def test_pipeline_creation_initiation_with_yml(self, tmp_path):
@@ -77,11 +80,13 @@ class NfcoreCreateTest(unittest.TestCase):
         assert os.path.isdir(os.path.join(pipeline.outdir, ".git"))
         assert f" {self.default_branch}\n" in git.Repo.init(pipeline.outdir).git.branch()
 
-        # Check pipeline yml has been dumped and matches input
-        pipeline_template = os.path.join(pipeline.outdir, "pipeline_template.yml")
-        assert os.path.exists(pipeline_template)
-        with open(pipeline_template) as fh:
-            assert fh.read() == PIPELINE_TEMPLATE_YML.read_text()
+        # Check pipeline template yml has been dumped to `.nf-core.yml` and matches input
+        assert not os.path.exists(os.path.join(pipeline.outdir, "pipeline_template.yml"))
+        assert os.path.exists(os.path.join(pipeline.outdir, ".nf-core.yml"))
+        with open(os.path.join(pipeline.outdir, ".nf-core.yml")) as fh:
+            nfcore_yml = yaml.safe_load(fh)
+            assert "template" in nfcore_yml
+            assert nfcore_yml["template"] == yaml.safe_load(PIPELINE_TEMPLATE_YML.read_text())
 
     @mock.patch.object(nf_core.create.PipelineCreate, "customize_template")
     @mock.patch.object(nf_core.create.questionary, "confirm")
@@ -103,11 +108,13 @@ class NfcoreCreateTest(unittest.TestCase):
         assert os.path.isdir(os.path.join(pipeline.outdir, ".git"))
         assert f" {self.default_branch}\n" in git.Repo.init(pipeline.outdir).git.branch()
 
-        # Check pipeline yml has been dumped and matches input
-        pipeline_template = os.path.join(pipeline.outdir, "pipeline_template.yml")
-        assert os.path.exists(pipeline_template)
-        with open(pipeline_template) as fh:
-            assert fh.read() == PIPELINE_TEMPLATE_YML.read_text()
+        # Check pipeline template yml has been dumped to `.nf-core.yml` and matches input
+        assert not os.path.exists(os.path.join(pipeline.outdir, "pipeline_template.yml"))
+        assert os.path.exists(os.path.join(pipeline.outdir, ".nf-core.yml"))
+        with open(os.path.join(pipeline.outdir, ".nf-core.yml")) as fh:
+            nfcore_yml = yaml.safe_load(fh)
+            assert "template" in nfcore_yml
+            assert nfcore_yml["template"] == yaml.safe_load(PIPELINE_TEMPLATE_YML.read_text())
 
     @with_temporary_folder
     def test_pipeline_creation_with_yml_skip(self, tmp_path):
@@ -126,11 +133,13 @@ class NfcoreCreateTest(unittest.TestCase):
         pipeline.init_pipeline()
         assert not os.path.isdir(os.path.join(pipeline.outdir, ".git"))
 
-        # Check pipeline yml has been dumped and matches input
-        pipeline_template = os.path.join(pipeline.outdir, "pipeline_template.yml")
-        assert os.path.exists(pipeline_template)
-        with open(pipeline_template) as fh:
-            assert fh.read() == PIPELINE_TEMPLATE_YML_SKIP.read_text()
+        # Check pipeline template yml has been dumped to `.nf-core.yml` and matches input
+        assert not os.path.exists(os.path.join(pipeline.outdir, "pipeline_template.yml"))
+        assert os.path.exists(os.path.join(pipeline.outdir, ".nf-core.yml"))
+        with open(os.path.join(pipeline.outdir, ".nf-core.yml")) as fh:
+            nfcore_yml = yaml.safe_load(fh)
+            assert "template" in nfcore_yml
+            assert nfcore_yml["template"] == yaml.safe_load(PIPELINE_TEMPLATE_YML_SKIP.read_text())
 
         # Check that some of the skipped files are not present
         assert not os.path.exists(os.path.join(pipeline.outdir, "CODE_OF_CONDUCT.md"))


### PR DESCRIPTION
When customizing the pipeline template, information was saved to a file named `pipeline_template.yml`. This PR deprecates such file and stores the info to `.nf-core.yml` instead.

Partially close #2359 (needs a follow-up PR moving data from `pipeline_tamplate.yml` in old pipelines)

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
