### PR TITLE
Ignore process selector warnings by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Modified devcontainer permissions so that singularity can be run in Codespaces/VS Code devcontainers ([Commit a103f44](https://github.com/CarsonJM/tools/commit/a103f4484eca8c6d668e4653a4ed8d20faf1b41d))
 - Update Gitpod profile resources to reflect base environment settings.
 - ([#747](https://github.com/nf-core/tools/issues/747)) Add to the template the code to dump the selected pipeline parameters into a json file.
+- [#2161] Disable process selector warnings by default.
 
 ### Download
 

--- a/nf_core/pipeline-template/.github/CONTRIBUTING.md
+++ b/nf_core/pipeline-template/.github/CONTRIBUTING.md
@@ -31,6 +31,9 @@ If you're not used to this workflow with git, you can start with some [docs from
 
 ## Tests
 
+You can optionally test your changes by running the pipeline locally. Then it is recommended to use the `debug` profile to
+receive warnings about process selectors and other debug info. Example: `nextflow run . -profile debug,test,docker --outdir <OUTDIR>`.
+
 When you create a pull request with changes, [GitHub Actions](https://github.com/features/actions) will run automatic tests.
 Typically, pull-requests are only fully reviewed when these tests are passing, though of course we can help out before then.
 

--- a/nf_core/pipeline-template/.github/PULL_REQUEST_TEMPLATE.md
+++ b/nf_core/pipeline-template/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,6 +21,7 @@ Learn more about contributing: [CONTRIBUTING.md](https://github.com/{{ name }}/t
       {%- endif %}
 - [ ] Make sure your code lints (`nf-core lint`).
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
+- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
 - [ ] Usage Documentation in `docs/usage.md` is updated.
 - [ ] Output Documentation in `docs/output.md` is updated.
 - [ ] `CHANGELOG.md` is updated.

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -91,6 +91,7 @@ profiles {
         dumpHashes             = true
         process.beforeScript   = 'echo $HOSTNAME'
         cleanup                = false
+        nextflow.enable.configProcessNamesValidation = true
     }
     conda {
         conda.enabled          = true
@@ -215,6 +216,9 @@ env {
 
 // Capture exit codes from upstream processes when piping
 process.shell = ['/bin/bash', '-euo', 'pipefail']
+
+// Disable process selector warnings by default. Use debug profile to enable warnings.
+nextflow.enable.configProcessNamesValidation = false
 
 def trace_timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
 timeline {


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] Documentation in `docs` is updated

This addresses issue #2161.

Changes nextflow.config in the template to set `nextflow.enable.configProcessNamesValidation = false`. The `debug` profile can then be used to re-enable these warnings.

The pull request template is updated to include a "testing with `debug` profile" step.

I will also send a PR for the website (docs). 