### PR TITLE
update prettier to 3.2.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,8 @@ repos:
     rev: "v3.1.0"
     hooks:
       - id: prettier
+        additional_dependencies:
+          - prettier@3.2.5
 
   - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
     rev: "2.7.3"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Update CI to use nf-core/setup-nextflow v2
 - Changelog bot: handle also patch version before dev suffix ([#2820](https://github.com/nf-core/tools/pull/2820))
+- update prettier to 3.2.5 ([#2830](https://github.com/nf-core/tools/pull/2830))
 
 ## [v2.13.1 - Tin Puppy Patch](https://github.com/nf-core/tools/releases/tag/2.13) - [2024-02-29]
 

--- a/nf_core/pipeline-template/.pre-commit-config.yaml
+++ b/nf_core/pipeline-template/.pre-commit-config.yaml
@@ -3,6 +3,9 @@ repos:
     rev: "v3.1.0"
     hooks:
       - id: prettier
+        additional_dependencies:
+          - prettier@3.2.5
+
   - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
     rev: "2.7.3"
     hooks:


### PR DESCRIPTION
not the most straight forward way, but the only way until the prettier-mirror is updated from 3.1.0

NB: Renovate doesn't check `additional_dependencies` yet, so we need to update this by hand.