### PR TITLE
Template: set LICENSE copyright to nf-core community

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Linting
 
-- Linting of pipeline LICENSE file is a warning to allow for autor/maintainer names ([#3366](https://github.com/nf-core/tools/pull/3366))
+- Linting of pipeline LICENSE file is a warning to allow for author/maintainer names ([#3366](https://github.com/nf-core/tools/pull/3366))
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Use outputs instead of the environment to pass around values between steps in the Download Test Action ([#3351](https://github.com/nf-core/tools/pull/3351))
 - Fix pre commit template ([#3358](https://github.com/nf-core/tools/pull/3358))
+- set LICENSE copyright to nf-core community ([#3366](https://github.com/nf-core/tools/pull/3366))
 
 ### Download
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@
 
 - Use outputs instead of the environment to pass around values between steps in the Download Test Action ([#3351](https://github.com/nf-core/tools/pull/3351))
 - Fix pre commit template ([#3358](https://github.com/nf-core/tools/pull/3358))
-- set LICENSE copyright to nf-core community ([#3366](https://github.com/nf-core/tools/pull/3366))
+- Set LICENSE copyright to nf-core community ([#3366](https://github.com/nf-core/tools/pull/3366))
 
 ### Download
 
 ### Linting
+
+- Linting of pipeline LICENSE file is a warning to allow for autor/maintainer names ([#3366](https://github.com/nf-core/tools/pull/3366))
 
 ### Modules
 

--- a/nf_core/pipeline-template/LICENSE
+++ b/nf_core/pipeline-template/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) {{ author }}
+Copyright (c) The nf-core community
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/nf_core/pipeline-template/LICENSE
+++ b/nf_core/pipeline-template/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) The nf-core community
+Copyright (c) {% if is_nfcore %} The nf-core community {% else %} The {{ short_name }} team {% endif %}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/nf_core/pipelines/lint/files_unchanged.py
+++ b/nf_core/pipelines/lint/files_unchanged.py
@@ -62,6 +62,7 @@ def files_unchanged(self) -> Dict[str, Union[List[str], bool]]:
 
     passed: List[str] = []
     failed: List[str] = []
+    warned: List[str] = []
     ignored: List[str] = []
     fixed: List[str] = []
     could_fix: bool = False
@@ -173,6 +174,12 @@ def files_unchanged(self) -> Dict[str, Union[List[str], bool]]:
                             shutil.copy(_tf(f), _pf(f))
                             passed.append(f"`{f}` matches the template")
                             fixed.append(f"`{f}` overwritten with template file")
+                        elif f.name in ["LICENSE", "LICENSE.md", "LICENCE", "LICENCE.md"]:
+                            # Report LICENSE as a warning since we are not using the mainfest.author names
+                            # TODO: Lint the content of the LICENSE file except the line containing author names
+                            # to allow for people to opt-in listing author/maintainer names instead of using the "nf-core community"
+                            warned.append(f"`{f}` does not match the template")
+                            could_fix = True
                         else:
                             failed.append(f"`{f}` does not match the template")
                             could_fix = True
@@ -217,4 +224,11 @@ def files_unchanged(self) -> Dict[str, Union[List[str], bool]]:
     # cleaning up temporary dir
     shutil.rmtree(tmp_dir)
 
-    return {"passed": passed, "failed": failed, "ignored": ignored, "fixed": fixed, "could_fix": could_fix}
+    return {
+        "passed": passed,
+        "failed": failed,
+        "warned": warned,
+        "ignored": ignored,
+        "fixed": fixed,
+        "could_fix": could_fix,
+    }

--- a/nf_core/pipelines/lint/files_unchanged.py
+++ b/nf_core/pipelines/lint/files_unchanged.py
@@ -175,7 +175,7 @@ def files_unchanged(self) -> Dict[str, Union[List[str], bool]]:
                             passed.append(f"`{f}` matches the template")
                             fixed.append(f"`{f}` overwritten with template file")
                         elif f.name in ["LICENSE", "LICENSE.md", "LICENCE", "LICENCE.md"]:
-                            # Report LICENSE as a warning since we are not using the mainfest.author names
+                            # Report LICENSE as a warning since we are not using the manifest.author names
                             # TODO: Lint the content of the LICENSE file except the line containing author names
                             # to allow for people to opt-in listing author/maintainer names instead of using the "nf-core community"
                             warned.append(f"`{f}` does not match the template")


### PR DESCRIPTION
lint LICENSE file is a warning instead of a failure
