### PR TITLE
Automatically create modules directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Replace ModulePatch by ComponentPatch ([#2482](https://github.com/nf-core/tools/pull/2482))
 - Fixed `nf-core modules lint` to work with new module structure for nf-test ([#2494](https://github.com/nf-core/tools/pull/2494))
 - Add option `--migrate-pytest` to create a module with nf-test taking into account an existing module ([#2549](https://github.com/nf-core/tools/pull/2549))
+- When installing modules and subworkflows, automatically create the `./modules` directory if it doesn't exist ([#2563](https://github.com/nf-core/tools/issues/2563))
 
 ### Subworkflows
 

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -67,7 +67,8 @@ class ModulesJson:
         new_modules_json = {"name": pipeline_name.strip("'"), "homePage": pipeline_url.strip("'"), "repos": {}}
 
         if not self.modules_dir.exists():
-            raise UserWarning("Can't find a ./modules directory. Is this a DSL2 pipeline?")
+            log.info(f"Creating ./modules directory in '{self.dir}'")
+            self.modules_dir.mkdir()
 
         # Get repositories
         repos, _ = self.get_pipeline_module_repositories("modules", self.modules_dir)


### PR DESCRIPTION
Addresses #2563 to automatically create a `./modules` dir when necessary for installing modules.

Combined with #2562, this allows easy installation of nf-core modules and subworkflows into non-nf-core pipelines, and reduces friction for reuse. 

## PR checklist

- [X] This comment contains a description of changes (with reason)
- [X] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
