### PR TITLE
Parameters schema validation: allow oneOf, anyOf and allOf with `required`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### General
 
+- Parameters schema validation: allow oneOf, anyOf and allOf with `required` ([#3386](https://github.com/nf-core/tools/pull/3386))
+
 ### Version updates
 
 ## [v3.1.1 - Brass Boxfish Patch](https://github.com/nf-core/tools/releases/tag/3.1.1) - [2024-12-20]

--- a/nf_core/pipelines/schema.py
+++ b/nf_core/pipelines/schema.py
@@ -359,6 +359,7 @@ class PipelineSchema:
                         schema_no_required[self.defs_notation][group_key].pop("oneOf")
             jsonschema.validate(self.schema_defaults, schema_no_required)
         except jsonschema.exceptions.ValidationError as e:
+            log.debug(f"Complete error message:\n{e}")
             raise AssertionError(f"Default parameters are invalid: {e.message}")
         for param, default in self.schema_defaults.items():
             if default in ("null", "", None, "None") or default is False:

--- a/nf_core/pipelines/schema.py
+++ b/nf_core/pipelines/schema.py
@@ -330,33 +330,16 @@ class PipelineSchema:
             for group_key, group in schema_no_required.get(self.defs_notation, {}).items():
                 if "required" in group:
                     schema_no_required[self.defs_notation][group_key].pop("required")
-                if "allOf" in group:
-                    for all_of in group["allOf"]:
-                        if "required" in all_of:
-                            schema_no_required[self.defs_notation][group_key]["allOf"].pop("required")
-                    schema_no_required[self.defs_notation][group_key]["allOf"] = [
-                        all_of for all_of in group["allOf"] if all_of
-                    ]
-                    if not group["allOf"]:
-                        schema_no_required[self.defs_notation][group_key].pop("allOf")
-                if "anyOf" in group:
-                    for any_of in group["anyOf"]:
-                        if "required" in any_of:
-                            schema_no_required[self.defs_notation][group_key]["anyOf"].pop("required")
-                    schema_no_required[self.defs_notation][group_key]["anyOf"] = [
-                        any_of for any_of in group["anyOf"] if any_of
-                    ]
-                    if not group["anyOf"]:
-                        schema_no_required[self.defs_notation][group_key].pop("anyOf")
-                if "oneOf" in group:
-                    for i, one_of in enumerate(group["oneOf"]):
-                        if "required" in one_of:
-                            schema_no_required[self.defs_notation][group_key]["oneOf"][i].pop("required")
-                    schema_no_required[self.defs_notation][group_key]["oneOf"] = [
-                        one_of for one_of in group["oneOf"] if one_of
-                    ]
-                    if not group["oneOf"]:
-                        schema_no_required[self.defs_notation][group_key].pop("oneOf")
+                for keyword in ["allOf", "anyOf", "oneOf"]:
+                    if keyword in group:
+                        for i, kw_content in enumerate(group[keyword]):
+                            if "required" in kw_content:
+                                schema_no_required[self.defs_notation][group_key][keyword][i].pop("required")
+                        schema_no_required[self.defs_notation][group_key][keyword] = [
+                            kw_content for kw_content in group[keyword] if kw_content
+                        ]
+                        if not group[keyword]:
+                            schema_no_required[self.defs_notation][group_key].pop(keyword)
             jsonschema.validate(self.schema_defaults, schema_no_required)
         except jsonschema.exceptions.ValidationError as e:
             log.debug(f"Complete error message:\n{e}")

--- a/nf_core/pipelines/schema.py
+++ b/nf_core/pipelines/schema.py
@@ -327,6 +327,16 @@ class PipelineSchema:
             schema_no_required = copy.deepcopy(self.schema)
             if "required" in schema_no_required:
                 schema_no_required.pop("required")
+            for keyword in ["allOf", "anyOf", "oneOf"]:
+                if keyword in schema_no_required:
+                    for i, kw_content in enumerate(schema_no_required[keyword]):
+                        if "required" in kw_content:
+                            schema_no_required[keyword][i].pop("required")
+                    schema_no_required[keyword] = [
+                        kw_content for kw_content in schema_no_required[keyword] if kw_content
+                    ]
+                    if not schema_no_required[keyword]:
+                        schema_no_required.pop(keyword)
             for group_key, group in schema_no_required.get(self.defs_notation, {}).items():
                 if "required" in group:
                     schema_no_required[self.defs_notation][group_key].pop("required")

--- a/nf_core/pipelines/schema.py
+++ b/nf_core/pipelines/schema.py
@@ -330,6 +330,33 @@ class PipelineSchema:
             for group_key, group in schema_no_required.get(self.defs_notation, {}).items():
                 if "required" in group:
                     schema_no_required[self.defs_notation][group_key].pop("required")
+                if "allOf" in group:
+                    for all_of in group["allOf"]:
+                        if "required" in all_of:
+                            schema_no_required[self.defs_notation][group_key]["allOf"].pop("required")
+                    schema_no_required[self.defs_notation][group_key]["allOf"] = [
+                        all_of for all_of in group["allOf"] if all_of
+                    ]
+                    if not group["allOf"]:
+                        schema_no_required[self.defs_notation][group_key].pop("allOf")
+                if "anyOf" in group:
+                    for any_of in group["anyOf"]:
+                        if "required" in any_of:
+                            schema_no_required[self.defs_notation][group_key]["anyOf"].pop("required")
+                    schema_no_required[self.defs_notation][group_key]["anyOf"] = [
+                        any_of for any_of in group["anyOf"] if any_of
+                    ]
+                    if not group["anyOf"]:
+                        schema_no_required[self.defs_notation][group_key].pop("anyOf")
+                if "oneOf" in group:
+                    for i, one_of in enumerate(group["oneOf"]):
+                        if "required" in one_of:
+                            schema_no_required[self.defs_notation][group_key]["oneOf"][i].pop("required")
+                    schema_no_required[self.defs_notation][group_key]["oneOf"] = [
+                        one_of for one_of in group["oneOf"] if one_of
+                    ]
+                    if not group["oneOf"]:
+                        schema_no_required[self.defs_notation][group_key].pop("oneOf")
             jsonschema.validate(self.schema_defaults, schema_no_required)
         except jsonschema.exceptions.ValidationError as e:
             raise AssertionError(f"Default parameters are invalid: {e.message}")


### PR DESCRIPTION
I found a case where we were using the following schema structure:

```
"oneOf": [{ "required": ["param_1"] }, { "required": ["param_2", "param_3"] }],
```

This was failing because our listing wasn't removing the `required` instances inside the `oneOf` when validating default parameter values. 
This PR allows having these cases and also prints the complete error message on debug mode, as the `e.message` text was not helpful in identifying the problem.