### PR TITLE
output passed to write_params_file as Path object

### DIFF
--- a/nf_core/commands_pipelines.py
+++ b/nf_core/commands_pipelines.py
@@ -218,7 +218,7 @@ def pipelines_create_params_file(ctx, pipeline, revision, output, force, show_hi
     """
     builder = ParamsFileBuilder(pipeline, revision)
 
-    if not builder.write_params_file(output, show_hidden=show_hidden, force=force):
+    if not builder.write_params_file(Path(output), show_hidden=show_hidden, force=force):
         sys.exit(1)
 
 


### PR DESCRIPTION
#### Bug Fix of #3434 : Incorrect Argument Type in `write_params_file()`  

When running the command `nf-core pipelines create-params-file`, an `AttributeError` was raised because the `write_params_file()` method of `ParamsFileBuilder` expected its first argument to be a `Path` object. However, a string representing the output parameter file name was passed instead, causing the error.  
This fix ensures that the argument is properly converted to a `Path` object before being passed to `write_params_file()`, resolving the issue.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
