### PR TITLE
Configure the default module repository, branch, and path from environment variables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Modules
 
 - increase meta index for multiple input channels ([#3463](https://github.com/nf-core/tools/pull/3463))
+- Configure the default module repository, branch, and path from environment variables. ([#3481](https://github.com/nf-core/tools/pull/3481))
 
 ### Subworkflows
 

--- a/nf_core/components/components_utils.py
+++ b/nf_core/components/components_utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
@@ -15,9 +16,9 @@ import nf_core.utils
 log = logging.getLogger(__name__)
 
 # Constants for the nf-core/modules repo used throughout the module files
-NF_CORE_MODULES_NAME = "nf-core"
-NF_CORE_MODULES_REMOTE = "https://github.com/nf-core/modules.git"
-NF_CORE_MODULES_DEFAULT_BRANCH = "master"
+NF_CORE_MODULES_NAME = os.environ.get("NF_CORE_MODULES_NAME", "nf-core")
+NF_CORE_MODULES_REMOTE = os.environ.get("NF_CORE_MODULES_REMOTE", "https://github.com/nf-core/modules.git")
+NF_CORE_MODULES_DEFAULT_BRANCH = os.environ.get("NF_CORE_MODULES_DEFAULT_BRANCH", "master")
 
 
 def get_repo_info(directory: Path, use_prompt: Optional[bool] = True) -> Tuple[Path, Optional[str], str]:

--- a/tests/components/test_components_utils.py
+++ b/tests/components/test_components_utils.py
@@ -1,3 +1,7 @@
+import importlib
+import os
+from unittest import mock
+
 import responses
 
 import nf_core.components.components_utils
@@ -55,3 +59,27 @@ class TestTestComponentsUtils(TestComponents):
             response = nf_core.components.components_utils.get_biotools_response("bpipe")
             nf_core.components.components_utils.get_channel_info_from_biotools(response, "test")
             assert "Could not find an EDAM ontology term for 'test'" in self.caplog.text
+
+    def test_environment_variables_override(self):
+        """Test environment variables override default values"""
+        # Define environment variables to mock
+        mock_env = {
+            "NF_CORE_MODULES_NAME": "custom-name",
+            "NF_CORE_MODULES_REMOTE": "https://custom-repo.git",
+            "NF_CORE_MODULES_DEFAULT_BRANCH": "custom-branch",
+        }
+
+        # Use mock as a context manager
+        try:
+            with mock.patch.dict(os.environ, mock_env):
+                importlib.reload(nf_core.components.components_utils)
+                # Check custom values are used
+                assert nf_core.components.components_utils.NF_CORE_MODULES_NAME == mock_env["NF_CORE_MODULES_NAME"]
+                assert nf_core.components.components_utils.NF_CORE_MODULES_REMOTE == mock_env["NF_CORE_MODULES_REMOTE"]
+                assert (
+                    nf_core.components.components_utils.NF_CORE_MODULES_DEFAULT_BRANCH
+                    == mock_env["NF_CORE_MODULES_DEFAULT_BRANCH"]
+                )
+        finally:
+            # Restore original values
+            importlib.reload(nf_core.components.components_utils)

--- a/tests/components/test_components_utils.py
+++ b/tests/components/test_components_utils.py
@@ -62,18 +62,15 @@ class TestTestComponentsUtils(TestComponents):
 
     def test_environment_variables_override(self):
         """Test environment variables override default values"""
-        # Define environment variables to mock
         mock_env = {
             "NF_CORE_MODULES_NAME": "custom-name",
             "NF_CORE_MODULES_REMOTE": "https://custom-repo.git",
             "NF_CORE_MODULES_DEFAULT_BRANCH": "custom-branch",
         }
 
-        # Use mock as a context manager
         try:
             with mock.patch.dict(os.environ, mock_env):
                 importlib.reload(nf_core.components.components_utils)
-                # Check custom values are used
                 assert nf_core.components.components_utils.NF_CORE_MODULES_NAME == mock_env["NF_CORE_MODULES_NAME"]
                 assert nf_core.components.components_utils.NF_CORE_MODULES_REMOTE == mock_env["NF_CORE_MODULES_REMOTE"]
                 assert (
@@ -81,5 +78,4 @@ class TestTestComponentsUtils(TestComponents):
                     == mock_env["NF_CORE_MODULES_DEFAULT_BRANCH"]
                 )
         finally:
-            # Restore original values
             importlib.reload(nf_core.components.components_utils)


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/main/.github/CONTRIBUTING.md
-->

Add the ability to configure the default modules repo, branch, and name as environment variables.

Context:
Within our org, we're looking to build an nf-core-style module repository in Gitlab - this is possible with the command line flags, but it's a hassle to set `--git-branch` every time we run a module command. 

This PR adds the ability to set `NF_CORE_MODULES_NAME`, `NF_CORE_MODULES_REMOTE`, and `NF_CORE_MODULES_DEFAULT_BRANCH` as environment variables, defaulting to the existing constants for those values if the variables are not set.

I took a quick look for other similar constants, but didn't see any, nor did I find an existing config file or object - if I missed something, let me know and I'll be happy to update this.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
