### PR TITLE
Ignore ignored config variables

### DIFF
--- a/nf_core/lint/nextflow_config.py
+++ b/nf_core/lint/nextflow_config.py
@@ -203,6 +203,8 @@ def nextflow_config(self):
 
     # Check the variables that should be set to 'true'
     for k in ["timeline.enabled", "report.enabled", "trace.enabled", "dag.enabled"]:
+        if k in ignore_configs:
+            continue
         if self.nf_config.get(k) == "true":
             passed.append(f"Config ``{k}`` had correct value: ``{self.nf_config.get(k)}``")
         else:


### PR DESCRIPTION
Skip `timeline.enabled`, `report.enabled`, `trace.enabled` and `dag.enabled` if they are configured as ignorable. Currently `nf-core lint` does not take this setting into account for these variables.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
