### PR TITLE
Components: allow spaces at the betinning of include statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - Update pre-commit hook pre-commit/mirrors-mypy to v1.11.1 ([#3091](https://github.com/nf-core/tools/pull/3091))
 - Pipelines: allow numbers in custom pipeline name ([#3094](https://github.com/nf-core/tools/pull/3094))
 - Add bot action to update textual snapshots and write bot documentation ([#3102](https://github.com/nf-core/tools/pull/3102))
+- Components: allow spaces at the betinning of include statements ([#3115](https://github.com/nf-core/tools/pull/3115))
 
 ## [v2.14.1 - Tantalum Toad - Patch](https://github.com/nf-core/tools/releases/tag/2.14.1) - [2024-05-09]
 

--- a/nf_core/components/components_utils.py
+++ b/nf_core/components/components_utils.py
@@ -143,7 +143,7 @@ def get_components_to_install(subworkflow_dir: str) -> Tuple[List[str], List[str
             regex = re.compile(
                 r"include(?: *{ *)([a-zA-Z\_0-9]*)(?: *as *)?(?:[a-zA-Z\_0-9]*)?(?: *})(?: *from *)(?:'|\")(.*)(?:'|\")"
             )
-            match = regex.match(line)
+            match = regex.search(line)
             if match and len(match.groups()) == 2:
                 name, link = match.groups()
                 if link.startswith("../../../"):


### PR DESCRIPTION
Changing `match` to `search` will look for the component name even if the `include` keyword is not at the beginning of the line. This is to allow spaces for cases such as the following, where we have indentation.
```
if ( params.aligner == "clustalo/align" ) {
    include { CLUSTALO_ALIGN as ALIGNER } from '../../../modules/mirpedrol/clustalo/align/main'
} else if ( params.aligner == "famsa/align" ) {
    include { FAMSA_ALIGN    as ALIGNER } from '../../../modules/mirpedrol/famsa/align/main'
}
```