### PR TITLE
Components: Handle extended set of git path prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v2.13.2dev
 
+- Handle more complete list of possible git URL forms (ssh:// and ftp:// prefixes specifically)
+
 ### Template
 
 - Remove fasta default from nextflow.config ([#2828](https://github.com/nf-core/tools/pull/2828))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - Update gitpod/workspace-base Docker digest to 5aeb24f ([#2929](https://github.com/nf-core/tools/pull/2929))
 - Update pre-commit hook pre-commit/mirrors-mypy to v1.10.0 ([#2933](https://github.com/nf-core/tools/pull/2933))
 - Update GitHub Actions ([#2939](https://github.com/nf-core/tools/pull/2939))
+- Components: Handle extended set of git path prefixes ([#2945](https://github.com/nf-core/tools/pull/2945))
 
 ## [v2.13.1 - Tin Puppy Patch](https://github.com/nf-core/tools/releases/tag/2.13) - [2024-02-29]
 

--- a/nf_core/modules/modules_utils.py
+++ b/nf_core/modules/modules_utils.py
@@ -20,22 +20,20 @@ def repo_full_name_from_remote(remote_url: str) -> str:
     Extracts the path from the remote URL
     See https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-clone.html#URLS for the possible URL patterns
     """
-    # Check whether we have a https or ssh url
-    if remote_url.startswith("https"):
-        path = urlparse(remote_url).path
-        # Remove the intial '/'
-        path = path[1:]
-        # Remove extension
-        path = os.path.splitext(path)[0]
-    else:
-        # Remove the initial `git@``
-        split_path: list = remote_url.split("@")
-        path = split_path[-1] if len(split_path) > 1 else split_path[0]
-        path = urlparse(path).path
-        # Remove extension
-        path = os.path.splitext(path)[0]
-    return path
 
+    if remote_url.startswith(("https://", "http://", "ftps://", "ftp://", "ssh://")):
+        # Parse URL and remove the initial '/'
+        path = urlparse(remote_url).path.lstrip('/') 
+    elif 'git@' in remote_url:
+        # Extract the part after 'git@' and parse it
+        path = urlparse(remote_url.split('git@')[-1]).path
+    else:
+        path = urlparse(remote_url).path
+
+    # Remove the file extension from the path
+    path, _ = os.path.splitext(path)
+
+    return path
 
 def get_installed_modules(dir: str, repo_type="modules") -> Tuple[List[str], List[NFCoreComponent]]:
     """

--- a/nf_core/modules/modules_utils.py
+++ b/nf_core/modules/modules_utils.py
@@ -23,10 +23,10 @@ def repo_full_name_from_remote(remote_url: str) -> str:
 
     if remote_url.startswith(("https://", "http://", "ftps://", "ftp://", "ssh://")):
         # Parse URL and remove the initial '/'
-        path = urlparse(remote_url).path.lstrip('/') 
-    elif 'git@' in remote_url:
+        path = urlparse(remote_url).path.lstrip("/")
+    elif "git@" in remote_url:
         # Extract the part after 'git@' and parse it
-        path = urlparse(remote_url.split('git@')[-1]).path
+        path = urlparse(remote_url.split("git@")[-1]).path
     else:
         path = urlparse(remote_url).path
 
@@ -34,6 +34,7 @@ def repo_full_name_from_remote(remote_url: str) -> str:
     path, _ = os.path.splitext(path)
 
     return path
+
 
 def get_installed_modules(dir: str, repo_type="modules") -> Tuple[List[str], List[NFCoreComponent]]:
     """


### PR DESCRIPTION
As per the document linked in the function description, valid git URLs may begin with ssh:// (and ftp://). This PR extends the nf-core tool to clone module repositories that are of these forms.

Before this fix, running a command like

```bash
nf-core modules list remote \
  --git-remote ssh://git-codecommit.us-east-2.amazonaws.com/v1/repos/modules.git
```

would pass the string `ssh://git-codecommit.us-east-2.amazonaws.com/v1/repos/modules.git` to the `repo_full_name_from_remote` function which would return the repo full name `/v1/repos/modules`, which would be passed to the `git clone` subshell to invoke the command trying to `git clone` into the root of the filesystem, which is going to fail for almost all users:

```bash
git clone -v --progress -- \
  ssh://git-codecommit.us-east-2.amazonaws.com/v1/repos/modules.git \
  /v1/repos/modules
```

This amended function now returns the string `v1/repos/modules` instead, which should allow the repo to be cloned correctly because it is no longer an absolute path.

```bash
git clone -v --progress -- \
  ssh://git-codecommit.us-east-2.amazonaws.com/v1/repos/modules.git \
  v1/repos/modules
```
