### PR TITLE
Download:  Fix unintentional downloading of containers in test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Improved container image resolution and prioritization of http downloads over Docker URIs ([#2364](https://github.com/nf-core/tools/pull/2364)).
 - Registries provided with `-l`/`--container-library` will be ignored for modules with explicit container registry specifications ([#2403](https://github.com/nf-core/tools/pull/2403)).
+- Fix unintentional downloading of containers in test for the Tower download functionality. Bug reported by @adamrtalbot and @awgymer ([#2434](https://github.com/nf-core/tools/pull/2434)).
 
 ### Linting
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -402,7 +402,8 @@ class DownloadTest(unittest.TestCase):
     # Test Download for Tower
     #
     @with_temporary_folder
-    def test_download_workflow_for_tower(self, tmp_dir):
+    @mock.patch("nf_core.download.DownloadWorkflow.get_singularity_images")
+    def test_download_workflow_for_tower(self, tmp_dir, _):
         download_obj = DownloadWorkflow(
             pipeline="nf-core/rnaseq",
             revision=("3.7", "3.9"),
@@ -451,11 +452,6 @@ class DownloadTest(unittest.TestCase):
 
         # download_obj.download_workflow_tower(location=tmp_dir) will run container image detection for all requested revisions
         assert isinstance(download_obj.containers, list) and len(download_obj.containers) == 33
-        # manually test container image detection for 3.7 revision only
-        download_obj.containers = []  # empty container list for the test
-        download_obj.workflow_repo.checkout(download_obj.wf_sha["3.7"])
-        download_obj.find_container_images(download_obj.workflow_repo.access())
-        assert len(download_obj.containers) == 30  # 30 containers for 3.7
         assert (
             "https://depot.galaxyproject.org/singularity/bbmap:38.93--he522d1c_0" in download_obj.containers
         )  # direct definition


### PR DESCRIPTION
When I initially wrote the tests for the new `nf-core download --tower` functionality, there was little test coverage regarding container image detection. Therefore, I incorporated some functionality along in this line into a new test [`test_download_workflow_for_tower()`](https://github.com/nf-core/tools/commit/340c5195067809b27d1f1da5273d9d2ca99bafc3). 

Since I felt that testing everything with a real pipeline was preferable over a dummy pipeline with just one or two nicely formatted modules, I chose [rnaseq](https://nf-co.re/rnaseq/3.9) as a test subject. Since the test was never intended to actually download any of the detected images, I was not bothered about the pipeline comprising more than 30 modules. 

Initially, the test also performed as intended. But already two weeks later, we decided that downloading containers by default would improve the UX of `nf-core download`. Therefore, [downloading containers was no longer optional when choosing the `--tower` download method](https://github.com/nf-core/tools/commit/315b9a3536a1d7cdd661bafc3e7f0f1cc63051a7). 

```
self.container = "singularity" if singularity_cache_index or bool(tower) else container
```

This small change had unintended side effects in the tests, because now the test would actually download the 33 containers and thus several GB of data. [This bug was noticed recently](https://nfcore.slack.com/archives/CE5LG7WMB/p1695306235722049) by @adamrtalbot and @awgymer (Thanks!).

Back then, I was not aware that it is possible to mock objects in tests. Therefore, instead of testing a function that also performs undesirable steps, I put a similar function in the test that resembled the original function, but omitted the unwanted steps. Since then, I learnt some basic mocking capability and changed the test to mock the download function now. This should ensure that no images are actually pulled, but will inevitably decrease test coverage slightly.

Since the actual download of a container image is tested with a different test `test_singularity_pull_image_singularity_installed()`, which I have written after the Tower functionality was first added, just mocking the download in `test_download_workflow_for_tower()` should be safe.


## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
