### PR TITLE
fix the nested list bug that makes email not be delivered

### DIFF
--- a/nf_core/pipeline-template/subworkflows/local/utils_nfcore_pipeline_pipeline/main.nf
+++ b/nf_core/pipeline-template/subworkflows/local/utils_nfcore_pipeline_pipeline/main.nf
@@ -117,13 +117,13 @@ workflow PIPELINE_INITIALISATION {
 workflow PIPELINE_COMPLETION {
 
     take:
-    email           //  string: email address
-    email_on_fail   //  string: email address sent on pipeline failure
-    plaintext_email // boolean: Send plain-text email instead of HTML
-    outdir          //    path: Path to output directory where results will be published
-    monochrome_logs // boolean: Disable ANSI colour codes in log output
-    hook_url        //  string: hook URL for notifications
-    multiqc_report  //  string: Path to MultiQC report
+    email           //   string: email address
+    email_on_fail   //   string: email address sent on pipeline failure
+    plaintext_email //  boolean: Send plain-text email instead of HTML
+    outdir          //     path: Path to output directory where results will be published
+    monochrome_logs //  boolean: Disable ANSI colour codes in log output
+    hook_url        //   string: hook URL for notifications
+    multiqc_report  // [string]: List of paths to MultiQC report (Note: only the first one will be used)
 
     main:
 
@@ -134,7 +134,7 @@ workflow PIPELINE_COMPLETION {
     //
     workflow.onComplete {
         if (email || email_on_fail) {
-            completionEmail(summary_params, email, email_on_fail, plaintext_email, outdir, monochrome_logs, multiqc_report.toList())
+            completionEmail(summary_params, email, email_on_fail, plaintext_email, outdir, monochrome_logs, multiqc_report)
         }
 
         completionSummary(monochrome_logs)


### PR DESCRIPTION
Fix the bug of nested list for generating the reports. Before calling the function `PIPELINE_COMPLETION` in `main.nf`, the `pipeline.nf` emit the `multiqc_report` as a list (see below):

https://github.com/nf-core/tools/blob/930ece572bf23b68c7a7c5259e918a878ba6499e/nf_core/pipeline-template/workflows/pipeline.nf#L89-L91

But in the `utils_nfcore_pipeline_pipeline`, the `workflow.onComplete` function, the report is double listed:

https://github.com/nf-core/tools/blob/930ece572bf23b68c7a7c5259e918a878ba6499e/nf_core/pipeline-template/subworkflows/local/utils_nfcore_pipeline_pipeline/main.nf#L137

This nested list make the `groovy.text.GStringTemplateEngine` cannot correctly render the HTML to send the email (The resulting HTML string is empty):

https://github.com/nf-core/tools/blob/930ece572bf23b68c7a7c5259e918a878ba6499e/nf_core/pipeline-template/subworkflows/nf-core/utils_nfcore_pipeline/main.nf#L343-L344

So, here remove one `toList()` call to make email back to work. I also test this change and find the email function back to work well after this change.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
