### PR TITLE
Fix issue where tool and subtool have the same name

### DIFF
--- a/nf_core/components/nfcore_component.py
+++ b/nf_core/components/nfcore_component.py
@@ -66,17 +66,13 @@ class NFCoreComponent:
 
             component_list = self.component_name.split("/")
 
-            name_index = (
-                len(self.component_dir.parts)
-                - 1
-                - self.component_dir.parts[::-1].index(component_list[0])
-            )
+            name_index = len(self.component_dir.parts) - 1 - self.component_dir.parts[::-1].index(component_list[0])
             if len(component_list) != 1 and component_list[0] == component_list[1]:
                 # Handle cases where the subtool has the same name as the tool
                 name_index -= 1
 
             repo_dir = self.component_dir.parts[:name_index][-1]
-            
+
             self.org = repo_dir
             self.nftest_testdir = Path(self.component_dir, "tests")
             self.nftest_main_nf = Path(self.nftest_testdir, "main.nf.test")

--- a/nf_core/components/nfcore_component.py
+++ b/nf_core/components/nfcore_component.py
@@ -64,12 +64,19 @@ class NFCoreComponent:
             self.process_name = ""
             self.environment_yml: Optional[Path] = Path(self.component_dir, "environment.yml")
 
+            component_list = self.component_name.split("/")
+
             name_index = (
                 len(self.component_dir.parts)
                 - 1
-                - self.component_dir.parts[::-1].index(self.component_name.split("/")[0])
+                - self.component_dir.parts[::-1].index(component_list[0])
             )
+            if len(component_list) != 1 and component_list[0] == component_list[1]:
+                # Handle cases where the subtool has the same name as the tool
+                name_index -= 1
+
             repo_dir = self.component_dir.parts[:name_index][-1]
+            
             self.org = repo_dir
             self.nftest_testdir = Path(self.component_dir, "tests")
             self.nftest_main_nf = Path(self.nftest_testdir, "main.nf.test")

--- a/tests/modules/test_lint.py
+++ b/tests/modules/test_lint.py
@@ -186,6 +186,15 @@ class TestModulesCreate(TestModules):
         assert len(module_lint.passed) > 0
         assert len(module_lint.warned) >= 0
 
+    def test_modules_lint_tabix_tabix(self):
+        """Test linting the tabix/tabix module"""
+        self.mods_install.install("tabix/tabix")
+        module_lint = nf_core.modules.lint.ModuleLint(directory=self.pipeline_dir)
+        module_lint.lint(print_results=False, module="tabix/tabix")
+        assert len(module_lint.failed) == 0, f"Linting failed with {[x.__dict__ for x in module_lint.failed]}"
+        assert len(module_lint.passed) > 0
+        assert len(module_lint.warned) >= 0
+
     def test_modules_lint_empty(self):
         """Test linting a pipeline with no modules installed"""
         self.mods_remove.remove("fastqc", force=True)


### PR DESCRIPTION
The linting on the current `dev` branch was failing with this error when it encountered a module where the tool and the subtool have the same name (`tabix/tabix`, `happy/happy`...):

```
LookupError: Could not find branch information for component 'happy/happy/happy'.Please remove the 'modules.json' and rerun the command to recreate it
```

@awgymer and I debugged and solved this like this. 
This PR checks if the tool and subtool have the same name and in that case it will move the org index one back so it will always pick the right name for the organization. 