### PR TITLE
nf-test linting tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Correctly pass subworkflow linting test if `COMPONENT.out.versions` is used in the script ([#2448](https://github.com/nf-core/tools/pull/2448))
 - Check for spaces in modules container URLs ([#2452](https://github.com/nf-core/tools/issues/2452))
 - Correctly ignore `timeline.enabled`, `report.enabled`, `trace.enabled`, `dag.enabled` variables when linting a pipeline. ([#2507](https://github.com/nf-core/tools/pull/2507))
+- Lint nf-test main.nf.test tags include all used components in chained tests ([#2572](https://github.com/nf-core/tools/pull/2572))
 
 ### Modules
 

--- a/nf_core/modules/lint/module_tests.py
+++ b/nf_core/modules/lint/module_tests.py
@@ -94,8 +94,11 @@ def module_tests(_, module: NFCoreComponent):
             required_tags = ["modules", "modules_nfcore", module.component_name]
             if module.component_name.count("/") == 1:
                 required_tags.append(module.component_name.split("/")[0])
+            chained_components_tags = module._get_included_components_in_chained_tests(module.nftest_main_nf)
             missing_tags = []
-            for tag in required_tags:
+            log.debug(f"Required tags: {required_tags}")
+            log.debug(f"Included components for chained nf-tests: {chained_components_tags}")
+            for tag in set(required_tags + chained_components_tags):
                 if tag not in main_nf_tags:
                     missing_tags.append(tag)
             if len(missing_tags) == 0:

--- a/nf_core/subworkflows/lint/subworkflow_tests.py
+++ b/nf_core/subworkflows/lint/subworkflow_tests.py
@@ -106,10 +106,12 @@ def subworkflow_tests(_, subworkflow: NFCoreComponent):
             included_components = []
             if subworkflow.main_nf.is_file():
                 included_components = subworkflow._get_included_components(subworkflow.main_nf)
+            chained_components_tags = subworkflow._get_included_components_in_chained_tests(subworkflow.nftest_main_nf)
             log.debug(f"Included components: {included_components}")
             log.debug(f"Required tags: {required_tags}")
+            log.debug(f"Included components for chained nf-tests: {chained_components_tags}")
             missing_tags = []
-            for tag in required_tags + included_components:
+            for tag in set(required_tags + included_components + chained_components_tags):
                 if tag not in main_nf_tags:
                     missing_tags.append(tag)
             if len(missing_tags) == 0:

--- a/tests/modules/lint.py
+++ b/tests/modules/lint.py
@@ -2,12 +2,13 @@ from pathlib import Path
 
 import pytest
 import yaml
+from git.repo import Repo
 
 import nf_core.modules
 from nf_core.modules.lint import main_nf
 from nf_core.utils import set_wd
 
-from ..utils import GITLAB_URL
+from ..utils import GITLAB_NFTEST_BRANCH, GITLAB_URL
 from .patch import BISMARK_ALIGN, CORRECT_SHA, PATCH_BRANCH, REPO_NAME, modify_main_nf
 
 
@@ -622,3 +623,24 @@ def test_modules_unused_pytest_files(self):
     assert len(module_lint.passed) >= 0
     assert len(module_lint.warned) >= 0
     assert module_lint.failed[0].lint_test == "test_old_test_dir"
+
+
+def test_nftest_failing_linting(self):
+    """Test linting a module which includes other modules in nf-test tests.
+    Linting tests"""
+    # Clone modules repo with testing modules
+    tmp_dir = self.nfcore_modules.parent
+    self.nfcore_modules = Path(tmp_dir, "modules-test")
+    Repo.clone_from(GITLAB_URL, self.nfcore_modules, branch=GITLAB_NFTEST_BRANCH)
+
+    module_lint = nf_core.modules.ModuleLint(dir=self.nfcore_modules)
+    module_lint.lint(print_results=False, module="kallisto/quant")
+
+    assert len(module_lint.failed) == 4, f"Linting failed with {[x.__dict__ for x in module_lint.failed]}"
+    assert len(module_lint.passed) >= 0
+    assert len(module_lint.warned) >= 0
+    assert module_lint.failed[0].lint_test == "environment_yml_valid"
+    assert module_lint.failed[1].lint_test == "meta_yml_valid"
+    assert module_lint.failed[2].lint_test == "test_main_tags"
+    assert "kallisto/index" in module_lint.failed[2].message
+    assert module_lint.failed[3].lint_test == "test_tags_yml"

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -202,6 +202,7 @@ class TestModules(unittest.TestCase):
         test_modules_missing_test_dir,
         test_modules_missing_test_main_nf,
         test_modules_unused_pytest_files,
+        test_nftest_failing_linting,
     )
     from .modules.list import (  # type: ignore[misc]
         test_modules_install_and_list_pipeline,


### PR DESCRIPTION
All components used in chained nf-tests, defined with `script` in the file `main.nf.test` must be added to the tags.
Close #2559 

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
