### PR TITLE
Fix module section linter regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 ### Linting
 
 - allow mixed `str` and `dict` entries in lint config ([#3228](https://github.com/nf-core/tools/pull/3228))
+- fix module section regex matching wrong things ([#3321](https://github.com/nf-core/tools/pull/3321))
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@
 ### Modules
 
 - add a panel around diff previews when updating ([#3246](https://github.com/nf-core/tools/pull/3246))
-- Fix module section linter regex ([#3321](https://github.com/nf-core/tools/pull/3321))
 
 ### Subworkflows
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### Modules
 
 - add a panel around diff previews when updating ([#3246](https://github.com/nf-core/tools/pull/3246))
+- Fix module section linter regex ([#3321](https://github.com/nf-core/tools/pull/3321))
 
 ### Subworkflows
 

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -96,19 +96,19 @@ def main_nf(
     for line in iter_lines:
         if re.search(r"^\s*process\s*\w*\s*{", line) and state == "module":
             state = "process"
-        if re.search(r"input\s*:", line) and state in ["process"]:
+        if re.search(r"^\s*input\s*:", line) and state in ["process"]:
             state = "input"
             continue
-        if re.search(r"output\s*:", line) and state in ["input", "process"]:
+        if re.search(r"^\s*output\s*:", line) and state in ["input", "process"]:
             state = "output"
             continue
-        if re.search(r"when\s*:", line) and state in ["input", "output", "process"]:
+        if re.search(r"^\s*when\s*:", line) and state in ["input", "output", "process"]:
             state = "when"
             continue
-        if re.search(r"script\s*:", line) and state in ["input", "output", "when", "process"]:
+        if re.search(r"^\s*script\s*:", line) and state in ["input", "output", "when", "process"]:
             state = "script"
             continue
-        if re.search(r"shell\s*:", line) and state in ["input", "output", "when", "process"]:
+        if re.search(r"^\s*shell\s*:", line) and state in ["input", "output", "when", "process"]:
             state = "shell"
             continue
 


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/main/.github/CONTRIBUTING.md
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated

## Description

Fix an issue where the regexs used to find where each section starts in the modules linter aren't robust enough and end up matching the wrong things.

## Example

add something like `container 'test_typescript:3.0.0'` to a module and you'll see these tests fail because the regex `r"script\s*:"` matches `script:` in `test_typescript:`

![image](https://github.com/user-attachments/assets/f118bd7e-480b-43f6-9ebd-21e3173c0af8)
