### PR TITLE
Remove Azure specific documentation which is no longer required

### DIFF
--- a/nf_core/pipeline-template/docs/usage.md
+++ b/nf_core/pipeline-template/docs/usage.md
@@ -207,14 +207,6 @@ See the main [Nextflow documentation](https://www.nextflow.io/docs/latest/config
 
 If you have any questions or issues please send us a message on [Slack](https://nf-co.re/join/slack) on the [`#configs` channel](https://nfcore.slack.com/channels/configs).
 
-## Azure Resource Requests
-
-To be used with the `azurebatch` profile by specifying the `-profile azurebatch`.
-We recommend providing a compute `params.vm_type` of `Standard_D16_v3` VMs by default but these options can be changed if required.
-
-Note that the choice of VM size depends on your quota and the overall workload during the analysis.
-For a thorough list, please refer the [Azure Sizes for virtual machines in Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/sizes).
-
 {% endif -%}
 
 ## Running in the background


### PR DESCRIPTION
There was additional documentation which was legacy and not required now. 

Users should refer to the `azurebatch` specific profile and/or the Nextflow documentation for relevant features.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] Documentation in `docs` is updated
