### PR TITLE
support remote paths in NfCoreTemplate:dump_parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Template
 
+- Support remote paths when dumping pipeline parameters into a json file ([#2465](https://github.com/nf-core/tools/pull/2465)
+
 ### Linting
 
 - Fix incorrectly failing linting if 'modules' was not found in meta.yml ([#2447](https://github.com/nf-core/tools/pull/2447))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Template
 
-- Support remote paths when dumping pipeline parameters into a json file ([#2465](https://github.com/nf-core/tools/pull/2465)
+- Fix writing files to a remote outdir in the NfcoreTemplate helper functions ([#2465](https://github.com/nf-core/tools/pull/2465)
 
 ### Linting
 

--- a/nf_core/pipeline-template/lib/NfcoreTemplate.groovy
+++ b/nf_core/pipeline-template/lib/NfcoreTemplate.groovy
@@ -4,6 +4,7 @@
 
 import org.yaml.snakeyaml.Yaml
 import groovy.json.JsonOutput
+import nextflow.extension.FilesEx
 
 class NfcoreTemplate {
 
@@ -227,15 +228,15 @@ class NfcoreTemplate {
     // Dump pipeline parameters in a json file
     //
     public static void dump_parameters(workflow, params) {
-        def output_d = new File("${params.outdir}/pipeline_info/")
-        if (!output_d.exists()) {
-            output_d.mkdirs()
-        }
-
         def timestamp  = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
-        def output_pf  = new File(output_d, "params_${timestamp}.json")
+        def filename   = "params_${timestamp}.json"
+        def temp_pf    = new File(workflow.launchDir.toString(), ".${filename}")
         def jsonStr    = JsonOutput.toJson(params)
-        output_pf.text = JsonOutput.prettyPrint(jsonStr)
+        temp_pf.text   = JsonOutput.prettyPrint(jsonStr)
+
+        def destination = "${params.outdir}/pipeline_info/params_${timestamp}.json"
+        FilesEx.copyTo(temp_pf.toPath(), destination)
+        temp_pf.delete()
     }
 
     //


### PR DESCRIPTION
Currently the new `dump_parameters` added in v2.10 (#2425) only works on local files.
When using a remote publish dir such as s3, the json file will be written to a weird directory `s3 / path / to / outdir / params_{timestamp}.json` in the launchDir.
This small tweak first creates the parameter dump on the nextflow head machine as a hidden file and then moves it to the possibly remote outdir using the nextflow FilesEx helper to deal with the remote filesystems.   


## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
