### PR TITLE
Linting params in main.nf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Linting
 
+- Only match assignments of params in `main.nf` and not references like `params.aligner == <something>` ([#2833](https://github.com/nf-core/tools/pull/2833))
+
 ### Components
 
 ### General

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -289,7 +289,7 @@ def fetch_wf_config(wf_path, cache_config=True):
         main_nf = os.path.join(wf_path, "main.nf")
         with open(main_nf) as fh:
             for line in fh:
-                match = re.match(r"^\s*(params\.[a-zA-Z0-9_]+)\s*=", line)
+                match = re.match(r"^\s*(params\.[a-zA-Z0-9_]+)\s*=(?!=)", line)
                 if match:
                     config[match.group(1)] = "null"
     except FileNotFoundError as e:


### PR DESCRIPTION
#2833. Trying to only match assignments of params in `main.nf` and **not** references like, for instance, `params.aligner == "bwa-mem"`.


I tested this solution locally on [this](https://github.com/maxulysse/nf-core_sarek/blob/1bf5222acf8f1d83c374fe92307c97c0f37255b1/main.nf#L165-L166) version of Sarek.

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
