### PR TITLE
Container cache download

### DIFF
--- a/nf_core/pipelines/download.py
+++ b/nf_core/pipelines/download.py
@@ -1086,7 +1086,7 @@ class DownloadWorkflow:
 
                 # Organise containers based on what we need to do with them
                 containers_exist: List[str] = []
-                containers_cache: List[Tuple[str, str, Optional[str]]] = []
+                containers_cache: List[Tuple[str, str, str]] = []
                 containers_download: List[Tuple[str, str, Optional[str]]] = []
                 containers_pull: List[Tuple[str, str, Optional[str]]] = []
                 for container in self.containers:
@@ -1283,15 +1283,13 @@ class DownloadWorkflow:
 
         return (out_path, cache_path)
 
-    def singularity_copy_cache_image(self, container: str, out_path: str, cache_path: Optional[str]) -> None:
+    def singularity_copy_cache_image(self, container: str, out_path: str, cache_path: str) -> None:
         """Copy Singularity image from NXF_SINGULARITY_CACHEDIR to target folder."""
-        # Copy to destination folder if we have a cached version
-        if cache_path and os.path.exists(cache_path):
-            log.debug(f"Copying {container} from cache: '{os.path.basename(out_path)}'")
-            shutil.copyfile(cache_path, out_path)
-            # Create symlinks to ensure that the images are found even with different registries being used.
-            self.symlink_singularity_images(cache_path)
-            self.symlink_singularity_images(out_path)
+        log.debug(f"Copying {container} from cache: '{os.path.basename(out_path)}'")
+        shutil.copyfile(cache_path, out_path)
+        # Create symlinks to ensure that the images are found even with different registries being used.
+        self.symlink_singularity_images(cache_path)
+        self.symlink_singularity_images(out_path)
 
     def singularity_download_image(
         self, container: str, out_path: str, cache_path: Optional[str], progress: DownloadProgress

--- a/nf_core/pipelines/download.py
+++ b/nf_core/pipelines/download.py
@@ -1290,6 +1290,7 @@ class DownloadWorkflow:
             log.debug(f"Copying {container} from cache: '{os.path.basename(out_path)}'")
             shutil.copyfile(cache_path, out_path)
             # Create symlinks to ensure that the images are found even with different registries being used.
+            self.symlink_singularity_images(cache_path)
             self.symlink_singularity_images(out_path)
 
     def singularity_download_image(
@@ -1346,6 +1347,8 @@ class DownloadWorkflow:
                 log.debug(f"Copying {container} to cache: '{os.path.basename(out_path)}'")
                 progress.update(task, description="Copying from target directory to cache")
                 shutil.copyfile(out_path, cache_path)
+                # Create symlinks to ensure that the images are found even with different registries being used.
+                self.symlink_singularity_images(cache_path)
 
             # Create symlinks to ensure that the images are found even with different registries being used.
             self.symlink_singularity_images(out_path)
@@ -1455,6 +1458,8 @@ class DownloadWorkflow:
             log.debug(f"Copying {container} to cache: '{os.path.basename(out_path)}'")
             progress.update(task, current_log="Copying from target directory to cache")
             shutil.copyfile(out_path, cache_path)
+            # Create symlinks to ensure that the images are found even with different registries being used.
+            self.symlink_singularity_images(cache_path)
 
         # Create symlinks to ensure that the images are found even with different registries being used.
         self.symlink_singularity_images(out_path)


### PR DESCRIPTION
Fixes #3019 and #3162.

First #3162. The code has to deal with an `out_path` (always defined) and sometimes a `cache_path` too. The implementation was slightly convoluted as it was doing fresh downloads into the `cache_path` or `out_path` (first decision point) and then doing an extra copy if needed (second decision point). Because of that confusion, symlinks across container registries were not all created across both locations.
I propose to reverse the logic to make it more straightforward:

1. Always download into `out_path` and create its symlinks.
2. Then, optionally copy to `cache_path` (and create symlinks there).

Then, #3019: I propose to handle the singularity "library" directory this way:

1. Just like in Nextflow itself, it's considered a read-only location. It means that containers can only be copied _from_ it, not _to_ it, and that we shouldn't be even creating symlinks there.
2. There is no point in having a `--container-library-utilisation` parameter for the library because i) `remote` would be redundant with the `--container-cache-utilisation`'s `remote` mode, ii) `amend` is not possible as per the read-only rule, so iii) `copy` is the only possible mode.
3. Therefore, the most natural place to use the library is as a _source_ of containers, in parallel of https downloads and `singularity pull`. When `NXF_SINGULARITY_LIBRARYDIR` is set and the container exists in the library, it is copied to the target directories (`out_path` and possibly `cache_path` too)

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] Unit-tests
- [ ] Documentation in `README.md`
