### PR TITLE
Fix meta_yml linting error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 ### Linting
 
 - allow mixed `str` and `dict` entries in lint config ([#3228](https://github.com/nf-core/tools/pull/3228))
-- fix meta_yml linting test failing due to module.process_name always being "" (#3317)
+- fix meta_yml linting test failing due to module.process_name always being "" ([#3317](https://github.com/nf-core/tools/pull/3317))
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 ### Linting
 
 - allow mixed `str` and `dict` entries in lint config ([#3228](https://github.com/nf-core/tools/pull/3228))
+- fix meta_yml linting test failing due to module.process_name always being "" (#3317)
 
 ### Modules
 

--- a/nf_core/components/nfcore_component.py
+++ b/nf_core/components/nfcore_component.py
@@ -62,7 +62,6 @@ class NFCoreComponent:
             # Initialize the important files
             self.main_nf: Path = Path(self.component_dir, "main.nf")
             self.meta_yml: Optional[Path] = Path(self.component_dir, "meta.yml")
-            self.process_name = ""
             self.environment_yml: Optional[Path] = Path(self.component_dir, "environment.yml")
 
             component_list = self.component_name.split("/")
@@ -95,6 +94,9 @@ class NFCoreComponent:
             self.test_dir = None
             self.test_yml = None
             self.test_main_nf = None
+
+        # Set process_name after self.main_nf is defined
+        self.process_name = self._get_process_name()
 
     def __repr__(self) -> str:
         return f"<NFCoreComponent {self.component_name} {self.component_dir} {self.repo_url}>"
@@ -168,6 +170,13 @@ class NFCoreComponent:
                     if component != "":
                         included_components.append(component)
         return included_components
+
+    def _get_process_name(self):
+        with open(self.main_nf) as fh:
+            for line in fh:
+                if re.search(r"^\s*process\s*\w*\s*{", line):
+                    return re.search(r"^\s*process\s*(\w*)\s*{.*", line).group(1) or ""
+        return ""
 
     def get_inputs_from_main_nf(self) -> None:
         """Collect all inputs from the main.nf file."""
@@ -263,3 +272,4 @@ class NFCoreComponent:
                     pass
             log.debug(f"Found {len(outputs)} outputs in {self.main_nf}")
             self.outputs = outputs
+

--- a/nf_core/components/nfcore_component.py
+++ b/nf_core/components/nfcore_component.py
@@ -272,4 +272,3 @@ class NFCoreComponent:
                     pass
             log.debug(f"Found {len(outputs)} outputs in {self.main_nf}")
             self.outputs = outputs
-

--- a/nf_core/components/nfcore_component.py
+++ b/nf_core/components/nfcore_component.py
@@ -95,8 +95,7 @@ class NFCoreComponent:
             self.test_yml = None
             self.test_main_nf = None
 
-        # Set process_name after self.main_nf is defined
-        self.process_name = self._get_process_name()
+        self.process_name: str = self._get_process_name()
 
     def __repr__(self) -> str:
         return f"<NFCoreComponent {self.component_name} {self.component_dir} {self.repo_url}>"

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -256,7 +256,6 @@ def check_process_section(self, lines, registry, fix_version, progress_bar):
     bioconda_packages = []
 
     # Process name should be all capital letters
-    self.process_name = lines[0].split()[1]
     if all(x.upper() for x in self.process_name):
         self.passed.append(("process_capitals", "Process name is in capital letters", self.main_nf))
     else:


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/main/.github/CONTRIBUTING.md
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated

## Description

This PR is to fix an issue where running `nf-core modules lint -a -k meta_yml` always has failing tests due to `module.process_name` always being `""` in [nfcore_component.py](https://github.com/nf-core/tools/blob/main/nf_core/components/nfcore_component.py).

It gets initialized to `""` then eventually gets updated in `main_nf` but not in any others which results in the failed `meta_yml` tests unless `-k main_nf` is specified as well

I've added a simple function for the component to set it's `process_name` itself rather than it being set in other separate parts of the code. It uses the same regex expression that `main_nf.py` uses