### PR TITLE
format name/value with YAML syntax

### DIFF
--- a/nf_core/pipelines/params_file.py
+++ b/nf_core/pipelines/params_file.py
@@ -213,7 +213,7 @@ class ParamsFileBuilder:
             out += _print_wrapped("Required", mode="none", indent=4)
 
         out += _print_wrapped("\n", mode="end")
-        out += f"# {name} = {json.dumps(default)}\n"
+        out += f"# {name}: {json.dumps(default)}\n"
 
         return out
 


### PR DESCRIPTION
 This PR fixes the incorrect formatting of the params file generated by the `nf-core pipelines create-params-file` command (issue #3441). The output written with the `name = value` format has been corrected to `name: value`.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
