### PR TITLE
POC: module yaml restructure

### DIFF
--- a/nf_core/components/nfcore_component.py
+++ b/nf_core/components/nfcore_component.py
@@ -166,15 +166,27 @@ class NFCoreComponent:
             log.info(f"Could not find any inputs in {self.main_nf}")
             return inputs
         input_data = data.split("input:")[1].split("output:")[0]
-        regex = r"(val|path)\s*(\(([^)]+)\)|\s*([^)\s,]+))"
-        matches = re.finditer(regex, input_data, re.MULTILINE)
-        for _, match in enumerate(matches, start=1):
-            if match.group(3):
-                input_val = match.group(3).split(",")[0]  # handle `files, stageAs: "inputs/*"` cases
-                inputs.append(input_val)
-            elif match.group(4):
-                input_val = match.group(4).split(",")[0]  # handle `files, stageAs: "inputs/*"` cases
-                inputs.append(input_val)
+        for line in input_data.split("\n"):
+            theseinputs = []
+            regex = r"(val|path)\s*(\(([^)]+)\)|\s*([^)\s,]+))"
+            matches = re.finditer(regex, line)
+            for _, match in enumerate(matches, start=1):
+                input_type = None
+                input_val = None
+                if match.group(1):
+                    input_type = match.group(1)
+                if match.group(3):
+                    input_val = match.group(3).split(",")[0]  # handle `files, stageAs: "inputs/*"` cases
+                elif match.group(4):
+                    input_val = match.group(4).split(",")[0]  # handle `files, stageAs: "inputs/*"` cases
+                if input_type and input_val:
+                    theseinputs.append({
+                        input_val: {
+                            "type": input_type
+                        }
+                    })
+            if len(theseinputs) > 0:
+                inputs.append(theseinputs)
         log.info(f"Found {len(inputs)} inputs in {self.main_nf}")
         self.inputs = inputs
 

--- a/nf_core/modules/lint/meta_yml.py
+++ b/nf_core/modules/lint/meta_yml.py
@@ -40,6 +40,8 @@ def meta_yml(module_lint_object: ComponentLint, module: NFCoreComponent) -> None
     """
 
     module.get_inputs_from_main_nf()
+    print(yaml.dump({"input": module.inputs}))
+    exit()
     module.get_outputs_from_main_nf()
     # Check if we have a patch file, get original file in that case
     meta_yaml = None


### PR DESCRIPTION
Proof of concept showing minor change to the parsing of module processes, to correctly capture structure of inputs. Currently just dumps a hypothetical YAML string to the console when running linting, eg:

```bash
nf-core modules lint affy/justrma
```
```yaml
input:
- - meta:
      type: val
  - samplesheet:
      type: path
  - celfiles_dir:
      type: path
- - meta2:
      type: val
  - description:
      type: path
```

Just a starting point. If we want to fix all module metas, needs a lot more work:

* [ ] Change how `meta.yml` is built when creating a new module from the template
* [ ] Update the linting code to expect this structure when checking existing modules
* [ ] Do all of the above for `output` as well as `input`
* [ ] Find and fix all the edge cases
* [ ] Update the website documentation pages to understand this format
* [ ] Update the developer docs
* [ ] Check where else `meta.yml` is used and update accordingly
* [ ] Somehow try to migrate all 1k modules to the new format, without losing custom data added by hand 😰
    * Note that even though the structure is different, the named keys should be the same. So hopefully can automate.

Related / would fix:
- https://github.com/nf-core/tools/issues/1555
- https://github.com/nf-core/tools/issues/1993