### PR TITLE
Linting: handle cases where the directory path contains the name of the component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Linting will now check if the schema is correct for the used validation plugin ([#3116])(https://github.com/nf-core/tools/pull/3116)
 - Linting will now check the use of the right validation plugin include statements in the workflow scripts ([#3116])(https://github.com/nf-core/tools/pull/3116)
 - Full linting for correct use of nf-schema and nf-validation ([#3116](https://github.com/nf-core/tools/pull/3116))
+- Handle cases where the directory path contains the name of the component ([#3147](https://github.com/nf-core/tools/pull/3147))
 
 ### Pipeline create command
 

--- a/nf_core/components/nfcore_component.py
+++ b/nf_core/components/nfcore_component.py
@@ -64,7 +64,12 @@ class NFCoreComponent:
             self.process_name = ""
             self.environment_yml: Optional[Path] = Path(self.component_dir, "environment.yml")
 
-            repo_dir = self.component_dir.parts[: self.component_dir.parts.index(self.component_name.split("/")[0])][-1]
+            name_index = (
+                len(self.component_dir.parts)
+                - 1
+                - self.component_dir.parts[::-1].index(self.component_name.split("/")[0])
+            )
+            repo_dir = self.component_dir.parts[:name_index][-1]
             self.org = repo_dir
             self.nftest_testdir = Path(self.component_dir, "tests")
             self.nftest_main_nf = Path(self.nftest_testdir, "main.nf.test")


### PR DESCRIPTION
When the path provided to the linting command contains the name of the component, the lining will fail.
This was reported by `nf-core/isoseq`, which includes a module with the same name as the pipeline, `isoseq`.
See [Slack discussion](https://nfcore.slack.com/archives/CE5LG7WMB/p1724653773276939)

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
