### PR TITLE
Fix pre commit template

### DIFF
--- a/nf_core/pipeline-template/.gitpod.yml
+++ b/nf_core/pipeline-template/.gitpod.yml
@@ -3,7 +3,7 @@ tasks:
   - name: Update Nextflow and setup pre-commit
     command: |
       pre-commit install --install-hooks
-      nextflow self-update {% if code_linters %}
+      nextflow self-update {%- if code_linters %}
 
 vscode:
   extensions:

--- a/nf_core/pipeline-template/.prettierignore
+++ b/nf_core/pipeline-template/.prettierignore
@@ -16,3 +16,6 @@ testing/
 testing*
 *.pyc
 bin/
+{%- if rocrate %}
+ro-crate-metadata.json
+{%- endif %}

--- a/nf_core/pipeline-template/subworkflows/local/utils_nfcore_pipeline_pipeline/main.nf
+++ b/nf_core/pipeline-template/subworkflows/local/utils_nfcore_pipeline_pipeline/main.nf
@@ -143,7 +143,7 @@ workflow PIPELINE_COMPLETION {
     {%- if multiqc %}
     def multiqc_reports = multiqc_report.toList()
     {%- endif %}
-    
+
     //
     // Completion email and summary
     //

--- a/nf_core/pipelines/create/create.py
+++ b/nf_core/pipelines/create/create.py
@@ -266,6 +266,11 @@ class PipelineCreate:
         # Init the git repository and make the first commit
         if not self.no_git:
             self.git_init_pipeline()
+            # Run prettier on files
+            current_dir = Path.cwd()
+            os.chdir(self.outdir)
+            run_prettier_on_file([str(f) for f in self.outdir.glob("**/*")])
+            os.chdir(current_dir)
 
         if self.config.is_nfcore and not self.is_interactive:
             log.info(
@@ -377,9 +382,6 @@ class PipelineCreate:
                     config_yml.template = NFCoreTemplateConfig(**self.config.model_dump(exclude_none=True))
                     yaml.safe_dump(config_yml.model_dump(exclude_none=True), fh)
                     log.debug(f"Dumping pipeline template yml to pipeline config file '{config_fn.name}'")
-
-        # Run prettier on files
-        run_prettier_on_file([str(f) for f in self.outdir.glob("**/*")])
 
     def fix_linting(self):
         """

--- a/nf_core/pipelines/lint_utils.py
+++ b/nf_core/pipelines/lint_utils.py
@@ -97,7 +97,7 @@ def run_prettier_on_file(file: Union[Path, str, List[str]]) -> None:
             all_lines = [line for line in e.stdout.decode().split("\n")]
             files = "\n".join(all_lines[3:])
             log.debug(f"The following files were modified by prettier:\n {files}")
-        elif e.stderr.decode():
+        else:
             log.warning(
                 "There was an error running the prettier pre-commit hook.\n"
                 f"STDOUT: {e.stdout.decode()}\nSTDERR: {e.stderr.decode()}"


### PR DESCRIPTION
Fixing pre-commit errors in the template.
Don't run prettier on the ro-crate JSON file, this file shouldn't be modified manually.
Run pre-commit from the pipeline directory after creating a git repository, otherwise it fails since it's not run from the git repo.

Probably a better approach would be to run pre-commit on a GitHub action where we render the template to test it, and modify it accordingly if needed. That way, we don't have to rely on running pre-commit after creating the pipeline.
If pre-commit modifies a file after creating the pipeline, there will be uncommitted changes.
With the current version of the template I made sure that there aren't linting errors so pre-commit doesn't modify any file.