### PR TITLE
Add config contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,8 @@
 - Update actions/cache action to v4 ([#2666](https://github.com/nf-core/tools/pull/2666))
 - Update peter-evans/create-or-update-comment action to v4 ([#2683](https://github.com/nf-core/tools/pull/2683))
 - Update peter-evans/create-or-update-comment action to v4 ([#2695](https://github.com/nf-core/tools/pull/2695))
+- Set pdiff as nf-test differ in Docker image for Gitpod ([#2642](https://github.com/nf-core/tools/pull/2642))
+- Add config contacts ([#2800](https://github.com/nf-core/tools/pull/2800))
 
 ## [v2.11.1 - Magnesium Dragon Patch](https://github.com/nf-core/tools/releases/tag/2.11) - [2023-12-20]
 

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -11,52 +11,52 @@ params {
 
     // TODO nf-core: Specify your pipeline's command line flags
     // Input options
-    input                      = null
+    input                            = null
 
     {%- if igenomes %}
     // References
-    genome                     = null
-    igenomes_base              = 's3://ngi-igenomes/igenomes/'
-    igenomes_ignore            = false
-    fasta                      = null
+    genome                           = null
+    igenomes_base                    = 's3://ngi-igenomes/igenomes/'
+    igenomes_ignore                  = false
+    fasta                            = null
     {%- endif -%}
 
     // MultiQC options
-    multiqc_config             = null
-    multiqc_title              = null
-    multiqc_logo               = null
-    max_multiqc_email_size     = '25.MB'
-    multiqc_methods_description = null
+    multiqc_config                   = null
+    multiqc_title                    = null
+    multiqc_logo                     = null
+    max_multiqc_email_size           = '25.MB'
+    multiqc_methods_description      = null
 
     // Boilerplate options
-    outdir                     = null
-    publish_dir_mode           = 'copy'
-    email                      = null
-    email_on_fail              = null
-    plaintext_email            = false
-    monochrome_logs            = false
-    hook_url                   = null
-    help                       = false
-    version                    = false
+    outdir                           = null
+    publish_dir_mode                 = 'copy'
+    email                            = null
+    email_on_fail                    = null
+    plaintext_email                  = false
+    monochrome_logs                  = false
+    hook_url                         = null
+    help                             = false
+    version                          = false
 
     // Config options
-    config_profile_name        = null
-    config_profile_description = null
+    config_profile_name              = null
+    config_profile_description       = null
 
     {%- if nf_core_configs %}
-    custom_config_version      = 'master'
-    custom_config_base         = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
-    config_profile_contact     = null
-    config_profile_contact_github = null
-    config_profile_contact_email = null
-    config_profile_url         = null
+    custom_config_version            = 'master'
+    custom_config_base               = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
+    config_profile_contact           = null
+    config_profile_contact_github    = null
+    config_profile_contact_email     = null
+    config_profile_url               = null
     {%- endif %}
 
     // Max resource options
     // Defaults only, expecting to be overwritten
-    max_memory                 = '128.GB'
-    max_cpus                   = 16
-    max_time                   = '240.h'
+    max_memory                       = '128.GB'
+    max_cpus                         = 16
+    max_time                         = '240.h'
 
     // Schema validation default options
     validationFailUnrecognisedParams = false

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -47,6 +47,8 @@ params {
     custom_config_version      = 'master'
     custom_config_base         = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
     config_profile_contact     = null
+    config_profile_contact_github = null
+    config_profile_contact_email = null
     config_profile_url         = null
     {%- endif %}
 

--- a/nf_core/pipeline-template/nextflow_schema.json
+++ b/nf_core/pipeline-template/nextflow_schema.json
@@ -116,11 +116,11 @@
                     "hidden": true,
                     "fa_icon": "fas fa-users-cog"
                 },
-                "config_profile_contact": {
+                "config_profile_contact_github": {
                     "type": "string",
                     "description": "Institutional config contact GitHub username.",
                     "hidden": true,
-                    "fa_icon": "fas fa-github-alt"
+                    "fa_icon": "fas fa-github-alt",
                     "pattern": "^@([A-Za-z0-9_]+)$"
                 },
                 "config_profile_contact_email ": {

--- a/nf_core/pipeline-template/nextflow_schema.json
+++ b/nf_core/pipeline-template/nextflow_schema.json
@@ -112,9 +112,23 @@
                 },
                 "config_profile_contact": {
                     "type": "string",
-                    "description": "Institutional config contact information.",
+                    "description": "Institutional config contact name.",
                     "hidden": true,
                     "fa_icon": "fas fa-users-cog"
+                },
+                "config_profile_contact": {
+                    "type": "string",
+                    "description": "Institutional config contact GitHub username.",
+                    "hidden": true,
+                    "fa_icon": "fas fa-github-alt"
+                    "pattern": "^@([A-Za-z0-9_]+)$"
+                },
+                "config_profile_contact_email ": {
+                    "type": "string",
+                    "description": "Email address for the institutional config contact.",
+                    "hidden": true,
+                    "fa_icon": "fas fa-envelope",
+                    "pattern": "^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$"
                 },
                 "config_profile_url": {
                     "type": "string",


### PR DESCRIPTION
- **feat: Add config profile contact github and email**
- **style: Align all params by ='s**

Ideally, the regex will leave the `config_profile_contact` free and not break the current configs, but check to make sure the GitHub and emails are properly formatted. 