### PR TITLE
Download: Add docker prefix for absolute container URIs as well.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 ### Download
 
-- Bugfix for AttributeError: 'ContainerError' object has no attribute 'absoluteURI' ([#2543](https://github.com/nf-core/tools/pull/2543)).
+- Add `docker://` prefix for absolute container URIs as well ([#2576](https://github.com/nf-core/tools/pull/2576)).
+- Bugfix for AttributeError: `ContainerError` object has no attribute `absoluteURI` ([#2543](https://github.com/nf-core/tools/pull/2543)).
 
 ### Linting
 

--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -1247,7 +1247,7 @@ class DownloadWorkflow:
         # Thus, if an explicit registry is specified, the provided -l value is ignored.
         container_parts = container.split("/")
         if len(container_parts) > 2:
-            address = container
+            address = f"docker://{container}"
             absolute_URI = True
         else:
             address = f"docker://{library}/{container.replace('docker://', '')}"

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -264,6 +264,11 @@ class DownloadTest(unittest.TestCase):
                 "hello-world", f"{tmp_dir}/hello-world.sif", None, "docker.io", mock_rich_progress
             )
 
+        # Test successful pull with absolute URI (use tiny 3.5MB test container from the "Kogia" project: https://github.com/bschiffthaler/kogia)
+        download_obj.singularity_pull_image(
+            "docker.io/bschiffthaler/sed", f"{tmp_dir}/hello-world.sif", None, "docker.io", mock_rich_progress
+        )
+
         # try to pull from non-existing registry (Name change hello-world_new.sif is needed, otherwise ImageExists is raised before attempting to pull.)
         with pytest.raises(ContainerError.RegistryNotFound):
             download_obj.singularity_pull_image(
@@ -288,6 +293,16 @@ class DownloadTest(unittest.TestCase):
         with pytest.raises(ContainerError.ImageNotFound):
             download_obj.singularity_pull_image(
                 "a-container", f"{tmp_dir}/acontainer.sif", None, "ghcr.io", mock_rich_progress
+            )
+
+        # test Image not found for absolute URI.
+        with pytest.raises(ContainerError.ImageNotFound):
+            download_obj.singularity_pull_image(
+                "docker.io/bschiffthaler/nothingtopullhere",
+                f"{tmp_dir}/nothingtopullhere.sif",
+                None,
+                "docker.io",
+                mock_rich_progress,
             )
 
         # Traffic from Github Actions to GitHub's Container Registry is unlimited, so no harm should be done here.

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -266,7 +266,7 @@ class DownloadTest(unittest.TestCase):
 
         # Test successful pull with absolute URI (use tiny 3.5MB test container from the "Kogia" project: https://github.com/bschiffthaler/kogia)
         download_obj.singularity_pull_image(
-            "docker.io/bschiffthaler/sed", f"{tmp_dir}/hello-world.sif", None, "docker.io", mock_rich_progress
+            "docker.io/bschiffthaler/sed", f"{tmp_dir}/sed.sif", None, "docker.io", mock_rich_progress
         )
 
         # try to pull from non-existing registry (Name change hello-world_new.sif is needed, otherwise ImageExists is raised before attempting to pull.)


### PR DESCRIPTION
This PR adds the `docker://` prefix to absolute URIs as well. 

While this will result in an error for prebuild Singularity images (and was thus once omitted deliberately), practical experience has demonstrated that the conversion of a Docker OCI is more common in nf-core pipelines.

It is a trade-off between Docker and Singularity support, however essentially all container-specifications I could find in custom, local modules refer to Docker images. Therefore, this change should increase the number of "_just works_" downloads.

It is also accompanied by two more tests that pull a tiny 3.5MB Docker OCI and convert it with `singularity build`.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
