### PR TITLE
Activate pipeline institutional configs in template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Update python to 3.12 ([#2805](https://github.com/nf-core/tools/pull/2805))
 - Remove `pyproject.toml` from template root
 - Shorten lines in pipeline template ([#2908](https://github.com/nf-core/tools/pull/2908))
-- Permanently activated pipeline-specific institutional configs support for all pipelines without need  for manual intervention ([#2936](https://github.com/nf-core/tools/pull/2936))
+- Permanently activated pipeline-specific institutional configs support for all pipelines without need for manual intervention ([#2936](https://github.com/nf-core/tools/pull/2936))
 
 ### Linting
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Update python to 3.12 ([#2805](https://github.com/nf-core/tools/pull/2805))
 - Remove `pyproject.toml` from template root
 - Shorten lines in pipeline template ([#2908](https://github.com/nf-core/tools/pull/2908))
+- Permanently activated pipeline-specific institutional configs support for all pipelines ([#2936](https://github.com/nf-core/tools/pull/2936))
 
 ### Linting
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Update python to 3.12 ([#2805](https://github.com/nf-core/tools/pull/2805))
 - Remove `pyproject.toml` from template root
 - Shorten lines in pipeline template ([#2908](https://github.com/nf-core/tools/pull/2908))
-- Permanently activated pipeline-specific institutional configs support for all pipelines ([#2936](https://github.com/nf-core/tools/pull/2936))
+- Permanently activated pipeline-specific institutional configs support for all pipelines without need  for manual intervention ([#2936](https://github.com/nf-core/tools/pull/2936))
 
 ### Linting
 

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -76,12 +76,11 @@ try {
 }
 
 // Load {{ name }} custom profiles from different institutions.
-// Warning: Uncomment only if a pipeline-specific institutional config already exists on nf-core/configs!
-// try {
-//   includeConfig "${params.custom_config_base}/pipeline/{{ short_name }}.config"
-// } catch (Exception e) {
-//   System.err.println("WARNING: Could not load nf-core/config/{{ short_name }} profiles: ${params.custom_config_base}/pipeline/{{ short_name }}.config")
-// }
+try {
+    includeConfig "${params.custom_config_base}/pipeline/{{ short_name }}.config"
+} catch (Exception e) {
+    System.err.println("WARNING: Could not load nf-core/config/{{ short_name }} profiles: ${params.custom_config_base}/pipeline/{{ short_name }}.config")
+}
 {% endif -%}
 
 profiles {


### PR DESCRIPTION
As this should be supported now though here: https://github.com/nf-core/configs/pull/674

Meaning devs don't need to touch the section of the config, and users can add configs when they need