### PR TITLE
Add bot action to update textual snapshots and write bot documentation

### DIFF
--- a/.github/workflows/regenerate-snapshots.yml
+++ b/.github/workflows/regenerate-snapshots.yml
@@ -8,7 +8,7 @@ jobs:
     # Only run if comment is on a PR with the main repo, and if it contains the magic keywords
     if: >
       contains(github.event.comment.html_url, '/pull/') &&
-      contains(github.event.comment.body, '@nf-core-bot regenerate snapshots') &&
+      contains(github.event.comment.body, '@nf-core-bot update snapshots') &&
       github.repository == 'nf-core/tools'
     runs-on: ubuntu-latest
     steps:
@@ -36,6 +36,7 @@ jobs:
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
         with:
           python-version: "3.12"
+          cache: "pip"
 
       - name: Install dependencies
         run: |
@@ -45,7 +46,7 @@ jobs:
       - name: Run pytest to regenerate snapshots
         id: pytest
         run: |
-          python3 -m pytest tests/test_create_app.py --snapshot-update --color=yes --cov --durations=0
+          python3 -m pytest tests/test_create_app.py --snapshot-update --color=yes  --durations=0
         continue-on-error: true
 
       # indication that the run has finished

--- a/.github/workflows/regenerate-snapshots.yml
+++ b/.github/workflows/regenerate-snapshots.yml
@@ -1,0 +1,92 @@
+name: Regenerate Textual snapshots from a comment
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  regenerate-snapshots:
+    # Only run if comment is on a PR with the main repo, and if it contains the magic keywords
+    if: >
+      contains(github.event.comment.html_url, '/pull/') &&
+      contains(github.event.comment.body, '@nf-core-bot regenerate snapshots') &&
+      github.repository == 'nf-core/tools'
+    runs-on: ubuntu-latest
+    steps:
+      # Use the @nf-core-bot token to check out so we can push later
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
+        with:
+          token: ${{ secrets.nf_core_bot_auth_token }}
+
+      # indication that the command is running
+      - name: React on comment
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: eyes
+
+      # Action runs on the issue comment, so we don't get the PR by default
+      # Use the gh cli to check out the PR
+      - name: Checkout Pull Request
+        run: gh pr checkout ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.nf_core_bot_auth_token }}
+
+      # Install dependencies and run pytest
+      - name: Set up Python
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip -r requirements-dev.txt
+          pip install -e .
+
+      - name: Run pytest to regenerate snapshots
+        id: pytest
+        run: |
+          python3 -m pytest tests/test_create_app.py --snapshot-update --color=yes --cov --durations=0
+        continue-on-error: true
+
+      # indication that the run has finished
+      - name: react if finished succesfully
+        if: steps.pytest.outcome == 'success'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: "+1"
+
+      - name: Commit & push changes
+        id: commit-and-push
+        if: steps.pytest.outcome == 'failure'
+        run: |
+          git config user.email "core@nf-co.re"
+          git config user.name "nf-core-bot"
+          git config push.default upstream
+          git add .
+          git status
+          git commit -m "[automated] Update Textual snapshots"
+          git push
+
+      - name: react if snapshots were updated
+        id: react-if-updated
+        if: steps.commit-and-push.outcome == 'success'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: hooray
+
+      - name: react if snapshots were not updated
+        if: steps.commit-and-push.outcome == 'failure'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: confused
+
+      - name: react if snapshots were not updated
+        if: steps.commit-and-push.outcome  == 'failure'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            @${{ github.actor }} I tried to update the snapshots, but it didn't work. Please update them manually.

--- a/.github/workflows/update-textual-snapshots.yml
+++ b/.github/workflows/update-textual-snapshots.yml
@@ -1,10 +1,10 @@
-name: Regenerate Textual snapshots from a comment
+name: Update Textual snapshots from a comment
 on:
   issue_comment:
     types: [created]
 
 jobs:
-  regenerate-snapshots:
+  update-snapshots:
     # Only run if comment is on a PR with the main repo, and if it contains the magic keywords
     if: >
       contains(github.event.comment.html_url, '/pull/') &&
@@ -43,7 +43,7 @@ jobs:
           python -m pip install --upgrade pip -r requirements-dev.txt
           pip install -e .
 
