### PR TITLE
Linting: environment.yml name must be lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Linting
 
+- environment.yml name must be lowercase ([#2676](https://github.com/nf-core/tools/pull/2676))
+
 ### Modules
 
 - Fix linting of a pipeline with patched custom module ([#2669](https://github.com/nf-core/tools/pull/2669))

--- a/nf_core/modules/lint/environment_yml.py
+++ b/nf_core/modules/lint/environment_yml.py
@@ -109,3 +109,21 @@ def environment_yml(module_lint_object: ComponentLint, module: NFCoreComponent) 
                         module.environment_yml,
                     )
                 )
+
+            # Check that the name is lowercase
+            if env_yml["name"] == env_yml["name"].lower():
+                module.passed.append(
+                    (
+                        "environment_yml_name_lowercase",
+                        "The module's `environment.yml` name is lowercase",
+                        module.environment_yml,
+                    )
+                )
+            else:
+                module.failed.append(
+                    (
+                        "environment_yml_name_lowercase",
+                        "The module's `environment.yml` name is not lowercase",
+                        module.environment_yml,
+                    )
+                )


### PR DESCRIPTION
Close https://github.com/nf-core/tools/issues/2515

Linting that the name matches the one in `meta.yml` was done with #2490 
All names were changed to lowercase with https://github.com/nf-core/modules/pull/4332