### PR TITLE
Allow `nf-core download -r` to download commits

### DIFF
--- a/nf_core/download.py
+++ b/nf_core/download.py
@@ -161,8 +161,8 @@ class DownloadWorkflow:
         # Get workflow details
         try:
             self.prompt_pipeline_name()
-            self.pipeline, self.wf_revisions, self.wf_branches, self.wf_commits = nf_core.utils.get_repo_releases_branches_commits(
-                self.pipeline, self.wfs
+            self.pipeline, self.wf_revisions, self.wf_branches, self.wf_commits = (
+                nf_core.utils.get_repo_releases_branches_commits(self.pipeline, self.wfs)
             )
             self.prompt_revision()
             self.get_revision_hash()
@@ -358,7 +358,6 @@ class DownloadWorkflow:
         """Find specified revision / branch / commit hash"""
 
         for revision in self.revision:  # revision is a list of strings, but may be of length 1
-
             # Branch
             if revision in self.wf_branches.keys():
                 self.wf_sha = {**self.wf_sha, revision: self.wf_branches[revision]}
@@ -375,7 +374,7 @@ class DownloadWorkflow:
                         self.wf_sha = {**self.wf_sha, revision: r["tag_sha"]}
                         break
 
-            # Can't find the revisions or branch - throw an error
+                # Can't find the revisions or branch - throw an error
                 else:
                     log.info(
                         "Available {} revisions: '{}'".format(

--- a/nf_core/launch.py
+++ b/nf_core/launch.py
@@ -207,7 +207,7 @@ class Launch:
 
             if not self.pipeline_revision:
                 try:
-                    self.pipeline, wf_releases, wf_branches = nf_core.utils.get_repo_releases_branches(
+                    self.pipeline, wf_releases, wf_branches, _ = nf_core.utils.get_repo_releases_branches_commits(
                         self.pipeline, self.wfs
                     )
                 except AssertionError as e:

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -940,7 +940,7 @@ class SingularityCacheFilePathValidator(questionary.Validator):
             return True
 
 
-def get_repo_releases_branches(pipeline, wfs):
+def get_repo_releases_branches_commits(pipeline, wfs):
     """Fetches details of a nf-core workflow to download.
 
     Args:
@@ -956,6 +956,7 @@ def get_repo_releases_branches(pipeline, wfs):
 
     wf_releases = []
     wf_branches = {}
+    wf_commits = []
 
     # Repo is a nf-core pipeline
     for wf in wfs.remote_workflows:
@@ -1009,8 +1010,12 @@ def get_repo_releases_branches(pipeline, wfs):
         ):
             wf_branches[branch["name"]] = branch["commit"]["sha"]
 
+        # Get commit information from github api
+        commit_response = gh_api.safe_get(f"https://api.github.com/repos/{pipeline}/commits?sha={branch['name']}")
+        for commit in commit_response.json():
+            wf_commits.append(commit["sha"])
     # Return pipeline again in case we added the nf-core/ prefix
-    return pipeline, wf_releases, wf_branches
+    return pipeline, wf_releases, wf_branches, wf_commits
 
 
 CONFIG_PATHS = [".nf-core.yml", ".nf-core.yaml"]

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -617,7 +617,7 @@ class DownloadTest(unittest.TestCase):
     def test_download_workflow_for_platform(self, tmp_dir, _):
         download_obj = DownloadWorkflow(
             pipeline="nf-core/rnaseq",
-            revision=("3.7", "3.9"),
+            revision=("3.7", "3.9", "1817d14"),
             compress_type="none",
             platform=True,
             container_system="singularity",
@@ -625,7 +625,7 @@ class DownloadTest(unittest.TestCase):
 
         download_obj.include_configs = False  # suppress prompt, because stderr.is_interactive doesn't.
 
-        assert isinstance(download_obj.revision, list) and len(download_obj.revision) == 2
+        assert isinstance(download_obj.revision, list) and len(download_obj.revision) == 3
         assert isinstance(download_obj.wf_sha, dict) and len(download_obj.wf_sha) == 0
         assert isinstance(download_obj.wf_download_url, dict) and len(download_obj.wf_download_url) == 0
 
@@ -635,13 +635,12 @@ class DownloadTest(unittest.TestCase):
             download_obj.pipeline,
             download_obj.wf_revisions,
             download_obj.wf_branches,
-            _
+            download_obj.wf_commits
         ) = nf_core.utils.get_repo_releases_branches_commits(download_obj.pipeline, wfs)
 
         download_obj.get_revision_hash()
-
-        # download_obj.wf_download_url is not set for Seqera Platform downloads, but the sha values are
-        assert isinstance(download_obj.wf_sha, dict) and len(download_obj.wf_sha) == 2
+        # download_obj.wf_download_url is not set for tower downloads, but the sha values are
+        assert isinstance(download_obj.wf_sha, dict) and len(download_obj.wf_sha) == 3
         assert isinstance(download_obj.wf_download_url, dict) and len(download_obj.wf_download_url) == 0
 
         # The outdir for multiple revisions is the pipeline name and date: e.g. nf-core-rnaseq_2023-04-27_18-54

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -32,7 +32,8 @@ class DownloadTest(unittest.TestCase):
             download_obj.pipeline,
             download_obj.wf_revisions,
             download_obj.wf_branches,
-        ) = nf_core.utils.get_repo_releases_branches(pipeline, wfs)
+            _
+        ) = nf_core.utils.get_repo_releases_branches_commits(pipeline, wfs)
         download_obj.get_revision_hash()
         assert download_obj.wf_sha[download_obj.revision[0]] == "b3e5e3b95aaf01d98391a62a10a3990c0a4de395"
         assert download_obj.outdir == "nf-core-methylseq_1.6"
@@ -51,10 +52,55 @@ class DownloadTest(unittest.TestCase):
             download_obj.pipeline,
             download_obj.wf_revisions,
             download_obj.wf_branches,
-        ) = nf_core.utils.get_repo_releases_branches(pipeline, wfs)
+            _
+        ) = nf_core.utils.get_repo_releases_branches_commits(pipeline, wfs)
         download_obj.get_revision_hash()
         assert download_obj.wf_sha[download_obj.revision[0]] == "819cbac792b76cf66c840b567ed0ee9a2f620db7"
         assert download_obj.outdir == "nf-core-exoseq_dev"
+        assert (
+            download_obj.wf_download_url[download_obj.revision[0]]
+            == "https://github.com/nf-core/exoseq/archive/819cbac792b76cf66c840b567ed0ee9a2f620db7.zip"
+        )
+
+    def test_get_release_hash_long_commit(self):
+        wfs = nf_core.list.Workflows()
+        wfs.get_remote_workflows()
+        # Exoseq pipeline is archived, so `dev` branch should be stable
+        pipeline = "exoseq"
+
+        download_obj = DownloadWorkflow(pipeline="exoseq", revision="819cbac792b76cf66c840b567ed0ee9a2f620db7")
+        (
+            download_obj.pipeline,
+            download_obj.wf_revisions,
+            download_obj.wf_branches,
+            download_obj.wf_commits,
+        ) = nf_core.utils.get_repo_releases_branches_commits(pipeline, wfs)
+        download_obj.get_revision_hash()
+        print(download_obj)
+        assert download_obj.wf_sha[download_obj.revision[0]] == "819cbac792b76cf66c840b567ed0ee9a2f620db7"
+        assert download_obj.outdir == "nf-core-exoseq_819cbac792b76cf66c840b567ed0ee9a2f620db7"
+        assert (
+            download_obj.wf_download_url[download_obj.revision[0]]
+            == "https://github.com/nf-core/exoseq/archive/819cbac792b76cf66c840b567ed0ee9a2f620db7.zip"
+        )
+
+    def test_get_release_hash_short_commit(self):
+        wfs = nf_core.list.Workflows()
+        wfs.get_remote_workflows()
+        # Exoseq pipeline is archived, so `dev` branch should be stable
+        pipeline = "exoseq"
+
+        download_obj = DownloadWorkflow(pipeline="exoseq", revision="819cbac")
+        (
+            download_obj.pipeline,
+            download_obj.wf_revisions,
+            download_obj.wf_branches,
+            download_obj.wf_commits,
+        ) = nf_core.utils.get_repo_releases_branches_commits(pipeline, wfs)
+        download_obj.get_revision_hash()
+        print(download_obj)
+        assert download_obj.wf_sha[download_obj.revision[0]] == "819cbac792b76cf66c840b567ed0ee9a2f620db7"
+        assert download_obj.outdir == "nf-core-exoseq_819cbac"
         assert (
             download_obj.wf_download_url[download_obj.revision[0]]
             == "https://github.com/nf-core/exoseq/archive/819cbac792b76cf66c840b567ed0ee9a2f620db7.zip"
@@ -69,7 +115,8 @@ class DownloadTest(unittest.TestCase):
             download_obj.pipeline,
             download_obj.wf_revisions,
             download_obj.wf_branches,
-        ) = nf_core.utils.get_repo_releases_branches(pipeline, wfs)
+            _
+        ) = nf_core.utils.get_repo_releases_branches_commits(pipeline, wfs)
         with pytest.raises(AssertionError):
             download_obj.get_revision_hash()
 
@@ -588,7 +635,8 @@ class DownloadTest(unittest.TestCase):
             download_obj.pipeline,
             download_obj.wf_revisions,
             download_obj.wf_branches,
-        ) = nf_core.utils.get_repo_releases_branches(download_obj.pipeline, wfs)
+            _
+        ) = nf_core.utils.get_repo_releases_branches_commits(download_obj.pipeline, wfs)
 
         download_obj.get_revision_hash()
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -28,12 +28,9 @@ class DownloadTest(unittest.TestCase):
         wfs.get_remote_workflows()
         pipeline = "methylseq"
         download_obj = DownloadWorkflow(pipeline=pipeline, revision="1.6")
-        (
-            download_obj.pipeline,
-            download_obj.wf_revisions,
-            download_obj.wf_branches,
-            _
-        ) = nf_core.utils.get_repo_releases_branches_commits(pipeline, wfs)
+        (download_obj.pipeline, download_obj.wf_revisions, download_obj.wf_branches, _) = (
+            nf_core.utils.get_repo_releases_branches_commits(pipeline, wfs)
+        )
         download_obj.get_revision_hash()
         assert download_obj.wf_sha[download_obj.revision[0]] == "b3e5e3b95aaf01d98391a62a10a3990c0a4de395"
         assert download_obj.outdir == "nf-core-methylseq_1.6"
@@ -48,12 +45,9 @@ class DownloadTest(unittest.TestCase):
         # Exoseq pipeline is archived, so `dev` branch should be stable
         pipeline = "exoseq"
         download_obj = DownloadWorkflow(pipeline=pipeline, revision="dev")
-        (
-            download_obj.pipeline,
-            download_obj.wf_revisions,
-            download_obj.wf_branches,
-            _
-        ) = nf_core.utils.get_repo_releases_branches_commits(pipeline, wfs)
+        (download_obj.pipeline, download_obj.wf_revisions, download_obj.wf_branches, _) = (
+            nf_core.utils.get_repo_releases_branches_commits(pipeline, wfs)
+        )
         download_obj.get_revision_hash()
         assert download_obj.wf_sha[download_obj.revision[0]] == "819cbac792b76cf66c840b567ed0ee9a2f620db7"
         assert download_obj.outdir == "nf-core-exoseq_dev"
@@ -111,12 +105,9 @@ class DownloadTest(unittest.TestCase):
         wfs.get_remote_workflows()
         pipeline = "methylseq"
         download_obj = DownloadWorkflow(pipeline=pipeline, revision="thisisfake")
-        (
-            download_obj.pipeline,
-            download_obj.wf_revisions,
-            download_obj.wf_branches,
-            _
-        ) = nf_core.utils.get_repo_releases_branches_commits(pipeline, wfs)
+        (download_obj.pipeline, download_obj.wf_revisions, download_obj.wf_branches, _) = (
+            nf_core.utils.get_repo_releases_branches_commits(pipeline, wfs)
+        )
         with pytest.raises(AssertionError):
             download_obj.get_revision_hash()
 
@@ -631,12 +622,9 @@ class DownloadTest(unittest.TestCase):
 
         wfs = nf_core.list.Workflows()
         wfs.get_remote_workflows()
-        (
-            download_obj.pipeline,
-            download_obj.wf_revisions,
-            download_obj.wf_branches,
-            download_obj.wf_commits
-        ) = nf_core.utils.get_repo_releases_branches_commits(download_obj.pipeline, wfs)
+        (download_obj.pipeline, download_obj.wf_revisions, download_obj.wf_branches, download_obj.wf_commits) = (
+            nf_core.utils.get_repo_releases_branches_commits(download_obj.pipeline, wfs)
+        )
 
         download_obj.get_revision_hash()
         # download_obj.wf_download_url is not set for tower downloads, but the sha values are

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -163,7 +163,9 @@ class TestUtils(unittest.TestCase):
     def test_get_repo_releases_branches_commits_nf_core(self):
         wfs = nf_core.list.Workflows()
         wfs.get_remote_workflows()
-        pipeline, wf_releases, wf_branches, wf_commits = nf_core.utils.get_repo_releases_branches_commits("methylseq", wfs)
+        pipeline, wf_releases, wf_branches, wf_commits = nf_core.utils.get_repo_releases_branches_commits(
+            "methylseq", wfs
+        )
         for r in wf_releases:
             if r.get("tag_name") == "1.6":
                 break
@@ -175,7 +177,9 @@ class TestUtils(unittest.TestCase):
     def test_get_repo_releases_branches_commits_not_nf_core(self):
         wfs = nf_core.list.Workflows()
         wfs.get_remote_workflows()
-        pipeline, wf_releases, wf_branches, wf_commits  = nf_core.utils.get_repo_releases_branches_commits("MultiQC/MultiQC", wfs)
+        pipeline, wf_releases, wf_branches, wf_commits = nf_core.utils.get_repo_releases_branches_commits(
+            "MultiQC/MultiQC", wfs
+        )
         for r in wf_releases:
             if r.get("tag_name") == "v1.10":
                 break

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -160,39 +160,41 @@ class TestUtils(unittest.TestCase):
         with pytest.raises(ValueError):
             nf_core.utils.pip_package("not_a_package=1.0")
 
-    def test_get_repo_releases_branches_nf_core(self):
+    def test_get_repo_releases_branches_commits_nf_core(self):
         wfs = nf_core.list.Workflows()
         wfs.get_remote_workflows()
-        pipeline, wf_releases, wf_branches = nf_core.utils.get_repo_releases_branches("methylseq", wfs)
+        pipeline, wf_releases, wf_branches, wf_commits = nf_core.utils.get_repo_releases_branches_commits("methylseq", wfs)
         for r in wf_releases:
             if r.get("tag_name") == "1.6":
                 break
         else:
             raise AssertionError("Release 1.6 not found")
         assert "dev" in wf_branches.keys()
+        assert "54f823e102ef3d04077cc091a5ae435519f9923a" in wf_commits
 
-    def test_get_repo_releases_branches_not_nf_core(self):
+    def test_get_repo_releases_branches_commits_not_nf_core(self):
         wfs = nf_core.list.Workflows()
         wfs.get_remote_workflows()
-        pipeline, wf_releases, wf_branches = nf_core.utils.get_repo_releases_branches("MultiQC/MultiQC", wfs)
+        pipeline, wf_releases, wf_branches, wf_commits  = nf_core.utils.get_repo_releases_branches_commits("MultiQC/MultiQC", wfs)
         for r in wf_releases:
             if r.get("tag_name") == "v1.10":
                 break
         else:
             raise AssertionError("MultiQC release v1.10 not found")
         assert "main" in wf_branches.keys()
+        assert "6764be5a6874f6601765e70316b404c01f6407fc" in wf_commits
 
-    def test_get_repo_releases_branches_not_exists(self):
+    def test_get_repo_releases_branches_commits_not_exists(self):
         wfs = nf_core.list.Workflows()
         wfs.get_remote_workflows()
         with pytest.raises(AssertionError):
-            nf_core.utils.get_repo_releases_branches("made_up_pipeline", wfs)
+            nf_core.utils.get_repo_releases_branches_commits("made_up_pipeline", wfs)
 
-    def test_get_repo_releases_branches_not_exists_slash(self):
+    def test_get_repo_releases_branches_commits_not_exists_slash(self):
         wfs = nf_core.list.Workflows()
         wfs.get_remote_workflows()
         with pytest.raises(AssertionError):
-            nf_core.utils.get_repo_releases_branches("made-up/pipeline", wfs)
+            nf_core.utils.get_repo_releases_branches_commits("made-up/pipeline", wfs)
 
 
 def test_validate_file_md5():


### PR DESCRIPTION
Mimic the behaviour of `nextflow run -r` and allow selected commit(s) to be downloaded.

https://nfcore.slack.com/archives/CE5LG7WMB/p1712143905189639

Not sure about the effect it will have on Tower downloads.  

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
