### PR TITLE
Added `-profile wave` to the template.

### DIFF
--- a/nf_core/pipeline-template/docs/usage.md
+++ b/nf_core/pipeline-template/docs/usage.md
@@ -164,7 +164,7 @@ If `-profile` is not specified, the pipeline will run locally and expect all sof
 - `apptainer`
   - A generic configuration profile to be used with [Apptainer](https://apptainer.org/)
 - `wave`
-  - A generic configuration profile to enable [Wave](https://seqera.io/wave/) containers. Use together with one of the above.
+  - A generic configuration profile to enable [Wave](https://seqera.io/wave/) containers. Use together with one of the above (requires Nextflow ` 24.03.0-edge` or later).
 - `conda`
   - A generic configuration profile to be used with [Conda](https://conda.io/docs/). Please only use Conda as a last resort i.e. when it's not possible to run the pipeline with Docker, Singularity, Podman, Shifter, Charliecloud, or Apptainer.
 

--- a/nf_core/pipeline-template/docs/usage.md
+++ b/nf_core/pipeline-template/docs/usage.md
@@ -163,6 +163,8 @@ If `-profile` is not specified, the pipeline will run locally and expect all sof
   - A generic configuration profile to be used with [Charliecloud](https://hpc.github.io/charliecloud/)
 - `apptainer`
   - A generic configuration profile to be used with [Apptainer](https://apptainer.org/)
+- `wave`
+  - A generic configuration profile to enable [Wave](https://seqera.io/wave/) containers. Use together with one of the above.
 - `conda`
   - A generic configuration profile to be used with [Conda](https://conda.io/docs/). Please only use Conda as a last resort i.e. when it's not possible to run the pipeline with Docker, Singularity, Podman, Shifter, Charliecloud, or Apptainer.
 

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -86,90 +86,90 @@ try {
 
 profiles {
     debug {
-        dumpHashes             = true
-        process.beforeScript   = 'echo $HOSTNAME'
-        cleanup                = false
+        dumpHashes              = true
+        process.beforeScript    = 'echo $HOSTNAME'
+        cleanup                 = false
         nextflow.enable.configProcessNamesValidation = true
     }
     conda {
-        conda.enabled          = true
-        docker.enabled         = false
-        singularity.enabled    = false
-        podman.enabled         = false
-        shifter.enabled        = false
-        charliecloud.enabled   = false
-        channels               = ['conda-forge', 'bioconda', 'defaults']
-        apptainer.enabled      = false
+        conda.enabled           = true
+        docker.enabled          = false
+        singularity.enabled     = false
+        podman.enabled          = false
+        shifter.enabled         = false
+        charliecloud.enabled    = false
+        channels                = ['conda-forge', 'bioconda', 'defaults']
+        apptainer.enabled       = false
     }
     mamba {
-        conda.enabled          = true
-        conda.useMamba         = true
-        docker.enabled         = false
-        singularity.enabled    = false
-        podman.enabled         = false
-        shifter.enabled        = false
-        charliecloud.enabled   = false
-        apptainer.enabled      = false
+        conda.enabled           = true
+        conda.useMamba          = true
+        docker.enabled          = false
+        singularity.enabled     = false
+        podman.enabled          = false
+        shifter.enabled         = false
+        charliecloud.enabled    = false
+        apptainer.enabled       = false
     }
     docker {
-        docker.enabled         = true
-        conda.enabled          = false
-        singularity.enabled    = false
-        podman.enabled         = false
-        shifter.enabled        = false
-        charliecloud.enabled   = false
-        apptainer.enabled      = false
-        docker.runOptions      = '-u $(id -u):$(id -g)'
+        docker.enabled          = true
+        conda.enabled           = false
+        singularity.enabled     = false
+        podman.enabled          = false
+        shifter.enabled         = false
+        charliecloud.enabled    = false
+        apptainer.enabled       = false
+        docker.runOptions       = '-u $(id -u):$(id -g)'
     }
     arm {
-        docker.runOptions      = '-u $(id -u):$(id -g) --platform=linux/amd64'
+        docker.runOptions       = '-u $(id -u):$(id -g) --platform=linux/amd64'
     }
     singularity {
-        singularity.enabled    = true
-        singularity.autoMounts = true
-        conda.enabled          = false
-        docker.enabled         = false
-        podman.enabled         = false
-        shifter.enabled        = false
-        charliecloud.enabled   = false
-        apptainer.enabled      = false
+        singularity.enabled     = true
+        singularity.autoMounts  = true
+        conda.enabled           = false
+        docker.enabled          = false
+        podman.enabled          = false
+        shifter.enabled         = false
+        charliecloud.enabled    = false
+        apptainer.enabled       = false
     }
     podman {
-        podman.enabled         = true
-        conda.enabled          = false
-        docker.enabled         = false
-        singularity.enabled    = false
-        shifter.enabled        = false
-        charliecloud.enabled   = false
-        apptainer.enabled      = false
+        podman.enabled          = true
+        conda.enabled           = false
+        docker.enabled          = false
+        singularity.enabled     = false
+        shifter.enabled         = false
+        charliecloud.enabled    = false
+        apptainer.enabled       = false
     }
     shifter {
-        shifter.enabled        = true
-        conda.enabled          = false
-        docker.enabled         = false
-        singularity.enabled    = false
-        podman.enabled         = false
-        charliecloud.enabled   = false
-        apptainer.enabled      = false
+        shifter.enabled         = true
+        conda.enabled           = false
+        docker.enabled          = false
+        singularity.enabled     = false
+        podman.enabled          = false
+        charliecloud.enabled    = false
+        apptainer.enabled       = false
     }
     charliecloud {
-        charliecloud.enabled   = true
-        conda.enabled          = false
-        docker.enabled         = false
-        singularity.enabled    = false
-        podman.enabled         = false
-        shifter.enabled        = false
-        apptainer.enabled      = false
+        charliecloud.enabled    = true
+        conda.enabled           = false
+        docker.enabled          = false
+        singularity.enabled     = false
+        podman.enabled          = false
+        shifter.enabled         = false
+        apptainer.enabled       = false
     }
     apptainer {
-        apptainer.enabled      = true
-        apptainer.autoMounts   = true
-        conda.enabled          = false
-        docker.enabled         = false
-        singularity.enabled    = false
-        podman.enabled         = false
-        shifter.enabled        = false
-        charliecloud.enabled   = false
+        apptainer.enabled       = true
+        apptainer.autoMounts    = true
+        conda.enabled           = false
+        docker.enabled          = false
+        singularity.enabled     = false
+        podman.enabled          = false
+        shifter.enabled         = false
+        charliecloud.enabled    = false
     }
     wave {
         apptainer.ociAutoPull   = true
@@ -179,9 +179,9 @@ profiles {
         wave.strategy           = 'conda,container'
     }
     gitpod {
-        executor.name          = 'local'
-        executor.cpus          = 4
-        executor.memory        = 8.GB
+        executor.name           = 'local'
+        executor.cpus           = 4
+        executor.memory         = 8.GB
     }
     test      { includeConfig 'conf/test.config'      }
     test_full { includeConfig 'conf/test_full.config' }

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -172,10 +172,10 @@ profiles {
         charliecloud.enabled   = false
     }
     wave {
-        wave.enabled = true
-        wave.strategy = 'conda,container'
-        wave.freeze = true
         singularity.ociAutoPull = true
+        wave.enabled            = true
+        wave.freeze             = true
+        wave.strategy           = 'conda,container'
     }
     gitpod {
         executor.name          = 'local'

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -172,6 +172,7 @@ profiles {
         charliecloud.enabled   = false
     }
     wave {
+        apptainer.ociAutoPull   = true
         singularity.ociAutoPull = true
         wave.enabled            = true
         wave.freeze             = true

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -176,6 +176,11 @@ profiles {
         executor.cpus          = 4
         executor.memory        = 8.GB
     }
+    wave {
+        wave.enabled = true
+        wave.strategy = 'conda,container'
+        wave.freeze = true
+    }
     test      { includeConfig 'conf/test.config'      }
     test_full { includeConfig 'conf/test_full.config' }
 }

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -175,6 +175,7 @@ profiles {
         wave.enabled = true
         wave.strategy = 'conda,container'
         wave.freeze = true
+        singularity.ociAutoPull = true
     }
     gitpod {
         executor.name          = 'local'

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -171,15 +171,15 @@ profiles {
         shifter.enabled        = false
         charliecloud.enabled   = false
     }
-    gitpod {
-        executor.name          = 'local'
-        executor.cpus          = 4
-        executor.memory        = 8.GB
-    }
     wave {
         wave.enabled = true
         wave.strategy = 'conda,container'
         wave.freeze = true
+    }
+    gitpod {
+        executor.name          = 'local'
+        executor.cpus          = 4
+        executor.memory        = 8.GB
     }
     test      { includeConfig 'conf/test.config'      }
     test_full { includeConfig 'conf/test_full.config' }


### PR DESCRIPTION
Add a config profile in the template to use Wave.

> [!NOTE]
> Requires `24.03.0-edge`! I considered bumping `nextflowVersion` to `24.04.0` but it feels a bit overkill when the vast majority of end users will not be using `-profile wave`. I'm inclined to mention this in the docs but not encode it in the config. Please shout if you disagree.

Will need more docs about Wave, but that's a larger effort, probably for the website repo.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] Documentation in `docs` is updated
