### PR TITLE
Ignore nf-core-bot in renovate PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,4 +14,5 @@
             registryUrls: ["docker.io"],
         },
     ],
+    gitIgnoredAuthors: ["core@nf-co.re"],
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - fix changelog titles ([#2708](https://github.com/nf-core/tools/pull/2708))
 - Print relative path not absolute path in logo cmd log output ([#2709](https://github.com/nf-core/tools/pull/2709))
 - Update codecov/codecov-action action to v4 ([#2713](https://github.com/nf-core/tools/pull/2713))
+- Ignore nf-core-bot in renovate PRs ([#2716](https://github.com/nf-core/tools/pull/2716))
 
 ## [v2.12 - Aluminium Wolf](https://github.com/nf-core/tools/releases/tag/2.11) - [2024-01-29]
 


### PR DESCRIPTION
Following this: https://docs.renovatebot.com/configuration-options/#gitignoredauthors, otherwise renovate doesn't update open PRs after the bot has updated the changelog