### PR TITLE
Add lint test to check existence of test profile

### DIFF
--- a/nf_core/lint/nextflow_config.py
+++ b/nf_core/lint/nextflow_config.py
@@ -2,7 +2,6 @@ import logging
 import os
 import re
 import subprocess
-from nf_core.utils import nextflow_cmd
 
 log = logging.getLogger(__name__)
 
@@ -110,7 +109,7 @@ def nextflow_config(self):
 
                 lint:
                     nextflow_config: False
-    
+
     **The configuration should contain the following or the test will fail:**
 
     * A ``test`` configuration profile should exist.
@@ -320,7 +319,9 @@ def nextflow_config(self):
             )
 
     # Check for the availability of the "test" configuration profile
-    nf_proc = subprocess.run(["nextflow", "config", "-flat", "-profile", "test"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    nf_proc = subprocess.run(
+        ["nextflow", "config", "-flat", "-profile", "test"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )
     if nf_proc.returncode == 1:
         # The equivalent command has already succeeded without `-profile test`, in utils.Pipeline.fetch_wf_config,
         # so we assume that the error now is due to a missing test profile

--- a/nf_core/lint/nextflow_config.py
+++ b/nf_core/lint/nextflow_config.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import re
-import subprocess
 
 log = logging.getLogger(__name__)
 

--- a/tests/lint/nextflow_config.py
+++ b/tests/lint/nextflow_config.py
@@ -1,6 +1,7 @@
 import nf_core.create
 import nf_core.lint
-
+import subprocess
+from unittest import mock
 
 def test_nextflow_config_example_pass(self):
     """Tests that config variable existence test works with good pipeline example"""
@@ -31,5 +32,20 @@ def test_nextflow_config_dev_in_release_mode_failed(self):
     lint_obj.release_mode = True
     lint_obj.nf_config["manifest.version"] = "dev_is_bad_name"
     result = lint_obj.nextflow_config()
+    assert len(result["failed"]) > 0
+    assert len(result["warned"]) == 0
+
+@mock.patch("subprocess.run")
+def test_nextflow_config_missing_test_profile_failed(self, mock_subprocess):
+    """Tests that the test fails if nextflow command with `-profile test` exits
+    with exit code 1."""
+    self.lint_obj._load_pipeline_config()
+    with mock.patch("subprocess.run") as mock_subprocess:
+        mock_subprocess.return_value = mock.Mock(returncode=1)
+        result = self.lint_obj.nextflow_config()
+        mock_subprocess.assert_called_once_with(
+            ["nextflow", "config", "-flat", "-profile", "test"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
+
     assert len(result["failed"]) > 0
     assert len(result["warned"]) == 0

--- a/tests/lint/nextflow_config.py
+++ b/tests/lint/nextflow_config.py
@@ -1,7 +1,9 @@
-import nf_core.create
-import nf_core.lint
 import subprocess
 from unittest import mock
+
+import nf_core.create
+import nf_core.lint
+
 
 def test_nextflow_config_example_pass(self):
     """Tests that config variable existence test works with good pipeline example"""
@@ -34,6 +36,7 @@ def test_nextflow_config_dev_in_release_mode_failed(self):
     result = lint_obj.nextflow_config()
     assert len(result["failed"]) > 0
     assert len(result["warned"]) == 0
+
 
 @mock.patch("subprocess.run")
 def test_nextflow_config_missing_test_profile_failed(self, mock_subprocess):

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -213,6 +213,7 @@ class TestLint(unittest.TestCase):
         test_nextflow_config_bad_name_fail,
         test_nextflow_config_dev_in_release_mode_failed,
         test_nextflow_config_example_pass,
+        test_nextflow_config_missing_test_profile_failed,
     )
     from .lint.version_consistency import test_version_consistency
 


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated

This is the first part of  #1837.

See below comment: The following is no longer true (no way to "strike through" in github?):
It is not an ideal implementation, because it has to call `nextflow`, and only gets indirect indication of the failure due to the exit code. If there's a better way to reliably parse the config with python, I will use that instead- I hope someone can offer guidance on that if possible.

This is a draft PR, not ready for merge.