### PR TITLE
Download: Trim explicit registries

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,12 +6,12 @@ on:
     branches:
       - dev
     paths-ignore:
-      - 'docs/**'
-      - 'CHANGELOG.md'
+      - "docs/**"
+      - "CHANGELOG.md"
   pull_request:
-      paths-ignore:
-        - 'docs/**'
-        - 'CHANGELOG.md'
+    paths-ignore:
+      - "docs/**"
+      - "CHANGELOG.md"
   release:
     types: [published]
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,7 +5,13 @@ on:
   push:
     branches:
       - dev
+    paths-ignore:
+      - 'docs/**'
+      - 'CHANGELOG.md'
   pull_request:
+      paths-ignore:
+        - 'docs/**'
+        - 'CHANGELOG.md'
   release:
     types: [published]
 

--- a/.github/workflows/tools-api-docs-dev.yml
+++ b/.github/workflows/tools-api-docs-dev.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - dev
+    paths-ignore:
+    - 'CHANGELOG.md'
   pull_request:
+    paths-ignore:
+    - 'CHANGELOG.md'
   release:
     types: [published]
 

--- a/.github/workflows/tools-api-docs-dev.yml
+++ b/.github/workflows/tools-api-docs-dev.yml
@@ -5,10 +5,10 @@ on:
     branches:
       - dev
     paths-ignore:
-    - 'CHANGELOG.md'
+      - "CHANGELOG.md"
   pull_request:
     paths-ignore:
