### PR TITLE
Template: Fix `process.shell` in `nextflow.config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### General
 
+- Fix `process.shell` in `nextflow.config` ([#3416](https://github.com/nf-core/tools/pull/3416))
+
 ## [v3.1.2 - Brass Boxfish Patch](https://github.com/nf-core/tools/releases/tag/3.1.2) - [2025-01-20]
 
 ### Template

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -238,14 +238,13 @@ env {
 }
 
 // Set bash options
-process.shell = """\
-bash
-
-set -e # Exit if a tool returns a non-zero status/exit code
-set -u # Treat unset variables and parameters as an error
-set -o pipefail # Returns the status of the last command to exit with a non-zero status or zero if all successfully execute
-set -C # No clobber - prevent output redirection from overwriting files.
-"""
+process.shell = [
+    "bash",
+    "-C",         // No clobber - prevent output redirection from overwriting files.
+    "-e",         // Exit if a tool returns a non-zero status/exit code
+    "-u",         // Treat unset variables and parameters as an error
+    "-o pipefail" // Returns the status of the last command to exit with a non-zero status or zero if all successfully execute
+]
 
 // Disable process selector warnings by default. Use debug profile to enable warnings.
 nextflow.enable.configProcessNamesValidation = false


### PR DESCRIPTION
The latest Nextflow edge release included some changes in how the bash shell command is used. This surfaced a problem that was introduced into the pipeline template in https://github.com/nf-core/tools/pull/2991 - the `process.shell` directive should be either a single-line or a list, not a multi-line string (as far as I can tell, there was no way for us to know this).

Reverting this to go back to using a list as before, which solves the problem found in https://github.com/nextflow-io/nextflow/issues/5686

See also https://github.com/nextflow-io/nextflow/pull/5689 which strengthens Nextflow's validation logic for this directive. Once that is merged and released, pipelines with the multi-line string above will not run and instead fail with an error.