### PR TITLE
Add organization to `main.nf.test` tag instead of using `nfcore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Components
 
+- The `modules_nfcore` tag in the `main.nf.test` file of modules/subworkflows now displays the organization name in custom modules repositories ([#3005](https://github.com/nf-core/tools/pull/3005))
+
 ### General
 
 - Update pre-commit hook astral-sh/ruff-pre-commit to v0.4.4 ([#2974](https://github.com/nf-core/tools/pull/2974))

--- a/nf_core/components/create.py
+++ b/nf_core/components/create.py
@@ -158,8 +158,8 @@ class ComponentCreate(ComponentCommand):
                 self._get_module_structure_components()
 
         # Add a valid organization name for nf-test tags
-        not_alphabet = re.compile(r'[^a-zA-Z]')
-        self.org_alphabet = not_alphabet.sub('', self.org)
+        not_alphabet = re.compile(r"[^a-zA-Z]")
+        self.org_alphabet = not_alphabet.sub("", self.org)
 
         # Create component template with jinja2
         self._render_template()

--- a/nf_core/components/create.py
+++ b/nf_core/components/create.py
@@ -157,6 +157,10 @@ class ComponentCreate(ComponentCommand):
             if self.component_type == "modules":
                 self._get_module_structure_components()
 
+        # Add a valid organization name for nf-test tags
+        not_alphabet = re.compile(r'[^a-zA-Z]')
+        self.org_alphabet = not_alphabet.sub('', self.org)
+
         # Create component template with jinja2
         self._render_template()
         log.info(f"Created component template: '{self.component_name}'")

--- a/nf_core/module-template/tests/main.nf.test.j2
+++ b/nf_core/module-template/tests/main.nf.test.j2
@@ -7,7 +7,7 @@ nextflow_process {
     process "{{ component_name_underscore|upper }}"
 
     tag "modules"
-    tag "modules_nfcore"
+    tag "modules_{{ org_alphabet }}"
     {%- if subtool %}
     tag "{{ component }}"
     {%- endif %}

--- a/nf_core/modules/lint/module_tests.py
+++ b/nf_core/modules/lint/module_tests.py
@@ -138,8 +138,8 @@ def module_tests(_, module: NFCoreComponent):
                     )
             # Verify that tags are correct.
             main_nf_tags = module._get_main_nf_tags(module.nftest_main_nf)
-            not_alphabet = re.compile(r'[^a-zA-Z]')
-            org_alp = not_alphabet.sub('', module.org)
+            not_alphabet = re.compile(r"[^a-zA-Z]")
+            org_alp = not_alphabet.sub("", module.org)
             org_alphabet = org_alp if org_alp != "" else "nfcore"
             required_tags = ["modules", f"modules_{org_alphabet}", module.component_name]
             if module.component_name.count("/") == 1:

--- a/nf_core/modules/lint/module_tests.py
+++ b/nf_core/modules/lint/module_tests.py
@@ -4,6 +4,7 @@ Lint the tests of a module in nf-core/modules
 
 import json
 import logging
+import re
 from pathlib import Path
 
 import yaml
@@ -137,7 +138,10 @@ def module_tests(_, module: NFCoreComponent):
                     )
             # Verify that tags are correct.
             main_nf_tags = module._get_main_nf_tags(module.nftest_main_nf)
-            required_tags = ["modules", "modules_nfcore", module.component_name]
+            not_alphabet = re.compile(r'[^a-zA-Z]')
+            org_alp = not_alphabet.sub('', module.org)
+            org_alphabet = org_alp if org_alp != "" else "nfcore"
+            required_tags = ["modules", f"modules_{org_alphabet}", module.component_name]
             if module.component_name.count("/") == 1:
                 required_tags.append(module.component_name.split("/")[0])
             chained_components_tags = module._get_included_components_in_chained_tests(module.nftest_main_nf)

--- a/nf_core/subworkflow-template/tests/main.nf.test.j2
+++ b/nf_core/subworkflow-template/tests/main.nf.test.j2
@@ -7,7 +7,7 @@ nextflow_workflow {
     workflow "{{ component_name_underscore|upper }}"
 
     tag "subworkflows"
-    tag "subworkflows_nfcore"
+    tag "subworkflows_{{ org_alphabet }}"
     tag "subworkflows/{{ component_name }}"
     // TODO nf-core: Add tags for all modules used within this subworkflow. Example:
     tag "samtools"

--- a/nf_core/subworkflows/lint/subworkflow_tests.py
+++ b/nf_core/subworkflows/lint/subworkflow_tests.py
@@ -4,6 +4,7 @@ Lint the tests of a subworkflow in nf-core/modules
 
 import json
 import logging
+import re
 from pathlib import Path
 
 import yaml
@@ -144,10 +145,13 @@ def subworkflow_tests(_, subworkflow: NFCoreComponent):
                     )
             # Verify that tags are correct.
             main_nf_tags = subworkflow._get_main_nf_tags(subworkflow.nftest_main_nf)
+            not_alphabet = re.compile(r'[^a-zA-Z]')
+            org_alp = not_alphabet.sub('', subworkflow.org)
+            org_alphabet = org_alp if org_alp != "" else "nfcore"
             required_tags = [
                 "subworkflows",
                 f"subworkflows/{subworkflow.component_name}",
-                "subworkflows_nfcore",
+                f"subworkflows_{org_alphabet}",
             ]
             included_components = []
             if subworkflow.main_nf.is_file():

--- a/nf_core/subworkflows/lint/subworkflow_tests.py
+++ b/nf_core/subworkflows/lint/subworkflow_tests.py
@@ -145,8 +145,8 @@ def subworkflow_tests(_, subworkflow: NFCoreComponent):
                     )
             # Verify that tags are correct.
             main_nf_tags = subworkflow._get_main_nf_tags(subworkflow.nftest_main_nf)
-            not_alphabet = re.compile(r'[^a-zA-Z]')
-            org_alp = not_alphabet.sub('', subworkflow.org)
+            not_alphabet = re.compile(r"[^a-zA-Z]")
+            org_alp = not_alphabet.sub("", subworkflow.org)
             org_alphabet = org_alp if org_alp != "" else "nfcore"
             required_tags = [
                 "subworkflows",


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated

Fixes #2979

In custom modules repositories, the `main.nf.test` file contains the `modules_nfcore` tag (which doesn't really make sense). This PR updates this by doing the following steps:
1. Update `nf-core modules create` and `nf-core subworkflows create` to add the `modules_<organization` tag instead of the `modules_nfcore` tag
2. Update `nf-core modules lint` to make sure it passes the linting check