### PR TITLE
fix subworkflows linting: test passes if component.out.version is found in script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Linting
 
+- Correctly pass subworkflow linting test if `COMPONENT.out.versions` is used in the script ([#2448](https://github.com/nf-core/tools/pull/2448))
+
 ### Modules
 
 ### Subworkflows

--- a/nf_core/subworkflows/lint/main_nf.py
+++ b/nf_core/subworkflows/lint/main_nf.py
@@ -134,7 +134,7 @@ def check_main_section(self, lines, included_components):
                         self.main_nf,
                     )
                 )
-            if component + ".out.versions" not in script:
+            if component + ".out.versions" in script:
                 self.passed.append(
                     (
                         "main_nf_include_versions",


### PR DESCRIPTION


## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
