### PR TITLE
fix syncing a pipeline from current directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 - Fix number of arguments for pipelines_create within the command_create function ([#3074](https://github.com/nf-core/tools/pull/3074))
 - Add bot action to update textual snapshots and write bot documentation ([#3102](https://github.com/nf-core/tools/pull/3102))
 - Update gitpod setup ([#3136](https://github.com/nf-core/tools/pull/3136))
+- fix syncing a pipeline from current directory ([#3143](https://github.com/nf-core/tools/pull/3143))
 
 ## Version updates
 

--- a/nf_core/pipelines/create/create.py
+++ b/nf_core/pipelines/create/create.py
@@ -70,6 +70,8 @@ class PipelineCreate:
                     self.config = CreateConfig(**config_yml["template"].model_dump())
                 else:
                     raise UserWarning("The template configuration was not provided in '.nf-core.yml'.")
+                # Update the output directory
+                self.config.outdir = outdir if outdir else Path().cwd()
             except (FileNotFoundError, UserWarning):
                 log.debug("The '.nf-core.yml' configuration file was not found.")
         elif (name and description and author) or (


### PR DESCRIPTION
When `nf-core pipelines sync` was run from the pipeline root directory, a new directory was created and all pipeline files deleted. This overrides the output directory to use the same used by the sync command when the template pipeline is created.