### PR TITLE
remove `--no-git` option from pipeline create command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fix prompt pipeline revision during launch ([#2375](https://github.com/nf-core/tools/pull/2375))
 - Add a `create-params-file` command to create a YAML parameter file for a pipeline containing parameter documentation and defaults. ([#2362](https://github.com/nf-core/tools/pull/2362))
 - Update the Code of Conduct ([#2381](https://github.com/nf-core/tools/pull/2381))
+- Remove `--no-git` option from `nf-core create`
 
 # [v2.9 - Chromium Falcon](https://github.com/nf-core/tools/releases/tag/2.9) + [2023-06-29]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 - Fix prompt pipeline revision during launch ([#2375](https://github.com/nf-core/tools/pull/2375))
 - Add a `create-params-file` command to create a YAML parameter file for a pipeline containing parameter documentation and defaults. ([#2362](https://github.com/nf-core/tools/pull/2362))
 - Update the Code of Conduct ([#2381](https://github.com/nf-core/tools/pull/2381))
-- Remove `--no-git` option from `nf-core create`
+- Remove `--no-git` option from `nf-core create` ([#2394](https://github.com/nf-core/tools/pull/2394))
 
 # [v2.9 - Chromium Falcon](https://github.com/nf-core/tools/releases/tag/2.9) + [2023-06-29]
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -378,12 +378,11 @@ def licences(pipeline, json):
 @click.option("-d", "--description", type=str, help="A short description of your pipeline")
 @click.option("-a", "--author", type=str, help="Name of the main author(s)")
 @click.option("--version", type=str, default="1.0dev", help="The initial version number to use")
-@click.option("--no-git", is_flag=True, default=False, help="Do not initialise pipeline as new git repository")
 @click.option("-f", "--force", is_flag=True, default=False, help="Overwrite output directory if it already exists")
 @click.option("-o", "--outdir", help="Output directory for new pipeline (default: pipeline name)")
 @click.option("-t", "--template-yaml", help="Pass a YAML file to customize the template")
 @click.option("--plain", is_flag=True, help="Use the standard nf-core template")
-def create(name, description, author, version, no_git, force, outdir, template_yaml, plain):
+def create(name, description, author, version, force, outdir, template_yaml, plain):
     """
     Create a new pipeline using the nf-core template.
 
@@ -393,7 +392,16 @@ def create(name, description, author, version, no_git, force, outdir, template_y
     from nf_core.create import PipelineCreate
 
     try:
-        create_obj = PipelineCreate(name, description, author, version, no_git, force, outdir, template_yaml, plain)
+        create_obj = PipelineCreate(
+            name,
+            description,
+            author,
+            version=version,
+            force=force,
+            outdir=outdir,
+            template_yaml_path=template_yaml,
+            plain=plain,
+        )
         create_obj.init_pipeline()
     except UserWarning as e:
         log.error(e)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -236,7 +236,6 @@ class TestCli(unittest.TestCase):
             "description": "pipeline description",
             "author": "Kalle Anka",
             "version": "1.2.3",
-            "no-git": None,
             "force": None,
             "outdir": "/path/outdir",
             "template-yaml": "file.yaml",
@@ -251,12 +250,11 @@ class TestCli(unittest.TestCase):
             params["name"],
             params["description"],
             params["author"],
-            params["version"],
-            "no-git" in params,
-            "force" in params,
-            params["outdir"],
-            params["template-yaml"],
-            "plain" in params,
+            version=params["version"],
+            force="force" in params,
+            outdir=params["outdir"],
+            template_yaml_path=params["template-yaml"],
+            plain="plain" in params,
         )
         mock_create.return_value.init_pipeline.assert_called_once()
 


### PR DESCRIPTION
Removing the `--no-git` option from `nf-core create`.
The argument is maintained as it is used by other commands such as `sync` and several tests
Close #2081 

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
