### PR TITLE
Fix nf-core pipelines sync

### DIFF
--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -1815,6 +1815,7 @@ def command_create_logo(logo_text, directory, name, theme, width, format, force)
 
 # nf-core sync (deprecated)
 @nf_core_cli.command("sync", hidden=True, deprecated=True)
+@click.pass_context
 @click.option(
     "-d",
     "--dir",
@@ -1845,14 +1846,14 @@ def command_create_logo(logo_text, directory, name, theme, width, format, force)
 @click.option("-g", "--github-repository", type=str, help="GitHub PR: target repository.")
 @click.option("-u", "--username", type=str, help="GitHub PR: auth username.")
 @click.option("-t", "--template-yaml", help="Pass a YAML file to customize the template")
-def command_sync(directory, from_branch, pull_request, github_repository, username, template_yaml, force_pr):
+def command_sync(ctx, directory, from_branch, pull_request, github_repository, username, template_yaml, force_pr):
     """
     Use `nf-core pipelines sync` instead.
     """
     log.warning(
         "The `[magenta]nf-core sync[/]` command is deprecated. Use `[magenta]nf-core pipelines sync[/]` instead."
     )
-    pipelines_sync(directory, from_branch, pull_request, github_repository, username, template_yaml, force_pr)
+    pipelines_sync(ctx, directory, from_branch, pull_request, github_repository, username, template_yaml, force_pr)
 
 
 # nf-core bump-version (deprecated)

--- a/nf_core/pipelines/create/create.py
+++ b/nf_core/pipelines/create/create.py
@@ -182,7 +182,7 @@ class PipelineCreate:
             self.config.force = force if force else False
         if self.config.outdir is None:
             self.config.outdir = outdir if outdir else "."
-        if self.config.is_nfcore is None:
+        if self.config.is_nfcore is None or self.config.is_nfcore == "null":
             self.config.is_nfcore = self.config.org == "nf-core"
 
     def obtain_jinja_params_dict(
@@ -363,11 +363,9 @@ class PipelineCreate:
             config_fn, config_yml = nf_core.utils.load_tools_config(self.outdir)
             if config_fn is not None and config_yml is not None:
                 with open(str(config_fn), "w") as fh:
-                    self.config.outdir = str(self.config.outdir)
                     config_yml.template = NFCoreTemplateConfig(**self.config.model_dump())
                     yaml.safe_dump(config_yml.model_dump(), fh)
                     log.debug(f"Dumping pipeline template yml to pipeline config file '{config_fn.name}'")
-                    run_prettier_on_file(self.outdir / config_fn)
 
         # Run prettier on files
         run_prettier_on_file(self.outdir)
@@ -400,8 +398,6 @@ class PipelineCreate:
             nf_core_yml.lint = cast(LintConfigType, lint_config)
             with open(self.outdir / config_fn, "w") as fh:
                 yaml.dump(nf_core_yml.model_dump(), fh, default_flow_style=False, sort_keys=False)
-
-            run_prettier_on_file(Path(self.outdir, config_fn))
 
     def make_pipeline_logo(self):
         """Fetch a logo for the new pipeline from the nf-core website"""

--- a/nf_core/pipelines/download.py
+++ b/nf_core/pipelines/download.py
@@ -746,7 +746,7 @@ class DownloadWorkflow:
                     self.nf_config is needed, because we need to restart search over raw input
                     if no proper container matches are found.
                     """
-                    config_findings.append((k, v.strip('"').strip("'"), self.nf_config, "Nextflow configs"))
+                    config_findings.append((k, v.strip("'\""), self.nf_config, "Nextflow configs"))
 
         # rectify the container paths found in the config
         # Raw config_findings may yield multiple containers, so better create a shallow copy of the list, since length of input and output may be different ?!?

--- a/nf_core/pipelines/schema.py
+++ b/nf_core/pipelines/schema.py
@@ -71,7 +71,7 @@ class PipelineSchema:
         else:
             conf = nf_core.utils.fetch_wf_config(Path(self.pipeline_dir))
 
-        plugins = str(conf.get("plugins", "")).strip('"').strip("'").strip(" ").split(",")
+        plugins = str(conf.get("plugins", "")).strip("'\"").strip(" ").split(",")
         plugin_found = False
         for plugin_instance in plugins:
             if "nf-schema" in plugin_instance:
@@ -373,7 +373,7 @@ class PipelineSchema:
         # If we have a default in the schema, check it matches the config
         if "default" in schema_param and (
             (schema_param["type"] == "boolean" and str(config_default).lower() != str(schema_param["default"]).lower())
-            and (str(schema_param["default"]) != str(config_default).strip('"').strip("'"))
+            and (str(schema_param["default"]) != str(config_default).strip("'\""))
         ):
             # Check that we are not deferring the execution of this parameter in the schema default with squiggly brakcets
             if schema_param["type"] != "string" or "{" not in schema_param["default"]:

--- a/nf_core/pipelines/sync.py
+++ b/nf_core/pipelines/sync.py
@@ -273,17 +273,23 @@ class PipelineSync:
                 yaml.safe_dump(self.config_yml.model_dump(), config_path)
 
         try:
-            nf_core.pipelines.create.create.PipelineCreate(
+            pipeline_create_obj = nf_core.pipelines.create.create.PipelineCreate(
                 outdir=str(self.pipeline_dir),
                 from_config_file=True,
                 no_git=True,
                 force=True,
-            ).init_pipeline()
+            )
+            pipeline_create_obj.init_pipeline()
 
             # set force to false to avoid overwriting files in the future
             if self.config_yml.template is not None:
+                self.config_yml.template = pipeline_create_obj.config
                 # Set force true in config to overwrite existing files
                 self.config_yml.template.force = False
+                # Set outdir as the current directory to avoid local info leaking
+                self.config_yml.template.outdir = "."
+                # Update nf-core version
+                self.config_yml.nf_core_version = nf_core.__version__
                 with open(self.config_yml_path, "w") as config_path:
                     yaml.safe_dump(self.config_yml.model_dump(), config_path)
 

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -1136,52 +1136,53 @@ def load_tools_config(directory: Union[str, Path] = ".") -> Tuple[Optional[Path]
             error_message += f"\n{error['loc'][0]}: {error['msg']}"
         raise AssertionError(error_message)
 
-    # Retrieve information if template from config file is empty
-    wf_config = fetch_wf_config(Path(directory))
-    config_template_keys = tools_config["template"].keys() if "template" in tools_config else []
-    if nf_core_yaml_config.template is None:
-        # The .nf-core.yml file did not contain template information
-        nf_core_yaml_config.template = NFCoreTemplateConfig(
-            org="nf-core",
-            name=wf_config["manifest.name"].strip('"').strip("'").split("/")[-1],
-            description=wf_config["manifest.description"].strip('"').strip("'"),
-            author=wf_config["manifest.author"].strip('"').strip("'"),
-            version=wf_config["manifest.version"].strip('"').strip("'"),
-            outdir=str(directory),
-            is_nfcore=True,
-        )
-    elif "prefix" in config_template_keys or "skip" in config_template_keys:
-        # The .nf-core.yml file contained the old prefix or skip keys
-        nf_core_yaml_config.template = NFCoreTemplateConfig(
-            org=tools_config["template"]["prefix"]
-            if "prefix" in config_template_keys
-            else tools_config["template"]["org"]
-            if "org" in config_template_keys
-            else "nf-core",
-            name=tools_config["template"]["name"]
-            if "name" in config_template_keys
-            else wf_config["manifest.name"].strip('"').strip("'").split("/")[-1],
-            description=tools_config["template"]["description"]
-            if "description" in config_template_keys
-            else wf_config["manifest.description"].strip('"').strip("'"),
-            author=tools_config["template"]["author"]
-            if "author" in config_template_keys
-            else wf_config["manifest.author"].strip('"').strip("'"),
-            version=tools_config["template"]["version"]
-            if "version" in config_template_keys
-            else wf_config["manifest.version"].strip('"').strip("'"),
-            outdir=tools_config["template"]["outdir"] if "outdir" in config_template_keys else str(directory),
-            skip_features=tools_config["template"]["skip"]
-            if "skip" in config_template_keys
-            else tools_config["template"]["skip_features"]
-            if "skip_features" in config_template_keys
-            else None,
-            is_nfcore=tools_config["template"]["prefix"] == "nf-core"
-            if "prefix" in config_template_keys
-            else tools_config["template"]["org"] == "nf-core"
-            if "org" in config_template_keys
-            else True,
-        )
+    if nf_core_yaml_config["repository_type"] == "pipeline":
+        # Retrieve information if template from config file is empty
+        wf_config = fetch_wf_config(Path(directory))
+        config_template_keys = tools_config["template"].keys() if "template" in tools_config else []
+        if nf_core_yaml_config.template is None:
+            # The .nf-core.yml file did not contain template information
+            nf_core_yaml_config.template = NFCoreTemplateConfig(
+                org="nf-core",
+                name=wf_config["manifest.name"].strip('"').strip("'").split("/")[-1],
+                description=wf_config["manifest.description"].strip('"').strip("'"),
+                author=wf_config["manifest.author"].strip('"').strip("'"),
+                version=wf_config["manifest.version"].strip('"').strip("'"),
+                outdir=str(directory),
+                is_nfcore=True,
+            )
+        elif "prefix" in config_template_keys or "skip" in config_template_keys:
+            # The .nf-core.yml file contained the old prefix or skip keys
+            nf_core_yaml_config.template = NFCoreTemplateConfig(
+                org=tools_config["template"]["prefix"]
+                if "prefix" in config_template_keys
+                else tools_config["template"]["org"]
+                if "org" in config_template_keys
+                else "nf-core",
+                name=tools_config["template"]["name"]
+                if "name" in config_template_keys
+                else wf_config["manifest.name"].strip('"').strip("'").split("/")[-1],
+                description=tools_config["template"]["description"]
+                if "description" in config_template_keys
+                else wf_config["manifest.description"].strip('"').strip("'"),
+                author=tools_config["template"]["author"]
+                if "author" in config_template_keys
+                else wf_config["manifest.author"].strip('"').strip("'"),
+                version=tools_config["template"]["version"]
+                if "version" in config_template_keys
+                else wf_config["manifest.version"].strip('"').strip("'"),
+                outdir=tools_config["template"]["outdir"] if "outdir" in config_template_keys else str(directory),
+                skip_features=tools_config["template"]["skip"]
+                if "skip" in config_template_keys
+                else tools_config["template"]["skip_features"]
+                if "skip_features" in config_template_keys
+                else None,
+                is_nfcore=tools_config["template"]["prefix"] == "nf-core"
+                if "prefix" in config_template_keys
+                else tools_config["template"]["org"] == "nf-core"
+                if "org" in config_template_keys
+                else True,
+            )
 
     log.debug("Using config file: %s", config_fn)
     return config_fn, nf_core_yaml_config

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -1136,6 +1136,45 @@ def load_tools_config(directory: Union[str, Path] = ".") -> Tuple[Optional[Path]
             error_message += f"\n{error['loc'][0]}: {error['msg']}"
         raise AssertionError(error_message)
 
+    # Retrieve information if template from config file is empty
+    wf_config = fetch_wf_config(Path(directory))
+    config_template_keys = tools_config["template"].keys() if "template" in tools_config else []
+    if nf_core_yaml_config.template is None:
+        # The .nf-core.yml file did not contain template information
+        nf_core_yaml_config.template = NFCoreTemplateConfig(
+            org="nf-core",
+            name=wf_config["manifest.name"].strip('"').strip("'").split("/")[-1],
+            description=wf_config["manifest.description"].strip('"').strip("'"),
+            author=wf_config["manifest.author"].strip('"').strip("'"),
+            version=wf_config["manifest.version"].strip('"').strip("'"),
+            outdir=str(directory),
+        )
+    elif "prefix" in config_template_keys or "skip" in config_template_keys:
+        # The .nf-core.yml file contained the old prefix or skip keys
+        nf_core_yaml_config.template = NFCoreTemplateConfig(
+            org=tools_config["template"]["prefix"]
+            if "prefix" in config_template_keys
+            else tools_config["template"]["org"] or "nf-core",
+            name=tools_config["template"]["name"]
+            if "name" in config_template_keys
+            else wf_config["manifest.name"].strip('"').strip("'").split("/")[-1],
+            description=tools_config["template"]["description"]
+            if "description" in config_template_keys
+            else wf_config["manifest.description"].strip('"').strip("'"),
+            author=tools_config["template"]["author"]
+            if "author" in config_template_keys
+            else wf_config["manifest.author"].strip('"').strip("'"),
+            version=tools_config["template"]["version"]
+            if "version" in config_template_keys
+            else wf_config["manifest.version"].strip('"').strip("'"),
+            outdir=tools_config["template"]["outdir"] if "outdir" in config_template_keys else str(directory),
+            skip_features=tools_config["template"]["skip"]
+            if "skip" in config_template_keys
+            else tools_config["template"]["skip_features"]
+            if "skip_features" in config_template_keys
+            else None,
+        )
+
     log.debug("Using config file: %s", config_fn)
     return config_fn, nf_core_yaml_config
 

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -1139,11 +1139,7 @@ def load_tools_config(directory: Union[str, Path] = ".") -> Tuple[Optional[Path]
     wf_config = fetch_wf_config(Path(directory))
     if nf_core_yaml_config["repository_type"] == "pipeline" and wf_config:
         # Retrieve information if template from config file is empty
-        config_template_keys = (
-            tools_config["template"].keys()
-            if "template" in tools_config and tools_config["template"] is not None
-            else []
-        )
+       config_template_keys = tools_config.get('template', {}).keys()
         if nf_core_yaml_config.template is None:
             # The .nf-core.yml file did not contain template information
             nf_core_yaml_config.template = NFCoreTemplateConfig(

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -1139,7 +1139,11 @@ def load_tools_config(directory: Union[str, Path] = ".") -> Tuple[Optional[Path]
     if nf_core_yaml_config["repository_type"] == "pipeline":
         # Retrieve information if template from config file is empty
         wf_config = fetch_wf_config(Path(directory))
-        config_template_keys = tools_config["template"].keys() if "template" in tools_config else []
+        config_template_keys = (
+            tools_config["template"].keys()
+            if "template" in tools_config and tools_config["template"] is not None
+            else []
+        )
         if nf_core_yaml_config.template is None:
             # The .nf-core.yml file did not contain template information
             nf_core_yaml_config.template = NFCoreTemplateConfig(

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -1139,7 +1139,8 @@ def load_tools_config(directory: Union[str, Path] = ".") -> Tuple[Optional[Path]
     wf_config = fetch_wf_config(Path(directory))
     if nf_core_yaml_config["repository_type"] == "pipeline" and wf_config:
         # Retrieve information if template from config file is empty
-        config_template_keys = tools_config.get("template", {}).keys()
+        template = tools_config.get("template")
+        config_template_keys = template.keys() if template is not None else []
         if nf_core_yaml_config.template is None:
             # The .nf-core.yml file did not contain template information
             nf_core_yaml_config.template = NFCoreTemplateConfig(

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -1136,9 +1136,9 @@ def load_tools_config(directory: Union[str, Path] = ".") -> Tuple[Optional[Path]
             error_message += f"\n{error['loc'][0]}: {error['msg']}"
         raise AssertionError(error_message)
 
-    if nf_core_yaml_config["repository_type"] == "pipeline":
+    wf_config = fetch_wf_config(Path(directory))
+    if nf_core_yaml_config["repository_type"] == "pipeline" and wf_config != {}:
         # Retrieve information if template from config file is empty
-        wf_config = fetch_wf_config(Path(directory))
         config_template_keys = (
             tools_config["template"].keys()
             if "template" in tools_config and tools_config["template"] is not None

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -1148,13 +1148,16 @@ def load_tools_config(directory: Union[str, Path] = ".") -> Tuple[Optional[Path]
             author=wf_config["manifest.author"].strip('"').strip("'"),
             version=wf_config["manifest.version"].strip('"').strip("'"),
             outdir=str(directory),
+            is_nfcore=True,
         )
     elif "prefix" in config_template_keys or "skip" in config_template_keys:
         # The .nf-core.yml file contained the old prefix or skip keys
         nf_core_yaml_config.template = NFCoreTemplateConfig(
             org=tools_config["template"]["prefix"]
             if "prefix" in config_template_keys
-            else tools_config["template"]["org"] or "nf-core",
+            else tools_config["template"]["org"]
+            if "org" in config_template_keys
+            else "nf-core",
             name=tools_config["template"]["name"]
             if "name" in config_template_keys
             else wf_config["manifest.name"].strip('"').strip("'").split("/")[-1],
@@ -1173,6 +1176,11 @@ def load_tools_config(directory: Union[str, Path] = ".") -> Tuple[Optional[Path]
             else tools_config["template"]["skip_features"]
             if "skip_features" in config_template_keys
             else None,
+            is_nfcore=tools_config["template"]["prefix"] == "nf-core"
+            if "prefix" in config_template_keys
+            else tools_config["template"]["org"] == "nf-core"
+            if "org" in config_template_keys
+            else True,
         )
 
     log.debug("Using config file: %s", config_fn)

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -1137,7 +1137,7 @@ def load_tools_config(directory: Union[str, Path] = ".") -> Tuple[Optional[Path]
         raise AssertionError(error_message)
 
     wf_config = fetch_wf_config(Path(directory))
-    if nf_core_yaml_config["repository_type"] == "pipeline" and wf_config != {}:
+    if nf_core_yaml_config["repository_type"] == "pipeline" and wf_config:
         # Retrieve information if template from config file is empty
         config_template_keys = (
             tools_config["template"].keys()

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -1154,34 +1154,14 @@ def load_tools_config(directory: Union[str, Path] = ".") -> Tuple[Optional[Path]
         elif "prefix" in config_template_keys or "skip" in config_template_keys:
             # The .nf-core.yml file contained the old prefix or skip keys
             nf_core_yaml_config.template = NFCoreTemplateConfig(
-                org=tools_config["template"]["prefix"]
-                if "prefix" in config_template_keys
-                else tools_config["template"]["org"]
-                if "org" in config_template_keys
-                else "nf-core",
-                name=tools_config["template"]["name"]
-                if "name" in config_template_keys
-                else wf_config["manifest.name"].strip("'\"").split("/")[-1],
-                description=tools_config["template"]["description"]
-                if "description" in config_template_keys
-                else wf_config["manifest.description"].strip("'\""),
-                author=tools_config["template"]["author"]
-                if "author" in config_template_keys
-                else wf_config["manifest.author"].strip("'\""),
-                version=tools_config["template"]["version"]
-                if "version" in config_template_keys
-                else wf_config["manifest.version"].strip("'\""),
-                outdir=tools_config["template"]["outdir"] if "outdir" in config_template_keys else str(directory),
-                skip_features=tools_config["template"]["skip"]
-                if "skip" in config_template_keys
-                else tools_config["template"]["skip_features"]
-                if "skip_features" in config_template_keys
-                else None,
-                is_nfcore=tools_config["template"]["prefix"] == "nf-core"
-                if "prefix" in config_template_keys
-                else tools_config["template"]["org"] == "nf-core"
-                if "org" in config_template_keys
-                else True,
+                org=tools_config["template"].get("prefix", tools_config["template"].get("org", "nf-core")),
+                name=tools_config["template"].get("name", wf_config["manifest.name"].strip("'\"").split("/")[-1]),
+                description=tools_config["template"].get("description", wf_config["manifest.description"].strip("'\"")),
+                author=tools_config["template"].get("author", wf_config["manifest.author"].strip("'\"")),
+                version=tools_config["template"].get("version", wf_config["manifest.version"].strip("'\"")),
+                outdir=tools_config["template"].get("outdir", str(directory)),
+                skip_features=tools_config["template"].get("skip", tools_config["template"].get("skip_features")),
+                is_nfcore=tools_config["template"].get("prefix", tools_config["template"].get("org")) == "nf-core",
             )
 
     log.debug("Using config file: %s", config_fn)

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -1139,15 +1139,15 @@ def load_tools_config(directory: Union[str, Path] = ".") -> Tuple[Optional[Path]
     wf_config = fetch_wf_config(Path(directory))
     if nf_core_yaml_config["repository_type"] == "pipeline" and wf_config:
         # Retrieve information if template from config file is empty
-       config_template_keys = tools_config.get('template', {}).keys()
+        config_template_keys = tools_config.get("template", {}).keys()
         if nf_core_yaml_config.template is None:
             # The .nf-core.yml file did not contain template information
             nf_core_yaml_config.template = NFCoreTemplateConfig(
                 org="nf-core",
-                name=wf_config["manifest.name"].strip('"').strip("'").split("/")[-1],
-                description=wf_config["manifest.description"].strip('"').strip("'"),
-                author=wf_config["manifest.author"].strip('"').strip("'"),
-                version=wf_config["manifest.version"].strip('"').strip("'"),
+                name=wf_config["manifest.name"].strip("'\"").split("/")[-1],
+                description=wf_config["manifest.description"].strip("'\""),
+                author=wf_config["manifest.author"].strip("'\""),
+                version=wf_config["manifest.version"].strip("'\""),
                 outdir=str(directory),
                 is_nfcore=True,
             )
@@ -1161,16 +1161,16 @@ def load_tools_config(directory: Union[str, Path] = ".") -> Tuple[Optional[Path]
                 else "nf-core",
                 name=tools_config["template"]["name"]
                 if "name" in config_template_keys
-                else wf_config["manifest.name"].strip('"').strip("'").split("/")[-1],
+                else wf_config["manifest.name"].strip("'\"").split("/")[-1],
                 description=tools_config["template"]["description"]
                 if "description" in config_template_keys
-                else wf_config["manifest.description"].strip('"').strip("'"),
+                else wf_config["manifest.description"].strip("'\""),
                 author=tools_config["template"]["author"]
                 if "author" in config_template_keys
-                else wf_config["manifest.author"].strip('"').strip("'"),
+                else wf_config["manifest.author"].strip("'\""),
                 version=tools_config["template"]["version"]
                 if "version" in config_template_keys
-                else wf_config["manifest.version"].strip('"').strip("'"),
+                else wf_config["manifest.version"].strip("'\""),
                 outdir=tools_config["template"]["outdir"] if "outdir" in config_template_keys else str(directory),
                 skip_features=tools_config["template"]["skip"]
                 if "skip" in config_template_keys


### PR DESCRIPTION
The old `nf-core sync` command was crashing, now it is fixed.

The new `nf-core pipelines sync` command was not taking into account the template information from `.nf-core.yml` and was also crashing for pipelines without the template information. Now it uses this info to sync a pipeline.

Testing PRs syncing nf-core and custom pipelines can be found here: [nf-core](https://github.com/mirpedrol/plainnfcore/pull/3) and [custom](https://github.com/mirpedrol/customnonnfcoresync/pull/2/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) and [custom with a new modification](https://github.com/mirpedrol/customnofastqc/pull/1/files#diff-2343acd64c297a361acf758556f3f7f7d9c5862a6841db803937b2eb5aaa1ec7)