### PR TITLE
fix: Drop container error to warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@
 - Add module MULTIQC to modules.config ([#2377](https://github.com/nf-core/tools/pull/2377))
 - Update the Code of Conduct ([#2381](https://github.com/nf-core/tools/pull/2381))
 - Save template information to `.nf-core.yml` and deprecate argument `--template-yaml` for `nf-core sync` ([#2388](https://github.com/nf-core/tools/pull/2388) and [#2389](https://github.com/nf-core/tools/pull/2389))
+<<<<<<< HEAD
 - Remove fixed Ubuntu test and added to standard testing matrix
+=======
+- Reduce container finding error to warning since the registries are not consistent.
+>>>>>>> 4e7fd2f3 (fix: Drop container error to warning)
 
 ### Download
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,8 @@
 - Add module MULTIQC to modules.config ([#2377](https://github.com/nf-core/tools/pull/2377))
 - Update the Code of Conduct ([#2381](https://github.com/nf-core/tools/pull/2381))
 - Save template information to `.nf-core.yml` and deprecate argument `--template-yaml` for `nf-core sync` ([#2388](https://github.com/nf-core/tools/pull/2388) and [#2389](https://github.com/nf-core/tools/pull/2389))
-<<<<<<< HEAD
-- Remove fixed Ubuntu test and added to standard testing matrix
-=======
-- Reduce container finding error to warning since the registries are not consistent.
->>>>>>> 4e7fd2f3 (fix: Drop container error to warning)
+- ([#2397](https://github.com/nf-core/tools/pull/2397)) Remove fixed Ubuntu test and added to standard testing matrix
+- ([#2396](https://github.com/nf-core/tools/pull/2396)) Reduce container finding error to warning since the registries are not consistent.
 
 ### Download
 

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -346,8 +346,9 @@ def check_process_section(self, lines, registry, fix_version, progress_bar):
         if url is None:
             continue
         try:
+            container_url = "https://" + urlunparse(url) if not url.scheme == "https" else urlunparse(url)
             response = requests.head(
-                "https://" + urlunparse(url) if not url.scheme == "https" else urlunparse(url),
+                container_url,
                 stream=True,
                 allow_redirects=True,
             )
@@ -360,10 +361,10 @@ def check_process_section(self, lines, registry, fix_version, progress_bar):
             self.failed.append(("container_links", "Unable to connect to container URL", self.main_nf))
             continue
         if not response.ok:
-            self.failed.append(
+            self.warned.append(
                 (
                     "container_links",
-                    f"Unable to connect to {response.url}, status code: {response.status_code}",
+                    f"Unable to connect to container registry, code:  {response.status_code}, url: {response.url}",
                     self.main_nf,
                 )
             )


### PR DESCRIPTION
Changes:
 - Container registries do not have a consistent API, so calling them
   for container presence doesn't seem to work on GHCR or NVCR.
 - In addition some registries require authentication and do not have a consistent method of authentication, likely oauth2 but not clear.
 - This drops the error to a warning so we don't fail tests.

Relates to https://github.com/nf-core/modules/issues/3693 and https://github.com/nf-core/tools/issues/2393

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
