### PR TITLE
Moduels: patch: handle file not found when it is an added file to a module

### DIFF
--- a/nf_core/modules/modules_differ.py
+++ b/nf_core/modules/modules_differ.py
@@ -447,8 +447,12 @@ class ModulesDiffer:
             log.debug(f"Applying patch to {file}")
             fn = Path(file).relative_to(module_relpath)
             file_path = module_dir / fn
-            with open(file_path) as fh:
-                file_lines = fh.readlines()
+            try:
+                with open(file_path) as fh:
+                    file_lines = fh.readlines()
+            except FileNotFoundError:
+                # The file was added with the patch
+                file_lines = [""]
             patched_new_lines = ModulesDiffer.try_apply_single_patch(file_lines, patch, reverse=reverse)
             new_files[str(fn)] = patched_new_lines
         return new_files


### PR DESCRIPTION
Close https://github.com/nf-core/tools/issues/2749

When adding a file to a module, it needs to be patched.
This avoids the file being removed when we update the module.
This PR fixes an error when trying to read a file that doesn't exist during applying patch.