### PR TITLE
Case where you have created a module/workflow on your own

### DIFF
--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -1186,13 +1186,20 @@ class ModulesJson:
         dep_mods, dep_subwfs = get_components_to_install(sw_path)
 
         for dep_mod in dep_mods:
+            if dep_mod not in self.modules_json["repos"][repo]["modules"][org]:
+                continue
+
             installed_by = self.modules_json["repos"][repo]["modules"][org][dep_mod]["installed_by"]
+
             if installed_by == ["modules"]:
                 self.modules_json["repos"][repo]["modules"][org][dep_mod]["installed_by"] = []
             if subworkflow not in installed_by:
                 self.modules_json["repos"][repo]["modules"][org][dep_mod]["installed_by"].append(subworkflow)
 
         for dep_subwf in dep_subwfs:
+            if dep_subwf not in self.modules_json["repos"][repo]["subworkflows"][org]:
+                continue
+            
             installed_by = self.modules_json["repos"][repo]["subworkflows"][org][dep_subwf]["installed_by"]
             if installed_by == ["subworkflows"]:
                 self.modules_json["repos"][repo]["subworkflows"][org][dep_subwf]["installed_by"] = []


### PR DESCRIPTION
`nf-core modules install tool` doesn't work when you have created a module/workflow on your own because it can't find it

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
