### PR TITLE
Unpin dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - chore(deps): update seqeralabs/action-tower-launch digest to aa88624 ([#2793](https://github.com/nf-core/tools/pull/2793))
 - chore(deps): update codecov/codecov-action digest to 0cfda1d ([#2794](https://github.com/nf-core/tools/pull/2794))
 - chore(deps): update gitpod/workspace-base docker digest to c15ee2f ([#2799](https://github.com/nf-core/tools/pull/2799))
+- Unpin dependencies ([#2806](https://github.com/nf-core/tools/pull/2806))
 
 ## [v2.13 - Tin Puppy](https://github.com/nf-core/tools/releases/tag/2.13) - [2024-02-20]
 

--- a/nf_core/pipeline-template/.github/workflows/awsfulltest.yml
+++ b/nf_core/pipeline-template/.github/workflows/awsfulltest.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Launch workflow via tower
-        uses: seqeralabs/action-tower-launch@aa88624706d400097880b69f1204f7f25436e93f # v2
+        uses: seqeralabs/action-tower-launch@v2
         # TODO nf-core: You can customise AWS full pipeline tests as required
         # Add full size test data (but still relatively small datasets for few samples)
         # on the `test_full.config` test runs with only one set of parameters {%- raw %}
@@ -31,7 +31,7 @@ jobs:
             }
           profiles: test_full
 
-      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
+      - uses: actions/upload-artifact@v4
         with:
           name: Tower debug log file
           path: |

--- a/nf_core/pipeline-template/.github/workflows/awstest.yml
+++ b/nf_core/pipeline-template/.github/workflows/awstest.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       # Launch workflow using Tower CLI tool action {%- raw %}
       - name: Launch workflow via tower
-        uses: seqeralabs/action-tower-launch@aa88624706d400097880b69f1204f7f25436e93f # v2
+        uses: seqeralabs/action-tower-launch@v2
         with:
           workspace_id: ${{ secrets.TOWER_WORKSPACE_ID }}
           access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
@@ -25,7 +25,7 @@ jobs:
             }
           profiles: test
 
-      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
+      - uses: actions/upload-artifact@v4
         with:
           name: Tower debug log file
           path: |


### PR DESCRIPTION
Renovate is doing some weird pinning. This cause the Tower API version 1.9.0 on several pipelines to be installed instead >2.x:
https://nfcore.slack.com/archives/CTY8L26C8/p1709126514228189

I unpinned it again. But longterm it would be good to prevent renovate from doing this in the first place. 

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
