### PR TITLE
Pipeline template: Modify download test action to capture the number of containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Remove if/else block to include `igenomes.config` ([#3168](https://github.com/nf-core/tools/pull/3168))
 - Fixed release announcement hashtags for Mastodon ([#3099](https://github.com/nf-core/tools/pull/3176))
 - Remove try/catch blocks from `nextflow.config` ([#3167](https://github.com/nf-core/tools/pull/3167))
+- Extend `download_pipeline.yml` to count pre-downloaded container images. ([#3182](https://github.com/nf-core/tools/pull/3182))
 
 ### Linting
 

--- a/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
+++ b/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
@@ -54,33 +54,60 @@ jobs:
           echo "REPOTITLE_LOWERCASE=$(basename ${GITHUB_REPOSITORY,,})" >> ${GITHUB_ENV}
           echo "{% raw %}REPO_BRANCH=${{ github.event.inputs.testbranch || 'dev' }}" >> ${GITHUB_ENV}
 
+      - name: Make a cache directory for the container images
+        run: |
+          mkdir -p ./singularity_container_images
+
       - name: Download the pipeline
         env:
-          NXF_SINGULARITY_CACHEDIR: ./
+          NXF_SINGULARITY_CACHEDIR: ./singularity_container_images
         run: |
           nf-core pipelines download ${{ env.REPO_LOWERCASE }} \
           --revision ${{ env.REPO_BRANCH }} \
           --outdir ./${{ env.REPOTITLE_LOWERCASE }} \
           --compress "none" \
           --container-system 'singularity' \
-          --container-library "quay.io" -l "docker.io" -l "ghcr.io" \
+          --container-library "quay.io" -l "docker.io" -l "ghcr.io" -l "community.wave.seqera.io" \
           --container-cache-utilisation 'amend' \
           --download-configuration 'yes'
 
       - name: Inspect download
         run: tree ./${{ env.REPOTITLE_LOWERCASE }}{% endraw %}{% if test_config %}{% raw %}
 
+      - name: Count the downloaded number of container images
+        id: count_initial
+        run: |
+          image_count=$(ls -1 ./singularity_container_images | wc -l)
+          echo "Initial container image count: $image_count"
+          echo "IMAGE_COUNT_INITIAL=$image_count" >> ${GITHUB_ENV}
+
       - name: Run the downloaded pipeline (stub)
         id: stub_run_pipeline
         continue-on-error: true
         env:
-          NXF_SINGULARITY_CACHEDIR: ./
+          NXF_SINGULARITY_CACHEDIR: ./singularity_container_images
           NXF_SINGULARITY_HOME_MOUNT: true
         run: nextflow run ./${{ env.REPOTITLE_LOWERCASE }}/$( sed 's/\W/_/g' <<< ${{ env.REPO_BRANCH }}) -stub -profile test,singularity --outdir ./results
       - name: Run the downloaded pipeline (stub run not supported)
         id: run_pipeline
         if: ${{ job.steps.stub_run_pipeline.status == failure() }}
         env:
-          NXF_SINGULARITY_CACHEDIR: ./
+          NXF_SINGULARITY_CACHEDIR: ./singularity_container_images
           NXF_SINGULARITY_HOME_MOUNT: true
         run: nextflow run ./${{ env.REPOTITLE_LOWERCASE }}/$( sed 's/\W/_/g' <<< ${{ env.REPO_BRANCH }}) -profile test,singularity --outdir ./results{% endraw %}{% endif %}
+
+      - name: Count the downloaded number of container images
+        id: count_afterwards
+        run: |
+          image_count=$(ls -1 ./singularity_container_images | wc -l)
+          echo "Post-pipeline container image count: $image_count"
+          echo "IMAGE_COUNT_AFTER=$image_count" >> ${GITHUB_ENV}
+
+      - name: Compare container image counts
+        run: |
+          if [ "${{ env.IMAGE_COUNT_INITIAL }}" -ne "${{ env.IMAGE_COUNT_AFTER }}" ]; then
+            echo "The number of container images has changed. The pipeline has no support for offline runs!"
+            exit 1
+          else
+            echo "The pipeline can be downloaded successfully!"
+          fi

--- a/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
+++ b/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
@@ -39,9 +39,11 @@ jobs:
         with:
           python-version: "3.12"
           architecture: "x64"
-      - uses: eWaterCycle/setup-singularity@931d4e31109e875b13309ae1d07c70ca8fbc8537 # v7
+
+      - name: Setup Apptainer
+        uses: eWaterCycle/setup-apptainer@4bb22c52d4f63406c49e94c804632975787312b3 # v2.0.0
         with:
-          singularity-version: 3.8.3
+          apptainer-version: 1.3.4
 
       - name: Install dependencies
         run: |
@@ -77,7 +79,7 @@ jobs:
       - name: Count the downloaded number of container images
         id: count_initial
         run: |
-          image_count=$(ls -1 ./singularity_container_images | wc -l)
+          image_count=$(ls -1 ./singularity_container_images | wc -l | xargs)
           echo "Initial container image count: $image_count"
           echo "IMAGE_COUNT_INITIAL=$image_count" >> ${GITHUB_ENV}
 
@@ -99,15 +101,18 @@ jobs:
       - name: Count the downloaded number of container images
         id: count_afterwards
         run: |
-          image_count=$(ls -1 ./singularity_container_images | wc -l)
-          echo "Post-pipeline container image count: $image_count"
+          image_count=$(ls -1 ./singularity_container_images | wc -l | xargs)
+          echo "Post-pipeline run container image count: $image_count"
           echo "IMAGE_COUNT_AFTER=$image_count" >> ${GITHUB_ENV}
 
       - name: Compare container image counts
         run: |
+          {% raw %}
           if [ "${{ env.IMAGE_COUNT_INITIAL }}" -ne "${{ env.IMAGE_COUNT_AFTER }}" ]; then
-            echo "The number of container images has changed. The pipeline has no support for offline runs!"
+            echo "$(expr ${{ env.IMAGE_COUNT_AFTER }}-${{ env.IMAGE_COUNT_INITIAL }}) additional container images were \n downloaded at runtime . The pipeline has no support for offline runs!"
+            tree ./singularity_container_images
             exit 1
           else
             echo "The pipeline can be downloaded successfully!"
           fi
+          {% endraw %}

--- a/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
+++ b/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
@@ -69,7 +69,7 @@ jobs:
           --outdir ./${{ env.REPOTITLE_LOWERCASE }} \
           --compress "none" \
           --container-system 'singularity' \
-          --container-library "quay.io" -l "docker.io" -l "ghcr.io" -l "community.wave.seqera.io" \
+          --container-library "quay.io" -l "docker.io" -l "community.wave.seqera.io" \
           --container-cache-utilisation 'amend' \
           --download-configuration 'yes'
 
@@ -109,7 +109,10 @@ jobs:
         run: |
           {% raw %}
           if [ "${{ env.IMAGE_COUNT_INITIAL }}" -ne "${{ env.IMAGE_COUNT_AFTER }}" ]; then
-            echo "$(expr ${{ env.IMAGE_COUNT_AFTER }}-${{ env.IMAGE_COUNT_INITIAL }}) additional container images were \n downloaded at runtime . The pipeline has no support for offline runs!"
+            initial_count=${{ env.IMAGE_COUNT_INITIAL }}
+            final_count=${{ env.IMAGE_COUNT_AFTER }}
+            difference=$((final_count - initial_count))
+            echo "$difference additional container images were \n downloaded at runtime . The pipeline has no support for offline runs!"
             tree ./singularity_container_images
             exit 1
           else

--- a/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
+++ b/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
@@ -74,7 +74,7 @@ jobs:
           --download-configuration 'yes'
 
       - name: Inspect download
-        run: tree ./${{ env.REPOTITLE_LOWERCASE }}{% if test_config %}
+        run: tree ./${{ env.REPOTITLE_LOWERCASE }}{% endraw %}{% if test_config %}{% raw %}
 
       - name: Count the downloaded number of container images
         id: count_initial
@@ -117,4 +117,4 @@ jobs:
           else
             echo "The pipeline can be downloaded successfully!"
           fi
-          {% endif %}{% endraw %}
+          {% endraw %}{% endif %}

--- a/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
+++ b/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
@@ -74,7 +74,7 @@ jobs:
           --download-configuration 'yes'
 
       - name: Inspect download
-        run: tree ./${{ env.REPOTITLE_LOWERCASE }}{% endraw %}{% if test_config %}{% raw %}
+        run: tree ./${{ env.REPOTITLE_LOWERCASE }}{% if test_config %}
 
       - name: Count the downloaded number of container images
         id: count_initial
@@ -96,7 +96,7 @@ jobs:
         env:
           NXF_SINGULARITY_CACHEDIR: ./singularity_container_images
           NXF_SINGULARITY_HOME_MOUNT: true
-        run: nextflow run ./${{ env.REPOTITLE_LOWERCASE }}/$( sed 's/\W/_/g' <<< ${{ env.REPO_BRANCH }}) -profile test,singularity --outdir ./results{% endraw %}{% endif %}
+        run: nextflow run ./${{ env.REPOTITLE_LOWERCASE }}/$( sed 's/\W/_/g' <<< ${{ env.REPO_BRANCH }}) -profile test,singularity --outdir ./results
 
       - name: Count the downloaded number of container images
         id: count_afterwards
@@ -107,7 +107,6 @@ jobs:
 
       - name: Compare container image counts
         run: |
-          {% raw %}
           if [ "${{ env.IMAGE_COUNT_INITIAL }}" -ne "${{ env.IMAGE_COUNT_AFTER }}" ]; then
             initial_count=${{ env.IMAGE_COUNT_INITIAL }}
             final_count=${{ env.IMAGE_COUNT_AFTER }}
@@ -118,4 +117,4 @@ jobs:
           else
             echo "The pipeline can be downloaded successfully!"
           fi
-          {% endraw %}
+          {% endif %}{% endraw %}


### PR DESCRIPTION
The Download Test fails, if there are obvious issues while downloading a pipeline, e.g. `nf-core pipeline download` errors out. 

But it did not assert that all required containers were downloaded.  Since it is impossible to take Github Action Runners offline for a certain step, it is quite difficult to test, if a pipeline would actually run offline.

But because Nextflow will pull container images at runtime that have not been downloaded correctly, the number of container images in the `$NXF_SINGULARITY_CACHEDIR` will change and this can be captured in the test.

[I have been testing that action in my fork of the testpipeline](https://github.com/MatthiasZepper/nfcore-testpipeline/actions/runs/11050968634) after manually removing the `{%raw%}` markup, but maybe there is a better way?

**PS: I have been adding the `{%raw%} `markup mannually to the new steps. I have no idea if the new steps should also be wrapped in the `{% if test_config %}` or not.**

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
