### PR TITLE
Template: Do not assume pipeline name is url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Template
 
+- Do not assume pipeline name is url ([#3225](https://github.com/nf-core/tools/pull/3225))
+
 ### Download
 
 ### Linting

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -272,7 +272,7 @@ validation {
     defaultIgnoreParams = ["genomes"]
     help {
         enabled = true
-        command = "nextflow run $manifest.name -profile <docker/singularity/.../institute> --input samplesheet.csv --outdir <OUTDIR>"
+        command = "nextflow run {{ name }} -profile <docker/singularity/.../institute> --input samplesheet.csv --outdir <OUTDIR>"
         fullParameter = "help_full"
         showHiddenParameter = "show_hidden"
         {% if is_nfcore -%}
@@ -283,7 +283,7 @@ validation {
 \033[0;34m  |\\ | |__  __ /  ` /  \\ |__) |__         \033[0;33m}  {\033[0m
 \033[0;34m  | \\| |       \\__, \\__/ |  \\ |___     \033[0;32m\\`-._,-`-,\033[0m
                                         \033[0;32m`._,._,\'\033[0m
-\033[0;35m  ${manifest.name} ${manifest.version}\033[0m
+\033[0;35m  {{ name }} ${manifest.version}\033[0m
 -\033[2m----------------------------------------------------\033[0m-
 """
         afterText = """${manifest.doi ? "* The pipeline\n" : ""}${manifest.doi.tokenize(",").collect { "  https://doi.org/${it.trim().replace('https://doi.org/','')}"}.join("\n")}${manifest.doi ? "\n" : ""}
@@ -291,7 +291,7 @@ validation {
     https://doi.org/10.1038/s41587-020-0439-x
 
 * Software dependencies
-    https://github.com/${manifest.name}/blob/master/CITATIONS.md
+    https://github.com/{{ name }}/blob/master/CITATIONS.md
 """{% endif %}
     }{% if is_nfcore %}
     summary {


### PR DESCRIPTION
I'd rather we use {{ name }} that way we see in the script what we have. If we have manifest.name we assume that people are using a name that org/pipeline, which should work for nf-core pipeline, but might not work for all.

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/main/.github/CONTRIBUTING.md
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
