### PR TITLE
Fix Renovate Docker

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,4 +2,10 @@
     $schema: "https://docs.renovatebot.com/renovate-schema.json",
     extends: ["github>nf-core/ops//.github/renovate/default.json5"],
     baseBranches: ["dev"],
+    packageRules: [
+        {
+            matchDatasources: ["docker"],
+            registryUrls: ["docker.io"],
+        },
+    ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,11 @@
     packageRules: [
         {
             matchDatasources: ["docker"],
+            matchPackageNames: ["python"],
+            versioning: "pep440",
+        },
+        {
+            matchDatasources: ["docker"],
             registryUrls: ["docker.io"],
         },
     ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,7 @@
 {
     $schema: "https://docs.renovatebot.com/renovate-schema.json",
     extends: ["github>nf-core/ops//.github/renovate/default.json5"],
+    ignorePaths: ["nf_core/pipeline-template/modules/nf-core/"],
     baseBranches: ["dev"],
     packageRules: [
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Update mshick/add-pr-comment action to v2 ([#2632](https://github.com/nf-core/tools/pull/2632))
 - update python image version in docker file ([#2636](https://github.com/nf-core/tools/pull/2636))
 - Set pdiff as nf-test differ in Docker image for Gitpod ([#2642](https://github.com/nf-core/tools/pull/2642))
+- Fix Renovate Dockerfile updating issues ([#2648](https://github.com/nf-core/tools/pull/2648))
 
 # [v2.11.1 - Magnesium Dragon Patch](https://github.com/nf-core/tools/releases/tag/2.11) - [2023-12-20]
 


### PR DESCRIPTION
Fixes a few things:
- Ignore Dockerfiles(and conda) in modules in pipeline template
- Add python pep440 versioning for main Dockerfile
- Set renovate docker registry to docker.io (https://developer.mend.io/github/nf-core/tools/-/job/502f6333-fe00-4194-95ca-6c8237128324)