### PR TITLE
Reduce WorkflowMain.initialise in favour of native Nextflow functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - ([#2415](https://github.com/nf-core/tools/pull/2415#issuecomment-1709847086)) Add autoMounts for apptainer.
 - Remove `igenomes_base` from the schema, so that nf-validation doesn't create a file path and throw errors offline for s3 objects.
 - Update Gitpod profile resources to reflect base environment settings.
+- Replace `WorkflowMain.initialise()` with native Nextflow tools where possible in order to simplify the pipeline.
 
 ### Download
 

--- a/nf_core/pipeline-template/lib/WorkflowMain.groovy
+++ b/nf_core/pipeline-template/lib/WorkflowMain.groovy
@@ -7,31 +7,9 @@ import nextflow.Nextflow
 class WorkflowMain {
 
     //
-    // Citation string for pipeline
-    //
-    public static String citation(workflow) {
-        return "If you use ${workflow.manifest.name} for your analysis please cite:\n\n" +
-            // TODO nf-core: Add Zenodo DOI for pipeline after first release
-            //"* The pipeline\n" +
-            //"  https://doi.org/10.5281/zenodo.XXXXXXX\n\n" +
-            "* The nf-core framework\n" +
-            "  https://doi.org/10.1038/s41587-020-0439-x\n\n" +
-            "* Software dependencies\n" +
-            "  https://github.com/${workflow.manifest.name}/blob/master/CITATIONS.md"
-    }
-
-
-    //
     // Validate parameters and print summary to screen
     //
     public static void initialise(workflow, params, log) {
-
-        // Print workflow version and exit on --version
-        if (params.version) {
-            String workflow_version = NfcoreTemplate.version(workflow)
-            log.info "${workflow.manifest.name} ${workflow_version}"
-            System.exit(0)
-        }
 
         // Check that a -profile or Nextflow config has been provided to run the pipeline
         NfcoreTemplate.checkConfigProvided(workflow, log)
@@ -44,10 +22,6 @@ class WorkflowMain {
         // Check AWS batch settings
         NfcoreTemplate.awsBatch(workflow, params)
 
-        // Check input has been provided
-        if (!params.input) {
-            Nextflow.error("Please provide an input samplesheet to the pipeline e.g. '--input samplesheet.csv'")
-        }
     }
 
     {%- if igenomes %}

--- a/nf_core/pipeline-template/lib/WorkflowMain.groovy
+++ b/nf_core/pipeline-template/lib/WorkflowMain.groovy
@@ -6,24 +6,6 @@ import nextflow.Nextflow
 
 class WorkflowMain {
 
-    //
-    // Validate parameters and print summary to screen
-    //
-    public static void initialise(workflow, params, log) {
-
-        // Check that a -profile or Nextflow config has been provided to run the pipeline
-        NfcoreTemplate.checkConfigProvided(workflow, log)
-
-        // Check that conda channels are set-up correctly
-        if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-            Utils.checkCondaChannels(log)
-        }
-
-        // Check AWS batch settings
-        NfcoreTemplate.awsBatch(workflow, params)
-
-    }
-
     {%- if igenomes %}
     //
     // Get attribute from genome config file e.g. fasta

--- a/nf_core/pipeline-template/main.nf
+++ b/nf_core/pipeline-template/main.nf
@@ -100,11 +100,6 @@ workflow {
 */
 
 
-// Create citation string
-def createCitation(workflow, monochrome) {
-
-}
-
 // Get version string from manifest and/or git commit
 def version(workflow) {
     String version_string = ""

--- a/nf_core/pipeline-template/main.nf
+++ b/nf_core/pipeline-template/main.nf
@@ -125,7 +125,7 @@ def checkConfigProvided(workflow) {
             "   (1) Using an existing pipeline profile e.g. `-profile docker` or `-profile singularity`\n" +
             "   (2) Using an existing nf-core/configs for your Institution e.g. `-profile crick` or `-profile uppmax`\n" +
             "   (3) Using your own local custom config e.g. `-c /path/to/your/custom.config`\n\n" +
-            "Please refer to the quick start section and usage docs for the pipeline.\n "
+            "Please refer to the quick start section and usage docs for the pipeline.\n"
     }
     
     // Check that conda channels are set-up correctly

--- a/nf_core/pipeline-template/main.nf
+++ b/nf_core/pipeline-template/main.nf
@@ -22,7 +22,7 @@ nextflow.enable.dsl = 2
 // TODO nf-core: Remove this line if you don't need a FASTA file
 //   This is an example of how to use getGenomeAttribute() to fetch parameters
 //   from igenomes.config using `--genome`
-params.fasta = .getGenomeAttribute(params, 'fasta')
+params.fasta = WorkflowMain.getGenomeAttribute(params, 'fasta')
 {% endif %}
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/nf_core/pipeline-template/main.nf
+++ b/nf_core/pipeline-template/main.nf
@@ -22,7 +22,7 @@ nextflow.enable.dsl = 2
 // TODO nf-core: Remove this line if you don't need a FASTA file
 //   This is an example of how to use getGenomeAttribute() to fetch parameters
 //   from igenomes.config using `--genome`
-params.fasta = WorkflowMain.getGenomeAttribute(params, 'fasta')
+params.fasta = .getGenomeAttribute(params, 'fasta')
 {% endif %}
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,9 +32,23 @@ params.fasta = WorkflowMain.getGenomeAttribute(params, 'fasta')
 
 include { validateParameters; paramsHelp } from 'plugin/nf-validation'
 
+// Pretty print to terminal
+def logo = NfcoreTemplate.logo(workflow, monochrome)
+log.info logo
+def citation = '\n' + "If you use ${workflow.manifest.name} for your analysis please cite:\n\n" +
+    // TODO nf-core: Add Zenodo DOI for pipeline after first release
+    //"* The pipeline\n" +
+    //"  https://doi.org/10.5281/zenodo.XXXXXXX\n\n" +
+    "* The nf-core framework\n" +
+    "  https://doi.org/10.1038/s41587-020-0439-x\n\n" +
+    "* Software dependencies\n" +
+    "  https://github.com/${workflow.manifest.name}/blob/master/CITATIONS.md" + '\n'
+log.info citation
+
 // Print help message if needed
 if (params.help) {
-    log.info createCitation(workflow, params.monochrome_logs)
+    def String command = "nextflow run ${workflow.manifest.name} --input samplesheet.csv -profile docker"
+    log.info paramsHelp(command)
     System.exit(0)
 }
 
@@ -88,18 +102,7 @@ workflow {
 
 // Create citation string
 def createCitation(workflow, monochrome) {
-    def logo = NfcoreTemplate.logo(workflow, monochrome)
-    def citation = '\n' + "If you use ${workflow.manifest.name} for your analysis please cite:\n\n" +
-        // TODO nf-core: Add Zenodo DOI for pipeline after first release
-        //"* The pipeline\n" +
-        //"  https://doi.org/10.5281/zenodo.XXXXXXX\n\n" +
-        "* The nf-core framework\n" +
-        "  https://doi.org/10.1038/s41587-020-0439-x\n\n" +
-        "* Software dependencies\n" +
-        "  https://github.com/${workflow.manifest.name}/blob/master/CITATIONS.md" + '\n'
-    
-    def String command = "nextflow run ${workflow.manifest.name} --input samplesheet.csv --genome GRCh37 -profile docker"
-    return logo + paramsHelp(command) + citation + NfcoreTemplate.dashedLine(monochrome)
+
 }
 
 // Get version string from manifest and/or git commit

--- a/nf_core/pipeline-template/workflows/pipeline.nf
+++ b/nf_core/pipeline-template/workflows/pipeline.nf
@@ -6,12 +6,8 @@
 
 include { paramsSummaryLog; paramsSummaryMap } from 'plugin/nf-validation'
 
-def logo = NfcoreTemplate.logo(workflow, params.monochrome_logs)
-def citation = '\n' + WorkflowMain.citation(workflow) + '\n'
-def summary_params = paramsSummaryMap(workflow)
-
 // Print parameter summary log to screen
-log.info logo + paramsSummaryLog(workflow) + citation
+log.info paramsSummaryLog(workflow)
 
 Workflow{{ short_name[0]|upper }}{{ short_name[1:] }}.initialise(params, log)
 


### PR DESCRIPTION
To simplify the pipeline, I have reduced the WorkflowMain class to not include the basic checking methods, instead they are in the `main.nf` file.

This is kind of a POC, since I'd like some discussion on what is the best for everyone to consider and maintain. I've opened the PR to trigger some tests and see what breaks. 

- Reduce components in WorkflowMain.initialise() in order to simplify pipeline
- Move checking functions to `main.nf`

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
