### PR TITLE
3257 - Add linkify version to fix bioconda dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix Manifest DOI text ([#3224](https://github.com/nf-core/tools/pull/3224))
 - Do not assume pipeline name is url ([#3225](https://github.com/nf-core/tools/pull/3225))
 - fix worklfow_dispatch trigger and parse more review comments in awsfulltest ([#3235](https://github.com/nf-core/tools/pull/3235))
+- Add `linkify` as an explicit dependency, to avoid it from being absent in the bioconda build. ([#3260](https://github.com/nf-core/tools/pull/3260)).
 
 ### Download
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ rich-click==1.8.*
 rich>=13.3.1
 tabulate
 textual==0.71.0
-linkify-it-py
+linkify-it-py>=1,<3
 trogon
 pdiff
 ruamel.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ rich-click==1.8.*
 rich>=13.3.1
 tabulate
 textual==0.71.0
+linkify-it-py
 trogon
 pdiff
 ruamel.yaml


### PR DESCRIPTION
As described in issue: https://github.com/nf-core/tools/issues/3257

Also see PR against the bioconda recipe (as a temporary fix): https://github.com/bioconda/bioconda-recipes/pull/51762

> The bioconda version of nf-core tools produced errors when running commands that launched the trogon TUI. The reason was the missing package linkify,
which gets pulled in as a dependency of textual in the PyPi build, but not in the conda-forge recipe.
See https://github.com/Textualize/textual/blob/22770300252deb28d266fe4ed4766d6e2a2f5dd2/pyproject.toml#L44, https://github.com/conda-forge/textual-feedstock/blob/main/recipe/meta.yaml and https://github.com/nf-core/tools/issues/3257.

Unless the conda-forge recipe for textual gets fixed, the bioconda recipe fix might get lost when a new version is built against the PyPi version of nf-core. So I propose that we also explicitly specify `linkify` in the `requirements.txt` file.

Before this is merged, could someone please verify if the version pinning makes sense? As you can see in the bioconda PR, coderabbitai suggested pinning a specific version, but I think it got it the wrong way around.


## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