-      - name: Run pytest to regenerate snapshots
+      - name: Run pytest to update snapshots
         id: pytest
         run: |
           python3 -m pytest tests/test_create_app.py --snapshot-update --color=yes  --durations=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - Update python:3.12-slim Docker digest to 740d94a ([#3079](https://github.com/nf-core/tools/pull/3079))
 - Update pre-commit hook pre-commit/mirrors-mypy to v1.11.1 ([#3091](https://github.com/nf-core/tools/pull/3091))
 - Pipelines: allow numbers in custom pipeline name ([#3094](https://github.com/nf-core/tools/pull/3094))
+- Add bot action to update textual snapshots and write bot documentation ([#3102](https://github.com/nf-core/tools/pull/3102))
 
 ## [v2.14.1 - Tantalum Toad - Patch](https://github.com/nf-core/tools/releases/tag/2.14.1) - [2024-05-09]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,3 +125,24 @@ To get started:
 Devcontainer specs:
 
 - [DevContainer config](.devcontainer/devcontainer.json)
+
+## nf-core-bot
+
+nf-core has a bot which you can use to perform certain actions on a PR.
+
+- Fix linting:
+
+If the linting tests is failing on a PR to nf-core/tools, you can post a comment with the magic words `@nf-core-bot fix linting`. The bot will try to fix the linting, push to your branch, and react to the comment if the fix was successful or not.
+
+- Update the `CHANGELOG.md`:
+
+The nf-core-bot runs automatically on every PR updating the `CHANGELOG.md` if it was not updated. It will add the new change using the title of your PR.
+If the action didn't run automatically, or you want to provide a different title, you can post a comment with `@nf-core-bot changelog`, optionally followed by the description that you want to add to the changelog.
+
+- Update Textual snapshots:
+
+If the Textual snapshots (run by `tests/test_crate_app.py`) fail, an HTML report is generated and uploaded as an artifact.
+If you are sure that these changes are correct, you can automatically update the snapshots form the PR by posting a comment with the magic words `@nf-core-bot regenerate snapshots`.
+
+> [!WARNING]
+> Please always check this report to make sure that the changes are expected.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,4 +145,4 @@ If the Textual snapshots (run by `tests/test_crate_app.py`) fail, an HTML report
 If you are sure that these changes are correct, you can automatically update the snapshots form the PR by posting a comment with the magic words `@nf-core-bot regenerate snapshots`.
 
 > [!WARNING]
-> Please always check this report to make sure that the changes are expected.
+> Please always check the HTML report to make sure that the changes are expected.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,17 +132,33 @@ nf-core has a bot which you can use to perform certain actions on a PR.
 
 - Fix linting:
 
-If the linting tests is failing on a PR to nf-core/tools, you can post a comment with the magic words `@nf-core-bot fix linting`. The bot will try to fix the linting, push to your branch, and react to the comment if the fix was successful or not.
+If the linting tests is failing on a PR to nf-core/tools, you can post a comment with the magic words:
+
+```
+@nf-core-bot fix linting
+```
+
+The bot will try to fix the linting, push to your branch, and react to the comment when it starts running (👀) and if the fix was successful (👍🏻) or not (😕).
 
 - Update the `CHANGELOG.md`:
 
 The nf-core-bot runs automatically on every PR updating the `CHANGELOG.md` if it was not updated. It will add the new change using the title of your PR.
-If the action didn't run automatically, or you want to provide a different title, you can post a comment with `@nf-core-bot changelog`, optionally followed by the description that you want to add to the changelog.
+If the action didn't run automatically, or you want to provide a different title, you can post a comment with:
+
+```
+@nf-core-bot changelog
+```
+
+Optionally followed by the description that you want to add to the changelog.
 
 - Update Textual snapshots:
 
 If the Textual snapshots (run by `tests/test_crate_app.py`) fail, an HTML report is generated and uploaded as an artifact.
-If you are sure that these changes are correct, you can automatically update the snapshots form the PR by posting a comment with the magic words `@nf-core-bot regenerate snapshots`.
+If you are sure that these changes are correct, you can automatically update the snapshots form the PR by posting a comment with the magic words:
+
+```
+@nf-core-bot update snapshots
+```
 
 > [!WARNING]
 > Please always check the HTML report to make sure that the changes are expected.


### PR DESCRIPTION
Add action of @nf-core-bot to update Textual snapshots.
Add documentation of the uses of @nf-core-bot to the `CONTRIBUTING.md` docs.