### PR TITLE
Pipeline template: Fix download test CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Template
 
 - Add empty line in README.md to fix badges. ([#2729](https://github.com/nf-core/tools/pull/2729))
+- Replace automatic branch detection in `nf-core download` CI test with hardcoded `dev` and input. ([#2727](https://github.com/nf-core/tools/pull/2727))
 
 ### Linting
 
@@ -35,7 +36,7 @@
 
 ### Template
 
-- Add a Github Action Workflow to the pipeline template that tests a successful download with 'nf-core download' ([#2618](https://github.com/nf-core/tools/pull/2618))
+- Add a Github Action Workflow to the pipeline template that tests a successful download with `nf-core download` ([#2618](https://github.com/nf-core/tools/pull/2618))
 - Use `pre-commit` to lint files in GitHub CI ([#2635](https://github.com/nf-core/tools/pull/2635))
 - Use pdiff also on gitpod for nf-test ([#2640](https://github.com/nf-core/tools/pull/2640))
 - switch to new image syntax in readme ([#2645](https://github.com/nf-core/tools/pull/2645))

--- a/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
+++ b/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
@@ -69,4 +69,4 @@ jobs:
         env:
           NXF_SINGULARITY_CACHEDIR: ./
           NXF_SINGULARITY_HOME_MOUNT: true
-        run: nextflow run ./${{ env.REPOTITLE_LOWERCASE }}/$( sed 's/\W/_/g' <<< ${{ env.REPO_BRANCH }}) -stub -profile test,singularity --outdir ./results {% endraw %}
+        run: nextflow run ./${{ env.REPOTITLE_LOWERCASE }}/$( sed 's/\W/_/g' <<< ${{ env.REPO_BRANCH }}) -stub -profile test,singularity --outdir ./results{% endraw %}

--- a/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
+++ b/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       testbranch:
-        description: "The branch to test the pipeline download."
+        description: "The specific branch you wish to utilize for the test execution of nf-core download."
         required: true
         default: "dev"
   pull_request:

--- a/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
+++ b/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
@@ -6,6 +6,11 @@ name: Test successful pipeline download with 'nf-core download'
 #  - the head branch of the pull request is updated, i.e. if fixes for a release are pushed last minute to dev.
 on:
   workflow_dispatch:
+    inputs:
+      testbranch:
+        description: "The branch to test the pipeline download."
+        required: true
+        default: "dev"
   pull_request:
     types:
       - opened
@@ -42,7 +47,7 @@ jobs:
         run: |
           echo "REPO_LOWERCASE=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
           echo "REPOTITLE_LOWERCASE=$(basename ${GITHUB_REPOSITORY,,})" >> ${GITHUB_ENV}
-          echo "REPO_BRANCH=${GITHUB_REF#refs/heads/}" >> ${GITHUB_ENV}
+          echo "REPO_BRANCH=${{ github.event.inputs.testbranch || 'dev' }}" >> ${GITHUB_ENV}
 
       - name: Download the pipeline
         env:


### PR DESCRIPTION
When writing the CI test that tested nf-core download on the current pipeline, I intended to run the test for any push on a branch underlying an active PR to _dev_. This required that the CI action would dynamically determine the branch name, for which I naively queried `/refs/heads/`. 

However, I now learned [that resolving the branch name is a bit more complex than I initially thought](https://mirrors.edge.kernel.org/pub/software/scm/git/docs/gitrevisions.html), since there may be a `HEAD`, `FETCH_HEAD`, `ORIG_HEAD`, `MERGE_HEAD` and `CHERRY_PICK_HEAD` and [sadly branch determination already failed in practice](https://github.com/nf-core/taxprofiler/actions/runs/7742219884) (cc @sofstam ) because a `MERGE_HEAD` existed in addition to `HEAD`.

Since it is quite difficult to determine the current branch reliably (except maybe by running `git`?) and we are exclusively running the CI test for merge-PRs to master, I decided to hardcode the `dev` branch instead. [This works on PRs to master](https://github.com/MatthiasZepper/testpipeline/actions/runs/7757005837/job/21155555475?pr=2), but it is still possible to manually dispatch the action on any other branch if needed.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
