### PR TITLE
Template: Link to troubleshooting docs when pipeline fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Add tests for assignment and referencing of params in main.nf ([#2841](https://github.com/nf-core/tools/pull/2841))
 - Optimize layers in dockerfile ([#2842](https://github.com/nf-core/tools/pull/2842))
 - Update gitpod/workspace-base Docker digest to 1e133e5 ([#2843](https://github.com/nf-core/tools/pull/2843))
+- Link to troubleshooting docs when pipeline fails ([#2845](https://github.com/nf-core/tools/pull/2845))
 
 ## [v2.13.1 - Tin Puppy Patch](https://github.com/nf-core/tools/releases/tag/2.13) - [2024-02-29]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Remove fasta default from nextflow.config ([#2828](https://github.com/nf-core/tools/pull/2828))
 - Update templates to use nf-core/setup-nextflow v2
+- Link to troubleshooting docs when pipeline fails ([#2845](https://github.com/nf-core/tools/pull/2845))
 
 ### Linting
 
@@ -24,7 +25,6 @@
 - Add tests for assignment and referencing of params in main.nf ([#2841](https://github.com/nf-core/tools/pull/2841))
 - Optimize layers in dockerfile ([#2842](https://github.com/nf-core/tools/pull/2842))
 - Update gitpod/workspace-base Docker digest to 1e133e5 ([#2843](https://github.com/nf-core/tools/pull/2843))
-- Link to troubleshooting docs when pipeline fails ([#2845](https://github.com/nf-core/tools/pull/2845))
 
 ## [v2.13.1 - Tin Puppy Patch](https://github.com/nf-core/tools/releases/tag/2.13) - [2024-02-29]
 

--- a/nf_core/pipeline-template/subworkflows/local/utils_nfcore_pipeline_pipeline/main.nf
+++ b/nf_core/pipeline-template/subworkflows/local/utils_nfcore_pipeline_pipeline/main.nf
@@ -143,6 +143,10 @@ workflow PIPELINE_COMPLETION {
             imNotification(summary_params, hook_url)
         }
     }
+
+    workflow.onError {
+        log.error "Pipeline failed. Please refer to troubleshooting docs: https://nf-co.re/docs/usage/troubleshooting"
+    }
 }
 
 /*


### PR DESCRIPTION
The following snippet was removed after v2.12.1 when we refactored the pipeline template to remove the `lib/` directory in favour of more granular `utils_*` subworkflows
https://github.com/nf-core/tools/blob/776089ac0e42f1fce9084182eba3b4ca0ed405e9/nf_core/pipeline-template/workflows/pipeline.nf#L130-L135

This PR adds it back in with the aim of catching any error and redirecting users to a single page where we can maintain a list of common errors encountered by users.