### PR TITLE
Components: set correct sha before running component lint tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 - Only match assignments of params in `main.nf` and not references like `params.aligner == <something>` ([#2833](https://github.com/nf-core/tools/pull/2833))
 - Include test for presence of versions in snapshot ([#2888](https://github.com/nf-core/tools/pull/2888))
+- Components: set correct sha before running component lint tests ([#2952](https://github.com/nf-core/tools/pull/2952))
 
 ### Download
 

--- a/nf_core/modules/lint/__init__.py
+++ b/nf_core/modules/lint/__init__.py
@@ -213,7 +213,7 @@ class ModuleLint(ComponentLint):
 
         # Otherwise run all the lint tests
         else:
-            if self.repo_type == "pipeline":
+            if self.repo_type == "pipeline" and self.modules_json:
                 # Set correct sha
                 version = self.modules_json.get_module_version(mod.component_name, mod.repo_url, mod.org)
                 mod.git_sha = version

--- a/nf_core/modules/lint/__init__.py
+++ b/nf_core/modules/lint/__init__.py
@@ -213,9 +213,10 @@ class ModuleLint(ComponentLint):
 
         # Otherwise run all the lint tests
         else:
-            # Set correct sha
-            version = self.modules_json.get_module_version(mod.component_name, mod.repo_url, mod.org)
-            mod.git_sha = version
+            if self.repo_type == "pipeline":
+                # Set correct sha
+                version = self.modules_json.get_module_version(mod.component_name, mod.repo_url, mod.org)
+                mod.git_sha = version
 
             for test_name in self.lint_tests:
                 if test_name == "main_nf":

--- a/nf_core/modules/lint/__init__.py
+++ b/nf_core/modules/lint/__init__.py
@@ -213,6 +213,10 @@ class ModuleLint(ComponentLint):
 
         # Otherwise run all the lint tests
         else:
+            # Set correct sha
+            version = self.modules_json.get_module_version(mod.component_name, mod.repo_url, mod.org)
+            mod.git_sha = version
+
             for test_name in self.lint_tests:
                 if test_name == "main_nf":
                     getattr(self, test_name)(mod, fix_version, self.registry, progress_bar)

--- a/nf_core/subworkflows/lint/__init__.py
+++ b/nf_core/subworkflows/lint/__init__.py
@@ -207,6 +207,10 @@ class SubworkflowLint(ComponentLint):
 
         # Otherwise run all the lint tests
         else:
+            # Set correct sha
+            version = self.modules_json.get_subworkflow_version(swf.component_name, swf.repo_url, swf.org)
+            swf.git_sha = version
+
             for test_name in self.lint_tests:
                 getattr(self, test_name)(swf)
 

--- a/nf_core/subworkflows/lint/__init__.py
+++ b/nf_core/subworkflows/lint/__init__.py
@@ -207,9 +207,10 @@ class SubworkflowLint(ComponentLint):
 
         # Otherwise run all the lint tests
         else:
-            # Set correct sha
-            version = self.modules_json.get_subworkflow_version(swf.component_name, swf.repo_url, swf.org)
-            swf.git_sha = version
+            if self.repo_type == "pipeline":
+                # Set correct sha
+                version = self.modules_json.get_subworkflow_version(swf.component_name, swf.repo_url, swf.org)
+                swf.git_sha = version
 
             for test_name in self.lint_tests:
                 getattr(self, test_name)(swf)

--- a/nf_core/subworkflows/lint/__init__.py
+++ b/nf_core/subworkflows/lint/__init__.py
@@ -207,7 +207,7 @@ class SubworkflowLint(ComponentLint):
 
         # Otherwise run all the lint tests
         else:
-            if self.repo_type == "pipeline":
+            if self.repo_type == "pipeline" and self.modules_json:
                 # Set correct sha
                 version = self.modules_json.get_subworkflow_version(swf.component_name, swf.repo_url, swf.org)
                 swf.git_sha = version

--- a/nf_core/synced_repo.py
+++ b/nf_core/synced_repo.py
@@ -319,9 +319,9 @@ class SyncedRepo:
         component_dir = self.get_component_dir(component_name, component_type)
         for file in component_files:
             try:
-                files_identical[file] = filecmp.cmp(os.path.join(component_dir, file), os.path.join(base_path, file))
+                files_identical[file] = filecmp.cmp(Path(component_dir, file), Path(base_path, file))
             except FileNotFoundError:
-                log.debug(f"Could not open file: {os.path.join(component_dir, file)}")
+                log.debug(f"Could not open file: {Path(component_dir, file)}")
                 continue
         self.checkout_branch()
         return files_identical


### PR DESCRIPTION
Fix linting tests failing when a subworkflow is not up to date but matches the remote.
Error reported: https://github.com/genomic-medicine-sweden/meta-val/actions/runs/8966887756/job/24623288271?pr=15