### PR TITLE
Only test min + max supported Python versions

### DIFF
--- a/.github/workflows/create-lint-wf.yml
+++ b/.github/workflows/create-lint-wf.yml
@@ -31,10 +31,10 @@ jobs:
         name: Check out source-code repository
 
       # Set up nf-core/tools
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install python dependencies
         run: |

--- a/.github/workflows/create-test-lint-wf-template.yml
+++ b/.github/workflows/create-test-lint-wf-template.yml
@@ -35,10 +35,10 @@ jobs:
       - uses: actions/checkout@v3
         name: Check out source-code repository
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install python dependencies
         run: |

--- a/.github/workflows/create-test-wf.yml
+++ b/.github/workflows/create-test-wf.yml
@@ -29,10 +29,10 @@ jobs:
       - uses: actions/checkout@v3
         name: Check out source-code repository
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install python dependencies
         run: |

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -16,10 +16,10 @@ jobs:
       - uses: actions/checkout@v3
         name: Check out source-code repository
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install python dependencies
         run: |

--- a/.github/workflows/fix-linting.yml
+++ b/.github/workflows/fix-linting.yml
@@ -38,10 +38,10 @@ jobs:
           # Override to remove the default --check flag so that we make changes
           options: "--color"
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: python-isort
         uses: isort/isort-action@v1.0.0
         with:

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -76,10 +76,10 @@ jobs:
       - name: Check out source-code repository
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: python-isort
         uses: isort/isort-action@v1.1.0
         with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.11"]
         runner: ["ubuntu-latest"]
         include:
           - runner: "ubuntu-20.04"

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -48,10 +48,10 @@ jobs:
           path: nf-core/${{ matrix.pipeline }}
           fetch-depth: "0"
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install python dependencies
         run: |

--- a/.github/workflows/tools-api-docs-dev.yml
+++ b/.github/workflows/tools-api-docs-dev.yml
@@ -26,10 +26,10 @@ jobs:
       - name: Check out source-code repository
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install python dependencies
         run: |

--- a/.github/workflows/tools-api-docs-release.yml
+++ b/.github/workflows/tools-api-docs-release.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Check out source-code repository
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.8
+      - name: Set up Python 11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install python dependencies
         run: |

--- a/.github/workflows/tools-api-docs-release.yml
+++ b/.github/workflows/tools-api-docs-release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Check out source-code repository
         uses: actions/checkout@v3
 
-      - name: Set up Python 11
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
           python-version: 3.11

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.9-slim
+FROM python:3.11.5-slim
 LABEL authors="phil.ewels@scilifelab.se,erik.danielsson@scilifelab.se" \
     description="Docker image containing requirements for the nfcore tools"
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ conda install nf-core
 Alternatively, you can create a new environment with both nf-core/tools and nextflow:
 
 ```bash
-conda create --name nf-core python=3.8 nf-core nextflow
+conda create --name nf-core python=3.11 nf-core nextflow
 conda activate nf-core
 ```
 

--- a/nf_core/pipeline-template/.github/workflows/linting.yml
+++ b/nf_core/pipeline-template/.github/workflows/linting.yml
@@ -78,7 +78,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.11"
           architecture: "x64"
 
       - name: Install dependencies


### PR DESCRIPTION
Bump Python 3.8 -> 3.11 for most CI tasks, plus docker base image.

This is a small measure to reduce the amount of CI jobs that we run.

I think it's vanishingly rare that anything fails only in a _middle_ version of Python - it's basically always one end of the range. So maybe it makes sense to only run tests on the extremes.

Might hopefully help with GitHub API rate limiting, and failing that should save a few grams of CO2.

Also, 3.11 is significantly faster than 3.8 so hopefully this alone will speed up CI a bit.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
