### PR TITLE
Pipeline template: Fix the faulty Download test / GitHub action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Download
 
 - Allow `nf-core pipelines download -r` to download commits ([#3374](https://github.com/nf-core/tools/pull/3374))
+- Fix faulty Download Test Action to ensure that setup and test run as one job and on the same runner ([#3389](https://github.com/nf-core/tools/pull/3389))
 
 ### Linting
 

--- a/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
+++ b/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
@@ -35,7 +35,7 @@ jobs:
       REPOTITLE_LOWERCASE: ${{ steps.get_repo_properties.outputs.REPOTITLE_LOWERCASE }}
       REPO_BRANCH: ${{ steps.get_repo_properties.outputs.REPO_BRANCH }}
     steps:
-      - name: Get the repository name and current branch set as environment variable
+      - name: Get the repository name and current branch
         id: get_repo_properties
         run: |
           echo "REPO_LOWERCASE=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
@@ -85,10 +85,10 @@ jobs:
           --download-configuration 'yes'
 
       - name: Inspect download
-        run: tree ./${{ needs.configure.outputs.REPOTITLE_LOWERCASE }}{% endraw %}{% if test_config %}{% raw %}
+        run: tree ./${{ needs.configure.outputs.REPOTITLE_LOWERCASE }}{% endraw %}
 
       - name: Inspect container images
-        run: tree ./singularity_container_images | tee ./container_initial
+        run: tree ./singularity_container_images | tee ./container_initial{% if test_config %}{% raw %}
 
       - name: Count the downloaded number of container images
         id: count_initial

--- a/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
+++ b/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
@@ -35,7 +35,18 @@ jobs:
       REPOTITLE_LOWERCASE: ${{ steps.get_repo_properties.outputs.REPOTITLE_LOWERCASE }}
       REPO_BRANCH: ${{ steps.get_repo_properties.outputs.REPO_BRANCH }}
     steps:
-      - name: Install Nextflow{% endraw %}
+      - name: Get the repository name and current branch set as environment variable
+        id: get_repo_properties
+        run: |
+          echo "REPO_LOWERCASE=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+          echo "REPOTITLE_LOWERCASE=$(basename ${GITHUB_REPOSITORY,,})" >> "$GITHUB_OUTPUT"
+          echo "REPO_BRANCH=${{ github.event.inputs.testbranch || 'dev' }}" >> "$GITHUB_OUTPUT{% endraw %}"
+
+  download:
+    runs-on: ubuntu-latest
+    needs: configure
+    steps:
+      - name: Install Nextflow
         uses: nf-core/setup-nextflow@v2
 
       - name: Disk space cleanup
@@ -56,24 +67,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install git+https://github.com/nf-core/tools.git@dev
 
-      - name: Get the repository name and current branch set as environment variable
-        id: get_repo_properties
-        run: |
-          echo "REPO_LOWERCASE=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
-          echo "REPOTITLE_LOWERCASE=$(basename ${GITHUB_REPOSITORY,,})" >> "$GITHUB_OUTPUT"
-          echo "{% raw %}REPO_BRANCH=${{ github.event.inputs.testbranch || 'dev' }}" >> "$GITHUB_OUTPUT"
-
       - name: Make a cache directory for the container images
         run: |
           mkdir -p ./singularity_container_images
 
-  download:
-    runs-on: ubuntu-latest
-    needs: configure
-    steps:
       - name: Download the pipeline
         env:
-          NXF_SINGULARITY_CACHEDIR: ./singularity_container_images
+          NXF_SINGULARITY_CACHEDIR: ./singularity_container_images{% raw %}
         run: |
           nf-core pipelines download ${{ needs.configure.outputs.REPO_LOWERCASE }} \
           --revision ${{ needs.configure.outputs.REPO_BRANCH }} \

--- a/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
+++ b/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
@@ -87,6 +87,9 @@ jobs:
       - name: Inspect download
         run: tree ./${{ needs.configure.outputs.REPOTITLE_LOWERCASE }}{% endraw %}{% if test_config %}{% raw %}
 
+      - name: Inspect container images
+        run: tree ./singularity_container_images | tee ./container_initial
+
       - name: Count the downloaded number of container images
         id: count_initial
         run: |
@@ -123,7 +126,8 @@ jobs:
             final_count=${{ steps.count_afterwards.outputs.IMAGE_COUNT_AFTER }}
             difference=$((final_count - initial_count))
             echo "$difference additional container images were \n downloaded at runtime . The pipeline has no support for offline runs!"
-            tree ./singularity_container_images
+            tree ./singularity_container_images > ./container_afterwards
+            diff ./container_initial ./container_afterwards
             exit 1
           else
             echo "The pipeline can be downloaded successfully!"


### PR DESCRIPTION
In #3351, I refactored the nf-core pipelines download test to use `$GITHUB_OUTPUT` instead of the environment for improved security. 

However, splitting the test into two independent jobs introduced the possibility of them running on different runners, which resulted in the second job lacking the correct setup. I have now resolved this issue by ensuring that all necessary setup setups are retained within the main job. Only the potentially vulnerable step remains isolated from the main job, but also does not require any setup.

[The new version of the CI pipeline was successfully tested](https://github.com/MatthiasZepper/nfcore-testpipeline/actions/runs/12674971883/job/35324917556) in [my Test pipeline repository](https://github.com/MatthiasZepper/nfcore-testpipeline). Any further independent tests are highly appreciated. 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
