### PR TITLE
Add cleanup step to download pipeline workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Update templates to use nf-core/setup-nextflow v2
 - Link to troubleshooting docs when pipeline fails ([#2845](https://github.com/nf-core/tools/pull/2845))
 - Add fallback to `download_pipeline.yml` in case the pipeline does not support stub runs ([#2846](https://github.com/nf-core/tools/pull/2846))
+- Add a cleanup action to `download_pipeline.yml` to fix failures caused by inadequate storage space on the runner ([#2849](https://github.com/nf-core/tools/pull/2849))
 
 ### Linting
 

--- a/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
+++ b/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install Nextflow
         uses: nf-core/setup-nextflow@v1
 
+      - name: Disk space cleanup
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5
         with:
           python-version: "3.11"


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

While testing raredisease pipeline, download_pipeline workflow failed pipeline due to lack of storage space, and adding a cleanup step to the workflow fixed it. So I propose adding this step to the template. 

https://github.com/nf-core/raredisease/actions/runs/8159070586/job/22302477254

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
