### PR TITLE
Make prompt less nf-core specific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - Update gitpod/workspace-base Docker digest to 12853f7 ([#3309](https://github.com/nf-core/tools/pull/3309))
 - Run pre-commit when testing linting the template pipeline ([#3280](https://github.com/nf-core/tools/pull/3280))
 - Update pre-commit hook astral-sh/ruff-pre-commit to v0.8.2 ([#3325](https://github.com/nf-core/tools/pull/3325))
+- Make prompt less nf-core specific ([#3326](https://github.com/nf-core/tools/pull/3326))
 
 ## [v3.0.2 - Titanium Tapir Patch](https://github.com/nf-core/tools/releases/tag/3.0.2) - [2024-10-11]
 

--- a/nf_core/components/components_utils.py
+++ b/nf_core/components/components_utils.py
@@ -43,10 +43,10 @@ def get_repo_info(directory: Path, use_prompt: Optional[bool] = True) -> Tuple[P
     if not repo_type and use_prompt:
         log.warning("'repository_type' not defined in %s", config_fn.name)
         repo_type = questionary.select(
-            "Is this repository an nf-core pipeline or a fork of nf-core/modules?",
+            "Is this repository a pipeline or a modules repository?",
             choices=[
                 {"name": "Pipeline", "value": "pipeline"},
-                {"name": "nf-core/modules", "value": "modules"},
+                {"name": "Modules repository", "value": "modules"},
             ],
             style=nf_core.utils.nfcore_question_style,
         ).unsafe_ask()


### PR DESCRIPTION
This tooling works with non-nf-core pipelines, so the language should reflect that.