### PR TITLE
set github api permissions to 'content:read'

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,6 +26,8 @@ env:
 jobs:
   pytest:
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.8", "3.11"]


### PR DESCRIPTION
**Why this change?**
We reach API rate limit with error 403
in the [headers](https://github.com/nf-core/tools/actions/runs/6339262937/job/17218023798#step:8:772) we see: `"x-accepted-github-permissions": "contents=read"`
Docs: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token