### PR TITLE
Add tests for assignment and referencing of params in main.nf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Update GitHub Actions ([#2827](https://github.com/nf-core/tools/pull/2827))
 - Switch to setup-nf-test ([#2834](https://github.com/nf-core/tools/pull/2834))
 - Update pre-commit hook astral-sh/ruff-pre-commit to v0.3.2 ([#2836](https://github.com/nf-core/tools/pull/2836))
+- Add tests for assignment and referencing of params in main.nf ([#2841](https://github.com/nf-core/tools/pull/2841))
 
 ## [v2.13.1 - Tin Puppy Patch](https://github.com/nf-core/tools/releases/tag/2.13) - [2024-02-29]
 

--- a/nf_core/lint/nextflow_config.py
+++ b/nf_core/lint/nextflow_config.py
@@ -374,7 +374,6 @@ def nextflow_config(self):
     schema.load_schema()
     schema.get_schema_defaults()  # Get default values from schema
     schema.get_schema_types()  # Get types from schema
-    self.nf_config.keys()  # Params in nextflow.config
     for param_name in schema.schema_defaults.keys():
         param = "params." + param_name
         if param in ignore_defaults:

--- a/nf_core/pipeline-template/main.nf
+++ b/nf_core/pipeline-template/main.nf
@@ -86,8 +86,6 @@ workflow {
         params.input
     )
 
-    params.max_time == 42
-
     //
     // WORKFLOW: Run main workflow
     //

--- a/nf_core/pipeline-template/main.nf
+++ b/nf_core/pipeline-template/main.nf
@@ -86,6 +86,8 @@ workflow {
         params.input
     )
 
+    params.max_time == 42
+
     //
     // WORKFLOW: Run main workflow
     //

--- a/tests/lint/nextflow_config.py
+++ b/tests/lint/nextflow_config.py
@@ -83,7 +83,6 @@ def test_default_values_fail(self):
     with open(nf_schema_file) as f:
         content = f.read()
         fail_content = re.sub(r'"default": "128.GB"', '"default": "18.GB"', content)
-        print(fail_content)
     with open(nf_schema_file, "w") as f:
         f.write(fail_content)
     lint_obj = nf_core.lint.PipelineLint(new_pipeline)
@@ -103,14 +102,10 @@ def test_default_values_fail(self):
 def test_catch_params_assignment_in_main_nf(self):
     """Test linting fails if main.nf contains an assignment to a parameter from nextflow_schema.json."""
     new_pipeline = self._make_pipeline_copy()
-    # Change reference of params.max_time to assignment
+    # Add parameter assignment in main.nf
     main_nf_file = Path(new_pipeline) / "main.nf"
-    with open(main_nf_file) as f:
-        content = f.read()
-        fail_content = re.sub(r"params.max_time ==", "params.max_time =", content)
-        print(fail_content)
-    with open(main_nf_file, "w") as f:
-        f.write(fail_content)
+    with open(main_nf_file, "a") as f:
+        f.write("params.max_time = 42")
     lint_obj = nf_core.lint.PipelineLint(new_pipeline)
     lint_obj._load_pipeline_config()
     result = lint_obj.nextflow_config()
@@ -124,6 +119,10 @@ def test_catch_params_assignment_in_main_nf(self):
 def test_allow_params_reference_in_main_nf(self):
     """Test linting allows for references like `params.aligner == 'bwa'` in main.nf. The test will detect if the bug mentioned in GitHub-issue #2833 reemerges."""
     new_pipeline = self._make_pipeline_copy()
+    # Add parameter reference in main.nf
+    main_nf_file = Path(new_pipeline) / "main.nf"
+    with open(main_nf_file, "a") as f:
+        f.write("params.max_time == 42")
     lint_obj = nf_core.lint.PipelineLint(new_pipeline)
     lint_obj._load_pipeline_config()
     result = lint_obj.nextflow_config()

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -221,6 +221,8 @@ class TestLint(unittest.TestCase):
         test_multiqc_incorrect_export_plots,
     )
     from .lint.nextflow_config import (  # type: ignore[misc]
+        test_allow_params_reference_in_main_nf,
+        test_catch_params_assignment_in_main_nf,
         test_default_values_fail,
         test_default_values_float,
         test_default_values_float_fail,


### PR DESCRIPTION
Trying to add some tests for the bug reported in #2833.

I locally tested that the test `test_allow_params_reference_in_main_nf` fails (as desired) with the former [regexp](https://github.com/nf-core/tools/blob/9eac5e9b33a4b86a5228e950a8c8fd16765f4a85/nf_core/utils.py#L291) which caused the bug  #2833.

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
