### PR TITLE
don't warn about missing `meta` value in meta.yml

### DIFF
--- a/nf_core/modules/lint/meta_yml.py
+++ b/nf_core/modules/lint/meta_yml.py
@@ -147,6 +147,14 @@ def meta_yml(module_lint_object: ComponentLint, module: NFCoreComponent) -> None
                             module.meta_yml,
                         )
                     )
+                elif output == "meta":
+                    module.passed.append(
+                        (
+                            "meta_output_meta_only",
+                            f"`{output}` is skipped for `meta.yml` outputs",
+                            module.meta_yml,
+                        )
+                    )
                 else:
                     module.warned.append(
                         (


### PR DESCRIPTION
Until we have figured out a better way to handle it in the meta.yml. This should at least avoid some confusion.