### PR TITLE
Create: allow more special characters on the pipeline name for non-nf-core pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - update minimal textual version and snapshots ([#2998](https://github.com/nf-core/tools/pull/2998))
 - return directory if base_dir is the root directory ([#3003](https://github.com/nf-core/tools/pull/3003))
 - Update pre-commit hook astral-sh/ruff-pre-commit to v0.4.6 ([#3006](https://github.com/nf-core/tools/pull/3006))
+- Create: allow more special characters on the pipeline name for non-nf-core pipelines ([#3008](https://github.com/nf-core/tools/pull/3008))
 
 ## [v2.14.1 - Tantalum Toad - Patch](https://github.com/nf-core/tools/releases/tag/2.14.1) - [2024-05-09]
 

--- a/nf_core/pipelines/create/__init__.py
+++ b/nf_core/pipelines/create/__init__.py
@@ -59,7 +59,7 @@ class PipelineCreateApp(App[utils.CreateConfig]):
     TEMPLATE_CONFIG = utils.CreateConfig()
 
     # Initialise pipeline type
-    PIPELINE_TYPE = None
+    NFCORE_PIPELINE = True
 
     # Log handler
     LOG_HANDLER = log_handler
@@ -74,12 +74,12 @@ class PipelineCreateApp(App[utils.CreateConfig]):
         if event.button.id == "start":
             self.push_screen("choose_type")
         elif event.button.id == "type_nfcore":
-            self.PIPELINE_TYPE = "nfcore"
-            utils.PIPELINE_TYPE_GLOBAL = "nfcore"
+            self.NFCORE_PIPELINE = True
+            utils.NFCORE_PIPELINE_GLOBAL = True
             self.push_screen("basic_details")
         elif event.button.id == "type_custom":
-            self.PIPELINE_TYPE = "custom"
-            utils.PIPELINE_TYPE_GLOBAL = "custom"
+            self.NFCORE_PIPELINE = False
+            utils.NFCORE_PIPELINE_GLOBAL = False
             self.push_screen("basic_details")
         elif event.button.id == "continue":
             self.push_screen("final_details")

--- a/nf_core/pipelines/create/__init__.py
+++ b/nf_core/pipelines/create/__init__.py
@@ -5,6 +5,7 @@ import logging
 from textual.app import App
 from textual.widgets import Button
 
+from nf_core.pipelines.create import utils
 from nf_core.pipelines.create.basicdetails import BasicDetails
 from nf_core.pipelines.create.custompipeline import CustomPipeline
 from nf_core.pipelines.create.finaldetails import FinalDetails
@@ -14,15 +15,10 @@ from nf_core.pipelines.create.githubrepoquestion import GithubRepoQuestion
 from nf_core.pipelines.create.loggingscreen import LoggingScreen
 from nf_core.pipelines.create.nfcorepipeline import NfcorePipeline
 from nf_core.pipelines.create.pipelinetype import ChoosePipelineType
-from nf_core.pipelines.create.utils import (
-    CreateConfig,
-    CustomLogHandler,
-    LoggingConsole,
-)
 from nf_core.pipelines.create.welcome import WelcomeScreen
 
-log_handler = CustomLogHandler(
-    console=LoggingConsole(classes="log_console"),
+log_handler = utils.CustomLogHandler(
+    console=utils.LoggingConsole(classes="log_console"),
     rich_tracebacks=True,
     show_time=False,
     show_path=False,
@@ -36,7 +32,7 @@ logging.basicConfig(
 log_handler.setLevel("INFO")
 
 
-class PipelineCreateApp(App[CreateConfig]):
+class PipelineCreateApp(App[utils.CreateConfig]):
     """A Textual app to manage stopwatches."""
 
     CSS_PATH = "create.tcss"
@@ -60,7 +56,7 @@ class PipelineCreateApp(App[CreateConfig]):
     }
 
     # Initialise config as empty
-    TEMPLATE_CONFIG = CreateConfig()
+    TEMPLATE_CONFIG = utils.CreateConfig()
 
     # Initialise pipeline type
     PIPELINE_TYPE = None
@@ -79,9 +75,11 @@ class PipelineCreateApp(App[CreateConfig]):
             self.push_screen("choose_type")
         elif event.button.id == "type_nfcore":
             self.PIPELINE_TYPE = "nfcore"
+            utils.PIPELINE_TYPE_GLOBAL = "nfcore"
             self.push_screen("basic_details")
         elif event.button.id == "type_custom":
             self.PIPELINE_TYPE = "custom"
+            utils.PIPELINE_TYPE_GLOBAL = "custom"
             self.push_screen("basic_details")
         elif event.button.id == "continue":
             self.push_screen("final_details")

--- a/nf_core/pipelines/create/basicdetails.py
+++ b/nf_core/pipelines/create/basicdetails.py
@@ -39,7 +39,7 @@ class BasicDetails(Screen):
                 "GitHub organisation",
                 "nf-core",
                 classes="column",
-                disabled=self.parent.PIPELINE_TYPE == "nfcore",
+                disabled=self.parent.NFCORE_PIPELINE,
             )
             yield TextInput(
                 "name",
@@ -85,7 +85,7 @@ class BasicDetails(Screen):
         add_hide_class(self.parent, "exist_warn")
         for text_input in self.query("TextInput"):
             if text_input.field_id == "org":
-                text_input.disabled = self.parent.PIPELINE_TYPE == "nfcore"
+                text_input.disabled = self.parent.NFCORE_PIPELINE
 
     @on(Button.Pressed)
     def on_button_pressed(self, event: Button.Pressed) -> None:
@@ -102,9 +102,9 @@ class BasicDetails(Screen):
         try:
             self.parent.TEMPLATE_CONFIG = CreateConfig(**config)
             if event.button.id == "next":
-                if self.parent.PIPELINE_TYPE == "nfcore":
+                if self.parent.NFCORE_PIPELINE:
                     self.parent.push_screen("type_nfcore")
-                elif self.parent.PIPELINE_TYPE == "custom":
+                else:
                     self.parent.push_screen("type_custom")
         except ValueError:
             pass

--- a/nf_core/pipelines/create/utils.py
+++ b/nf_core/pipelines/create/utils.py
@@ -30,7 +30,7 @@ def init_context(value: Dict[str, Any]) -> Iterator[None]:
 
 
 # Define a global variable to store the pipeline type
-PIPELINE_TYPE_GLOBAL: Union[str, None] = None
+NFCORE_PIPELINE_GLOBAL: bool = True
 
 
 class CreateConfig(BaseModel):
@@ -148,7 +148,7 @@ class ValidateConfig(Validator):
 
         If it fails, return the error messages."""
         try:
-            with init_context({"is_nfcore": PIPELINE_TYPE_GLOBAL == "nfcore"}):
+            with init_context({"is_nfcore": NFCORE_PIPELINE_GLOBAL}):
                 CreateConfig(**{f"{self.key}": value})
                 return self.success()
         except ValidationError as e:

--- a/nf_core/pipelines/create/utils.py
+++ b/nf_core/pipelines/create/utils.py
@@ -30,7 +30,7 @@ def init_context(value: Dict[str, Any]) -> Iterator[None]:
 
 
 # Define a global variable to store the pipeline type
-PIPELINE_TYPE_GLOBAL: str | None = None
+PIPELINE_TYPE_GLOBAL: Union[str, None] = None
 
 
 class CreateConfig(BaseModel):


### PR DESCRIPTION
Close #2963 

Use validation context from pydantic with Model initialization. See docs [here](https://docs.pydantic.dev/latest/concepts/validators/#using-validation-context-with-basemodel-initialization)

Adding a global variable was the only option to access the pipeline type from validation, where the app is not available, so we can't use class attributes.