### PR TITLE
Remove `igenomes_base` from the schema, so that nf-validation doesn't…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - ([#2397](https://github.com/nf-core/tools/pull/2397)) Remove fixed Ubuntu test and added to standard testing matrix
 - ([#2396](https://github.com/nf-core/tools/pull/2396)) Reduce container finding error to warning since the registries are not consistent.
 - ([#2415](https://github.com/nf-core/tools/pull/2415#issuecomment-1709847086)) Add autoMounts for apptainer.
+- Remove `igenomes_base` from the schema, so that nf-validation doesn't create a file path and throw errors offline for s3 objects.
 
 ### Download
 

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -60,7 +60,7 @@ params {
     // Schema validation default options
     validationFailUnrecognisedParams = false
     validationLenientMode            = false
-    validationSchemaIgnoreParams     = 'genomes'
+    validationSchemaIgnoreParams     = 'genomes,igenomes_base'
     validationShowHiddenParams       = false
     validate_params                  = true
 

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -196,6 +196,10 @@ plugins {
 {% if igenomes -%}
 // Load igenomes.config if required
 if (!params.igenomes_ignore) {
+    // Check if the igenomes_base exists
+    file(params.igenomes_base, checkIfExists:true)
+
+    // Include the igenomes config
     includeConfig 'conf/igenomes.config'
 } else {
     params.genomes = [:]

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -196,10 +196,6 @@ plugins {
 {% if igenomes -%}
 // Load igenomes.config if required
 if (!params.igenomes_ignore) {
-    // Check if the igenomes_base exists
-    file(params.igenomes_base, checkIfExists:true)
-
-    // Include the igenomes config
     includeConfig 'conf/igenomes.config'
 } else {
     params.genomes = [:]

--- a/nf_core/pipeline-template/nextflow_schema.json
+++ b/nf_core/pipeline-template/nextflow_schema.json
@@ -64,14 +64,6 @@
                     "help_text": "This parameter is *mandatory* if `--genome` is not specified. If you don't have a BWA index available this will be generated for you automatically. Combine with `--save_reference` to save BWA index for future runs.",
                     "fa_icon": "far fa-file-code"
                 },
-                "igenomes_base": {
-                    "type": "string",
-                    "format": "directory-path",
-                    "description": "Directory / URL base for iGenomes references.",
-                    "default": "s3://ngi-igenomes/igenomes",
-                    "fa_icon": "fas fa-cloud-download-alt",
-                    "hidden": true
-                },
                 "igenomes_ignore": {
                     "type": "boolean",
                     "description": "Do not load the iGenomes reference config.",


### PR DESCRIPTION
From [this Slack thread](https://nfcore.slack.com/archives/CE6SDBX2A/p1694428036144569).

In short - nf-validation is creating a `file` object for `params.igenomes_base`, even if igenomes is not being used. This is set to an s3 path by default. On offline systems, this causes an error:

```
Sept-11 11:51:25.634 [main] DEBUG nextflow.file.FileHelper - Creating a file system instance for provider: S3FileSystemProvider
Sept-11 11:51:25.642 [main] DEBUG nextflow.file.FileHelper - AWS S3 config details: {max_error_retry=5}
Sept-11 11:51:32.524 [main] DEBUG nextflow.Session - Session aborted -- Cause: Forbidden (Service: Amazon S3; Status Code: 403; Error Code: 403 Forbidde
n; Request ID: null; S3 Extended Request ID: null; Proxy: pfsense.int.corp.gel.ac)
```
And the console output:
```
Check script 'main.nf' at line: 39 
```

Fix is to remove it from the schema, as we already are doing for `params.genomes`.

May also fix some problems for people with AWS regions.

⚠️  Currently untested.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
