### PR TITLE
Template: Lint pipelines with the nf-core template version and post comment if it is outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Linting
 
+- Template: Lint pipelines with the nf-core template version and post comment if it is outdated ([#2978](https://github.com/nf-core/tools/pull/2978))
+
 ### Download
 
 ### Components

--- a/nf_core/pipeline-template/.github/workflows/linting.yml
+++ b/nf_core/pipeline-template/.github/workflows/linting.yml
@@ -41,10 +41,16 @@ jobs:
           python-version: "3.12"
           architecture: "x64"
 
+      - name: read .nf-core.yml
+        uses: pietrobolcato/action-read-yaml@1.0.0
+        id: read_yml
+        with:
+          config: ${{ github.workspace }}/.nf-core.yaml
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install nf-core
+          pip install nf-core==${{ steps.read_yml.outputs['nf_core_version'] }}
 
       - name: Run nf-core lint
         env:

--- a/nf_core/pipeline-template/.github/workflows/template_version_comment.yml
+++ b/nf_core/pipeline-template/.github/workflows/template_version_comment.yml
@@ -31,10 +31,10 @@ jobs:
         if: |
           ${{ steps.nf_core_outdated.outputs.stdout }} =~ 'nf-core'
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.NF_CORE_BOT_AUTH_TOKEN }}
           allow-repeats: false
           message: |
-            ## :warning: New nf-core template version available
+            ## :warning: Newer version of the nf-core template is available.
 
             Your pipeline is using an old version of the nf-core template: ${{ steps.read_yml.outputs['nf_core_version'] }}.
             Please update your pipeline to the latest version.

--- a/nf_core/pipeline-template/.github/workflows/template_version_comment.yml
+++ b/nf_core/pipeline-template/.github/workflows/template_version_comment.yml
@@ -1,0 +1,42 @@
+name: nf-core template version comment
+# This workflow is triggered on PRs to check if the pipeline template version matches the latest nf-core version.
+# It posts a comment to the PR, even if it comes from a fork.
+
+on: pull_request_target
+
+jobs:
+  template_version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out pipeline code
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
+
+      - name: Read template version from .nf-core.yml
+        uses: pietrobolcato/action-read-yaml@1.0.0
+        id: read_yml
+        with:
+          config: ${{ github.workspace }}/.nf-core.yml
+
+      - name: Install nf-core
+        run: |
+          python -m pip install --upgrade pip
+          pip install nf-core==${{ steps.read_yml.outputs['nf_core_version'] }}
+
+      - name: Check nf-core outdated
+        id: nf_core_outdated
+        run: pip list --outdated | grep nf-core
+
+      - name: Post nf-core template version comment
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2
+        if: |
+          ${{ steps.nf_core_outdated.outputs.stdout }} =~ 'nf-core'
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-repeats: false
+          message: |
+            ## :warning: New nf-core template version available
+
+            Your pipeline is using an old version of the nf-core template: ${{ steps.read_yml.outputs['nf_core_version'] }}.
+            Please update your pipeline to the latest version.
+
+            For more documentation on how to update your pipeline, please see the [nf-core documentation](https://github.com/nf-core/tools?tab=readme-ov-file#sync-a-pipeline-with-the-template) and [Synchronisation documentation](https://nf-co.re/docs/contributing/sync).


### PR DESCRIPTION
Check the pipeline template version from `.nf-core.yml`. 
Run nf-core linting with that version.
If the template version is outdated, post a comment to the PR warning about a new version available.

Tested with the nf-core/testpipeline: https://github.com/nf-core/testpipeline/pull/84

Close https://github.com/nf-core/tools/issues/2966