### PR TITLE
fix(pipeline-sync): Removes requirement to have authors defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 - Parameters schema validation: allow oneOf, anyOf and allOf with `required` ([#3386](https://github.com/nf-core/tools/pull/3386))
 - Run pre-comit when rendering template for pipelines sync ([#3371](https://github.com/nf-core/tools/pull/3371))
-- fix(pipeline-sync): Removes requirement to have authors defined ([#3393](https://github.com/nf-core/tools/pull/3393))
+- Remove requirement to have authors defined ([#3393](https://github.com/nf-core/tools/pull/3393))
 
 ### Version updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Parameters schema validation: allow oneOf, anyOf and allOf with `required` ([#3386](https://github.com/nf-core/tools/pull/3386))
 - Run pre-comit when rendering template for pipelines sync ([#3371](https://github.com/nf-core/tools/pull/3371))
+- fix(pipeline-sync): Removes requirement to have authors defined ([#3393](https://github.com/nf-core/tools/pull/3393))
 
 ### Version updates
 

--- a/nf_core/pipelines/sync.py
+++ b/nf_core/pipelines/sync.py
@@ -277,24 +277,29 @@ class PipelineSync:
             with open(self.config_yml_path, "w") as config_path:
                 yaml.safe_dump(self.config_yml.model_dump(exclude_none=True), config_path)
 
-        pipeline_create_obj = nf_core.pipelines.create.create.PipelineCreate(
-            outdir=str(self.pipeline_dir),
-            from_config_file=True,
-            no_git=True,
-            force=True,
-        )
-        pipeline_create_obj.init_pipeline()
+        try:
+            pipeline_create_obj = nf_core.pipelines.create.create.PipelineCreate(
+                outdir=str(self.pipeline_dir),
+                from_config_file=True,
+                no_git=True,
+                force=True,
+            )
+            pipeline_create_obj.init_pipeline()
 
-        # set force to false to avoid overwriting files in the future
-        if self.config_yml.template is not None:
-            self.config_yml.template = pipeline_create_obj.config
-            # Set force true in config to overwrite existing files
-            self.config_yml.template.force = False
-            # Set outdir as the current directory to avoid local info leaking
-            self.config_yml.template.outdir = "."
-            # Update nf-core version
-            self.config_yml.nf_core_version = nf_core.__version__
-            dump_yaml_with_prettier(self.config_yml_path, self.config_yml.model_dump(exclude_none=True))
+            # set force to false to avoid overwriting files in the future
+            if self.config_yml.template is not None:
+                self.config_yml.template = pipeline_create_obj.config
+                # Set force true in config to overwrite existing files
+                self.config_yml.template.force = False
+                # Set outdir as the current directory to avoid local info leaking
+                self.config_yml.template.outdir = "."
+                # Update nf-core version
+                self.config_yml.nf_core_version = nf_core.__version__
+                dump_yaml_with_prettier(self.config_yml_path, self.config_yml.model_dump(exclude_none=True))
+        except Exception as e:
+            # Reset to where you were to prevent git getting messed up.
+            self.repo.git.reset("--hard")
+            raise SyncExceptionError(f"Failed to rebuild pipeline from template with error:\n{e}")
 
     def commit_template_changes(self):
         """If we have any changes with the new template files, make a git commit"""

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -20,7 +20,18 @@ import sys
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, List, Literal, Optional, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import git
 import prompt_toolkit.styles
@@ -89,7 +100,10 @@ NFCORE_CACHE_DIR = Path(
     os.environ.get("XDG_CACHE_HOME", Path(os.getenv("HOME") or "", ".cache")),
     "nfcore",
 )
-NFCORE_DIR = Path(os.environ.get("XDG_CONFIG_HOME", os.path.join(os.getenv("HOME") or "", ".config")), "nfcore")
+NFCORE_DIR = Path(
+    os.environ.get("XDG_CONFIG_HOME", os.path.join(os.getenv("HOME") or "", ".config")),
+    "nfcore",
+)
 
 
 def fetch_remote_version(source_url):
@@ -942,7 +956,9 @@ def prompt_remote_pipeline_name(wfs):
 
 
 def prompt_pipeline_release_branch(
-    wf_releases: List[Dict[str, Any]], wf_branches: Dict[str, Any], multiple: bool = False
+    wf_releases: List[Dict[str, Any]],
+    wf_branches: Dict[str, Any],
+    multiple: bool = False,
 ) -> Tuple[Any, List[str]]:
     """Prompt for pipeline release / branch
 
@@ -1332,8 +1348,10 @@ def load_tools_config(directory: Union[str, Path] = ".") -> Tuple[Optional[Path]
             contributors = wf_config["manifest.contributors"]
             names = re.findall(r"name:'([^']+)'", contributors)
             author_names = ", ".join(names)
-        else:
+        elif "manifest.author" in wf_config:
             author_names = wf_config["manifest.author"].strip("'\"")
+        else:
+            author_names = ""
         if nf_core_yaml_config.template is None:
             # The .nf-core.yml file did not contain template information
             nf_core_yaml_config.template = NFCoreTemplateConfig(


### PR DESCRIPTION
If authors were missing the pipelines sync failed with a meaningless error. This wastes developer time while users have to fight configuration. Since authors are easy to maintain manually it seems silly to break the pipeline sync just for on field, so this PR makes it optional, it is encouraged by the .nf-core.yml and existing template.

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/main/.github/CONTRIBUTING.md
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