-    - 'CHANGELOG.md'
+      - "CHANGELOG.md"
   release:
     types: [published]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 - `params.max_multiqc_email_size` is no longer required ([#2273](https://github.com/nf-core/tools/pull/2273))
 - Remove `cleanup = true` from `test_full.config` in pipeline template ([#2279](https://github.com/nf-core/tools/pull/2279))
 - Fix usage docs for specifying `params.yaml` ([#2279](https://github.com/nf-core/tools/pull/2279))
-- Added stub in modules template ([#2277])(<https://github.com/nf-core/tools/pull/2277>) [Contributed by @nvnieuwk]
+- Added stub in modules template ([#2277](https://github.com/nf-core/tools/pull/2277)) [Contributed by @nvnieuwk]
 - Move registry definitions out of profile scope ([#2286])(<https://github.com/nf-core/tools/pull/2286>)
 - Remove `aws_tower` profile ([#2287])(<https://github.com/nf-core/tools/pull/2287>)
 - Fixed the Slack report to include the pipeline name ([#2291](https://github.com/nf-core/tools/pull/2291))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Download
 
 - Improved container image resolution and prioritization of http downloads over Docker URIs ([#2364](https://github.com/nf-core/tools/pull/2364)).
+- Explicit container registry specifications will be ignored, so registries provided with `-l`/`--container-library` are used instead. ([#2403](https://github.com/nf-core/tools/pull/2403)).
 
 ### Linting
 
@@ -42,9 +43,9 @@
 - `params.max_multiqc_email_size` is no longer required ([#2273](https://github.com/nf-core/tools/pull/2273))
 - Remove `cleanup = true` from `test_full.config` in pipeline template ([#2279](https://github.com/nf-core/tools/pull/2279))
 - Fix usage docs for specifying `params.yaml` ([#2279](https://github.com/nf-core/tools/pull/2279))
-- Added stub in modules template ([#2277])(https://github.com/nf-core/tools/pull/2277) [Contributed by @nvnieuwk]
-- Move registry definitions out of profile scope ([#2286])(https://github.com/nf-core/tools/pull/2286)
-- Remove `aws_tower` profile ([#2287])(https://github.com/nf-core/tools/pull/2287)
+- Added stub in modules template ([#2277])(<https://github.com/nf-core/tools/pull/2277>) [Contributed by @nvnieuwk]
+- Move registry definitions out of profile scope ([#2286])(<https://github.com/nf-core/tools/pull/2286>)
+- Remove `aws_tower` profile ([#2287])(<https://github.com/nf-core/tools/pull/2287>)
 - Fixed the Slack report to include the pipeline name ([#2291](https://github.com/nf-core/tools/pull/2291))
 - Fix link in the MultiQC report to point to exact version of output docs ([#2298](https://github.com/nf-core/tools/pull/2298))
 - Updates seqeralabs/action-tower-launch to v2.0.0 ([#2301](https://github.com/nf-core/tools/pull/2301))
@@ -85,7 +86,7 @@ _In addition, `-r` / `--revision` has been changed to a parameter that can be pr
 ### Linting
 
 - Warn if container access is denied ([#2270](https://github.com/nf-core/tools/pull/2270))
-- Error if module container specification has quay.io as prefix when it shouldn't have ([#2278])(https://github.com/nf-core/tools/pull/2278/files)
+- Error if module container specification has quay.io as prefix when it shouldn't have ([#2278])(<https://github.com/nf-core/tools/pull/2278/files>)
 - Detect if container is 'simple name' and try to contact quay.io server by default ([#2281](https://github.com/nf-core/tools/pull/2281))
 - Warn about null/None/empty default values in `nextflow_schema.json` ([#3328](https://github.com/nf-core/tools/pull/2328))
 - Fix linting when creating a pipeline skipping some parts of the template and add CI test ([#2330](https://github.com/nf-core/tools/pull/2330))
@@ -116,7 +117,7 @@ _In addition, `-r` / `--revision` has been changed to a parameter that can be pr
 - Consistent syntax for branch checks in PRs ([#2202](https://github.com/nf-core/tools/issues/2202))
 - Fixed minor Jinja2 templating bug that caused the PR template to miss a newline
 - Updated AWS tests to use newly moved `seqeralabs/action-tower-launch` instead of `nf-core/tower-action`
-- Remove `.cff` files from `.editorconfig` [(#2145)[https://github.com/nf-core/tools/pull/2145]]
+- Remove `.cff` files from `.editorconfig` [[#2145](https://github.com/nf-core/tools/pull/2145)]
 - Simplify pipeline README ([#2186](https://github.com/nf-core/tools/issues/2186))
 - Added support for the apptainer container engine via `-profile apptainer`. ([#2244](https://github.com/nf-core/tools/issues/2244)) [Contributed by @jfy133]
 - Added config `docker.registry` to pipeline template for a configurable default container registry when using Docker containers. Defaults to `quay.io` ([#2133](https://github.com/nf-core/tools/pull/2133))
@@ -1143,7 +1144,7 @@ making a pull-request. See [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md) 
 - Move `params`section from `base.config` to `nextflow.config`
 - Use `env` scope to export `PYTHONNOUSERSITE` in `nextflow.config` to prevent conflicts with host Python environment
 - Bump minimum Nextflow version to `19.10.0` - required to properly use `env` scope in `nextflow.config`
-- Added support for nf-tower in the travis tests, using public mailbox nf-core@mailinator.com
+- Added support for nf-tower in the travis tests, using public mailbox <nf-core@mailinator.com>
 - Add link to [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and [Semantic Versioning](http://semver.org/spec/v2.0.0.html) to CHANGELOG
 - Adjusted `.travis.yml` checks to allow for `patch` branches to be tested
 - Add Python 3.7 dependency to the `environment.yml` file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### Download
 
 - Improved container image resolution and prioritization of http downloads over Docker URIs ([#2364](https://github.com/nf-core/tools/pull/2364)).
-- Explicit container registry specifications will be ignored, so registries provided with `-l`/`--container-library` are used instead. ([#2403](https://github.com/nf-core/tools/pull/2403)).
+- Registries provided with `-l`/`--container-library` will be ignored for modules with explicit container registry specifications ([#2403](https://github.com/nf-core/tools/pull/2403)).
 
 ### Linting
 

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -1244,9 +1244,10 @@ class DownloadWorkflow:
         if len(container_parts) > 2:
             container = "/".join(container_parts[-2:])
             found_library = container_parts[-3]
-            log.info(
-                f'Found explicit container library [bright_magenta]{found_library}[/] in a module. Upon pull failure, retry the download with [bright_magenta] -l "{found_library}"[/]'
-            )
+            if found_library not in ["", "docker:"]:
+                log.info(
+                    f'Found explicit container library [bright_magenta]{found_library}[/] in a module. Upon pull failure, retry the download with [bright_magenta] -l "{found_library}"[/]'
+                )
 
         # Pull using singularity
         address = f"docker://{library}/{container.replace('docker://', '')}"

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -1238,9 +1238,15 @@ class DownloadWorkflow:
 
         # Sometimes, container still contain an explicit library specification, which
         # results in attempted pulls e.g. from docker://quay.io/quay.io/qiime2/core:2022.11
+        # Thus, we trim whatever precedes the base image specification, but also
+        # issue a warning about that behavior.
         container_parts = container.split("/")
         if len(container_parts) > 2:
             container = "/".join(container_parts[-2:])
+            found_library = container_parts[-3]
+            log.info(
+                f'Found explicit container library [bright_magenta]{found_library}[/] in a module. Upon pull failure, retry the download with [bright_magenta] -l "{found_library}"[/]'
+            )
 
         # Pull using singularity
         address = f"docker://{library}/{container.replace('docker://', '')}"

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -1235,6 +1235,13 @@ class DownloadWorkflow:
             Various exceptions possible from `subprocess` execution of Singularity.
         """
         output_path = cache_path or out_path
+
+        # Sometimes, container still contain an explicit library specification, which
+        # results in attempted pulls e.g. from docker://quay.io/quay.io/qiime2/core:2022.11
+        container_parts = container.split("/")
+        if len(container_parts) > 2:
+            container = "/".join(container_parts[-2:])
+
         # Pull using singularity
         address = f"docker://{library}/{container.replace('docker://', '')}"
         if shutil.which("singularity"):


### PR DESCRIPTION
## Issue

Some pipelines respectively modules use full-length URIs such as `quay.io/qiime2/core:2022.11` when referencing the Docker container image. 

Such URIs were not properly accounted for when the new `-l` / `--container-library` feature for _tools 2.9_ was devised.   This prevented the user from successfully pulling the images, because the registry was duplicated in the final URI as is exemplified with `nf-core download ampliseq -r '2.6.1' -s 'singularity' -t`:

```
INFO     Pulling of "quay.io/qiime2/core:2022.11" failed.
         Please troubleshoot the command
         "singularity pull --name
         /crex/proj/sllstore2017079/private/zepper/nextflow/download_pipelines/ampliseq/singularity-images/quay.io-qii
         me2-core-2022.11.img docker://quay.io/quay.io/qiime2/core:2022.11" manually. 
```


## Approach

In general, three possible solutions to this problem exist:

1.  Ignore the provided `-l` / `--container-library` arguments for full length URIs. 
2.  Exclusively considering the provided `-l` / `--container-library` arguments while ignoring any module-specified registry.
3.  Trimming the registry from the module, but adding it to the list of `-l` / `--container-library` provided ones.

All in all, option 2 was chosen. 

If changes were required after pipeline publication, for example due to the migration to another registry, option 1 would have prevented any. Option 3 would have posed the challenge of interfering with the items to loop over during the loop execution itself, with merely questionable benefits for the UX. Although it would have allowed for more instant successful downloads than any other approach, silently adding another container registry would also have been dangerous, as it would have enabled URI hijacking for other modules in a pipeline.  

Therefore, option 2 was ultimately implemented. It eliminates a possible registry automatically to avoid duplications and fixes most download issues, since far the most explicit registries in nf-core modules are `quay.io` and `docker.io`. An _INFO_ message with the module-specified registry is printed to the screen, so that a user can retry the download with said registry as explicit argument.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
