### PR TITLE
Make module/subworkflow names case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Fix issue with config resolution that was causing nested configs to behave unexpectedly ([#2862](https://github.com/nf-core/tools/pull/2862))
 - Fix schema docs console output truncating ([#2880](https://github.com/nf-core/tools/pull/2880))
 - fix: ensure path object converted to string before stripping quotes ([#2878](https://github.com/nf-core/tools/pull/2878))
+- Make cli-provided module/subworkflow names case insensitive ([#2869](https://github.com/nf-core/tools/pull/2869))
 
 ## [v2.13.1 - Tin Puppy Patch](https://github.com/nf-core/tools/releases/tag/2.13) - [2024-02-29]
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -1608,7 +1608,7 @@ def subworkflows_lint(ctx, subworkflow, dir, registry, key, all, fail_warned, lo
 # nf-core subworkflows info
 @subworkflows.command("info")
 @click.pass_context
-@click.argument("tool", type=str, callback=normalize_case, required=False, metavar="subworkflow name")
+@click.argument("subworkflow", type=str, callback=normalize_case, required=False, metavar="subworkflow name")
 @click.option(
     "-d",
     "--dir",
@@ -1616,7 +1616,7 @@ def subworkflows_lint(ctx, subworkflow, dir, registry, key, all, fail_warned, lo
     default=".",
     help=r"Pipeline directory. [dim]\[default: Current working directory][/]",
 )
-def subworkflows_info(ctx, tool, dir):
+def subworkflows_info(ctx, subworkflow, dir):
     """
     Show developer usage information about a given subworkflow.
 
@@ -1633,7 +1633,7 @@ def subworkflows_info(ctx, tool, dir):
     try:
         subworkflow_info = SubworkflowInfo(
             dir,
-            tool,
+            subworkflow,
             ctx.obj["modules_repo_url"],
             ctx.obj["modules_repo_branch"],
             ctx.obj["modules_repo_no_pull"],

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -103,6 +103,14 @@ def selective_traceback_hook(exctype, value, traceback):
 sys.excepthook = selective_traceback_hook
 
 
+# Define callback function to normalize the case of click arguments,
+# which is used to make the module/subworkflow names, provided by the
+# user on the cli, case insensitive.
+def normalize_case(ctx, param, component_name):
+    if component_name is not None:
+        return component_name.casefold()
+
+
 def run_nf_core():
     # print nf-core header if environment variable is not set
     if os.environ.get("_NF_CORE_COMPLETE") is None:
@@ -786,7 +794,7 @@ def modules_list_local(ctx, keywords, json, dir):  # pylint: disable=redefined-b
 # nf-core modules install
 @modules.command("install")
 @click.pass_context
-@click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
+@click.argument("tool", type=str, callback=normalize_case, required=False, metavar="<tool> or <tool/subtool>")
 @click.option(
     "-d",
     "--dir",
@@ -838,7 +846,7 @@ def modules_install(ctx, tool, dir, prompt, force, sha):
 # nf-core modules update
 @modules.command("update")
 @click.pass_context
-@click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
+@click.argument("tool", type=str, callback=normalize_case, required=False, metavar="<tool> or <tool/subtool>")
 @click.option(
     "-d",
     "--dir",
@@ -930,7 +938,7 @@ def modules_update(
 # nf-core modules patch
 @modules.command()
 @click.pass_context
-@click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
+@click.argument("tool", type=str, callback=normalize_case, required=False, metavar="<tool> or <tool/subtool>")
 @click.option(
     "-d",
     "--dir",
@@ -967,7 +975,7 @@ def patch(ctx, tool, dir, remove):
 # nf-core modules remove
 @modules.command("remove")
 @click.pass_context
-@click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
+@click.argument("tool", type=str, callback=normalize_case, required=False, metavar="<tool> or <tool/subtool>")
 @click.option(
     "-d",
     "--dir",
@@ -1121,7 +1129,7 @@ def create_module(
 # nf-core modules test
 @modules.command("test")
 @click.pass_context
-@click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
+@click.argument("tool", type=str, callback=normalize_case, required=False, metavar="<tool> or <tool/subtool>")
 @click.option(
     "-d",
     "--dir",
@@ -1180,7 +1188,7 @@ def test_module(ctx, tool, dir, no_prompts, update, once, profile):
 # nf-core modules lint
 @modules.command("lint")
 @click.pass_context
-@click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
+@click.argument("tool", type=str, callback=normalize_case, required=False, metavar="<tool> or <tool/subtool>")
 @click.option(
     "-d",
     "--dir",
@@ -1267,7 +1275,7 @@ def modules_lint(ctx, tool, dir, registry, key, all, fail_warned, local, passed,
 # nf-core modules info
 @modules.command("info")
 @click.pass_context
-@click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
+@click.argument("tool", type=str, callback=normalize_case, required=False, metavar="<tool> or <tool/subtool>")
 @click.option(
     "-d",
     "--dir",
@@ -1306,7 +1314,7 @@ def modules_info(ctx, tool, dir):
 # nf-core modules bump-versions
 @modules.command()
 @click.pass_context
-@click.argument("tool", type=str, required=False, metavar="<tool> or <tool/subtool>")
+@click.argument("tool", type=str, callback=normalize_case, required=False, metavar="<tool> or <tool/subtool>")
 @click.option(
     "-d",
     "--dir",
@@ -1392,7 +1400,7 @@ def create_subworkflow(ctx, subworkflow, dir, author, force, migrate_pytest):
 # nf-core subworkflows test
 @subworkflows.command("test")
 @click.pass_context
-@click.argument("subworkflow", type=str, required=False, metavar="subworkflow name")
+@click.argument("subworkflow", type=str, callback=normalize_case, required=False, metavar="subworkflow name")
 @click.option(
     "-d",
     "--dir",
@@ -1519,7 +1527,7 @@ def subworkflows_list_local(ctx, keywords, json, dir):  # pylint: disable=redefi
 # nf-core subworkflows lint
 @subworkflows.command("lint")
 @click.pass_context
-@click.argument("subworkflow", type=str, required=False, metavar="subworkflow name")
+@click.argument("subworkflow", type=str, callback=normalize_case, required=False, metavar="subworkflow name")
 @click.option(
     "-d",
     "--dir",
@@ -1600,7 +1608,7 @@ def subworkflows_lint(ctx, subworkflow, dir, registry, key, all, fail_warned, lo
 # nf-core subworkflows info
 @subworkflows.command("info")
 @click.pass_context
-@click.argument("tool", type=str, required=False, metavar="subworkflow name")
+@click.argument("tool", type=str, callback=normalize_case, required=False, metavar="subworkflow name")
 @click.option(
     "-d",
     "--dir",
@@ -1639,7 +1647,7 @@ def subworkflows_info(ctx, tool, dir):
 # nf-core subworkflows install
 @subworkflows.command("install")
 @click.pass_context
-@click.argument("subworkflow", type=str, required=False, metavar="subworkflow name")
+@click.argument("subworkflow", type=str, callback=normalize_case, required=False, metavar="subworkflow name")
 @click.option(
     "-d",
     "--dir",
@@ -1697,7 +1705,7 @@ def subworkflows_install(ctx, subworkflow, dir, prompt, force, sha):
 # nf-core subworkflows remove
 @subworkflows.command("remove")
 @click.pass_context
-@click.argument("subworkflow", type=str, required=False, metavar="subworkflow name")
+@click.argument("subworkflow", type=str, callback=normalize_case, required=False, metavar="subworkflow name")
 @click.option(
     "-d",
     "--dir",
@@ -1727,7 +1735,7 @@ def subworkflows_remove(ctx, dir, subworkflow):
 # nf-core subworkflows update
 @subworkflows.command("update")
 @click.pass_context
-@click.argument("subworkflow", type=str, required=False, metavar="subworkflow name")
+@click.argument("subworkflow", type=str, callback=normalize_case, required=False, metavar="subworkflow name")
 @click.option(
     "-d",
     "--dir",


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated

Quick attempt at a fix for https://github.com/nf-core/tools/issues/2759.

EDIT: New approach is summarized in the main commit message body. Original PR history preserved below:

---

I went for the naive approach and simply converted all occurrences of tool/subworkflow names to lowercase, whenever they were being used as an input to a function.

A cleaner solution might be to use a decorator for this, but I couldn't find an option for click ([token normalization](https://click.palletsprojects.com/en/8.1.x/advanced/#token-normalization) only appears to work on choices or options, not arguments). 

Alternatively, a check could be implemented inside the various functions of the ComponentCommand class, but I must admit I felt a bit lost trying to understand the overall structure of how these are currently implementend. I couldn't identify a uniform approach to verify input options used by the various components:

- The `ComponentInstall` class contains a `collect_and_verify_name()` function where the input can be standardized.
- `ComponentUpdate` uses a different approach than `ComponentPatch`, which itself has a `remove` function that differs from `ModuleRemove`.
- Need to take into account single module install vs automatic collection of all modules inside a workflow.
- Then there's another install option used by `synced_repo`, which does not reuse the `ComponentInstall` class?

If my current fix is "good enough", I will update the changelog and look at tests, but if another approach is preferred, I'll need some help from someone who's more familiar with the code base.