### PR TITLE
Use variable for includeConfig to avoid ternary expression

### DIFF
--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -210,11 +210,13 @@ profiles {
 
 {% if nf_core_configs -%}
 // Load nf-core custom profiles from different Institutions
-includeConfig !System.getenv('NXF_OFFLINE') && params.custom_config_base ? "${params.custom_config_base}/nfcore_custom.config" : "/dev/null"
+custom_config_url = !System.getenv('NXF_OFFLINE') && params.custom_config_base ? "${params.custom_config_base}/nfcore_custom.config" : "/dev/null"
+includeConfig custom_config_url
 
 // Load {{ name }} custom profiles from different institutions.
 // TODO nf-core: Optionally, you can add a pipeline-specific nf-core config at https://github.com/nf-core/configs
-// includeConfig !System.getenv('NXF_OFFLINE') && params.custom_config_base ? "${params.custom_config_base}/pipeline/{{ short_name }}.config" : "/dev/null"
+// custom_pipeline_config_url = !System.getenv('NXF_OFFLINE') && params.custom_config_base ? "${params.custom_config_base}/pipeline/{{ short_name }}.config" : "/dev/null"
+// includeConfig custom_pipeline_config_url
 {%- endif %}
 
 // Set default registry for Apptainer, Docker, Podman, Charliecloud and Singularity independent of -profile
@@ -228,7 +230,8 @@ charliecloud.registry = 'quay.io'
 
 {% if igenomes -%}
 // Load igenomes.config if required
-includeConfig !params.igenomes_ignore ? 'conf/igenomes.config' : 'conf/igenomes_ignored.config'
+igenomes_config_path = !params.igenomes_ignore ? 'conf/igenomes.config' : 'conf/igenomes_ignored.config'
+includeConfig igenomes_config_path
 {%- endif %}
 
 // Export these variables to prevent local Python/R libraries from conflicting with those in the container


### PR DESCRIPTION
Potential fix for ternary expression on an `includeConfig`.

Needs confirmation that this is ok for the following before accepting:

- [ ] Nextflow (at least 24.04 onwards)
- [ ] Nextflow language server / VS Code
- [ ] Interactive launch interfaces