### PR TITLE
Add --update-all flag to conda in Gitpod

### DIFF
--- a/nf_core/gitpod/gitpod.Dockerfile
+++ b/nf_core/gitpod/gitpod.Dockerfile
@@ -45,7 +45,7 @@ USER gitpod
 RUN conda config --add channels bioconda && \
     conda config --add channels conda-forge && \
     conda config --set channel_priority strict && \
-    conda install --quiet --yes --name base \
+    conda install --quiet --yes --update-all --name base \
     nextflow \
     nf-test \
     prettier \


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

By removing the conda defaults channel from the Dockerfile, the libmamba solver isn't correctly found after installation after package clean up.
This is fixed by using `--update-all` which updates all package dependencies based on defaults, to use conda-forge. Perhaps `defaults` is still part of the standard channels on installation.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
