### PR TITLE
Components: Modules : allow module lables between double quotes

### DIFF
--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -437,7 +437,7 @@ def check_process_labels(self, lines):
     if len(all_labels) > 0:
         for label in all_labels:
             try:
-                label = re.match(r"^label\s+'?([a-zA-Z0-9_-]+)'?$", label).group(1)
+                label = re.match(r"^label\s+'?\"?([a-zA-Z0-9_-]+)'?\"?$", label).group(1)
             except AttributeError:
                 self.warned.append(
                     (


### PR DESCRIPTION
close https://github.com/nf-core/tools/issues/3010