### PR TITLE
allow more formats for params.input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Remove the on `pull_request_target` trigger and `pull_request` types from the download test. Also drop `push` triggers on other CI tests. ([#3399](https://github.com/nf-core/tools/pull/3399))
 - Add nf-core template version badges to README ([#3396](https://github.com/nf-core/tools/pull/3396))
 - Add Bluesky badge to readme ([#3475](https://github.com/nf-core/tools/pull/3475))
+- Allow more formats for params.input ([#3484](https://github.com/nf-core/tools/pull/3484))
 
 ### Linting
 
@@ -38,7 +39,6 @@
 - chore(deps): update gitpod/workspace-base docker digest to 7f35e40 ([#3473](https://github.com/nf-core/tools/pull/3473))
 - chore(deps): update python:3.12-slim docker digest to aaa3f8c ([#3474](https://github.com/nf-core/tools/pull/3474))
 - chore(deps): update pre-commit hook astral-sh/ruff-pre-commit to v0.9.9 ([#3470](https://github.com/nf-core/tools/pull/3470))
-- Feature/flexible input types ([#3484](https://github.com/nf-core/tools/pull/3484))
 
 ## [v3.2.0 - Pewter Pangolin](https://github.com/nf-core/tools/releases/tag/3.2.0) - [2025-01-27]
 
@@ -127,7 +127,6 @@
 - Update template components ([#3328](https://github.com/nf-core/tools/pull/3328))
 - Template: Remove mention of GRCh37 if igenomes is skipped ([#3330](https://github.com/nf-core/tools/pull/3330))
 - Be more verbose in approval check action ([#3338](https://github.com/nf-core/tools/pull/3338))
-- Allow more formats for params.input in the pipeline template schema ([#3484](https://github.com/nf-core/tools/pull/3484))
 
 ### Download
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@
 - Update template components ([#3328](https://github.com/nf-core/tools/pull/3328))
 - Template: Remove mention of GRCh37 if igenomes is skipped ([#3330](https://github.com/nf-core/tools/pull/3330))
 - Be more verbose in approval check action ([#3338](https://github.com/nf-core/tools/pull/3338))
+- Allow more formats for params.input in the pipeline template schema ([#3484](https://github.com/nf-core/tools/pull/3484))
 
 ### Download
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Remove Twitter from README ([#3454](https://github.com/nf-core/tools/pull/3454))
 - docs: fix contributing link in the main README ([#3459](https://github.com/nf-core/tools/pull/3459))
 - Cleanup: Removed Redundant if Condition ([#3468](https://github.com/nf-core/tools/pull/3468))
+- chore(deps): update gitpod/workspace-base docker digest to 7f35e40 ([#3473](https://github.com/nf-core/tools/pull/3473))
 - chore(deps): update python:3.12-slim docker digest to aaa3f8c ([#3474](https://github.com/nf-core/tools/pull/3474))
 - chore(deps): update pre-commit hook astral-sh/ruff-pre-commit to v0.9.9 ([#3470](https://github.com/nf-core/tools/pull/3470))
 

--- a/nf_core/gitpod/gitpod.Dockerfile
+++ b/nf_core/gitpod/gitpod.Dockerfile
@@ -2,7 +2,7 @@
 #   docker build -t gitpod:test -f nf_core/gitpod/gitpod.Dockerfile .
 
 # See https://docs.renovatebot.com/docker/#digest-pinning for why a digest is used.
-FROM gitpod/workspace-base@sha256:12853f7c901eb2b677a549cb112c85f9679d18feb30093bcc63aa252540ecad9
+FROM gitpod/workspace-base@sha256:7f35e401405c38ebc1185dfc3d6c066f73a524e8b86641453ea4690cc5c24fb6
 
 USER root
 

--- a/nf_core/pipeline-template/nextflow_schema.json
+++ b/nf_core/pipeline-template/nextflow_schema.json
@@ -32,7 +32,7 @@
                         },
                         {
                             "mimetype": "text/tab-separated-values",
-                            "pattern": "^\\S+\\.txt$"
+                            "pattern": "^\\S+\\.tsv$"
                         }
                     ],
                     "description": "Path to comma-separated file containing information about the samples in the experiment.",

--- a/nf_core/pipeline-template/nextflow_schema.json
+++ b/nf_core/pipeline-template/nextflow_schema.json
@@ -17,8 +17,24 @@
                     "format": "file-path",
                     "exists": true,
                     "schema": "assets/schema_input.json",
-                    "mimetype": "text/csv",
-                    "pattern": "^\\S+\\.csv$",
+                    "oneOf": [
+                        {
+                            "mimetype": "application/json",
+                            "pattern": "^\\S+\\.json$"
+                        },
+                        {
+                            "mimetype": "text/csv",
+                            "pattern": "^\\S+\\.csv$"
+                        },
+                        {
+                            "mimetype": "application/yaml",
+                            "pattern": "^\\S+\\.(yaml|yml)$"
+                        },
+                        {
+                            "mimetype": "text/tab-separated-values",
+                            "pattern": "^\\S+\\.txt$"
+                        }
+                    ],
                     "description": "Path to comma-separated file containing information about the samples in the experiment.",
                     "help_text": "You will need to create a design file with information about the samples in your experiment before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 3 columns, and a header row.{% if is_nfcore %} See [usage docs](https://nf-co.re/{{ short_name }}/usage#samplesheet-input).{% endif %}",
                     "fa_icon": "fas fa-file-csv"

--- a/nf_core/pipelines/schema.py
+++ b/nf_core/pipelines/schema.py
@@ -553,9 +553,30 @@ class PipelineSchema:
         if "input" not in self.schema.get(self.defs_notation, {}).get("input_output_options", {}).get("properties", {}):
             raise LookupError("Parameter `input` is not defined in the correct subschema (input_output_options)")
         input_entry = self.schema[self.defs_notation]["input_output_options"]["properties"]["input"]
-        if "mimetype" not in input_entry:
+        def find_mimetype(json_data):
+            """
+            Recursively searches a JSON structure for the "mimetype" attribute and returns its value.
+
+            Args:
+              json_data: A JSON object (dict, list, string, number, or boolean).
+
+            Returns:
+              The value of the "mimetype" attribute if found, or None if not found.
+            """
+            if isinstance(json_data, dict):
+                if "mimetype" in json_data:
+                    return json_data["mimetype"]
+                for value in json_data.values():
+                    result = find_mimetype(value)
+                    if result:
+                        return result
+            elif isinstance(json_data, list):
+                for item in json_data:
+                    result = find_mimetype(item)
+                    if result:
+                        return result
             return None
-        mimetype = input_entry["mimetype"]
+        mimetype = find_mimetype(input_entry)
         if mimetype == "" or mimetype is None:
             return None
         return mimetype

--- a/nf_core/pipelines/schema.py
+++ b/nf_core/pipelines/schema.py
@@ -553,6 +553,7 @@ class PipelineSchema:
         if "input" not in self.schema.get(self.defs_notation, {}).get("input_output_options", {}).get("properties", {}):
             raise LookupError("Parameter `input` is not defined in the correct subschema (input_output_options)")
         input_entry = self.schema[self.defs_notation]["input_output_options"]["properties"]["input"]
+
         def find_mimetype(json_data):
             """
             Recursively searches a JSON structure for the "mimetype" attribute and returns its value.
@@ -576,6 +577,7 @@ class PipelineSchema:
                     if result:
                         return result
             return None
+
         mimetype = find_mimetype(input_entry)
         if mimetype == "" or mimetype is None:
             return None

--- a/tests/pipelines/test_schema.py
+++ b/tests/pipelines/test_schema.py
@@ -151,6 +151,8 @@ class TestSchema(unittest.TestCase):
         self.schema_obj.load_schema()
         self.schema_obj.input_params = {"input": "fubar.csv", "outdir": "results/"}
         assert self.schema_obj.validate_params()
+        self.schema_obj.input_params = {"input": "fubar.json", "outdir": "results/"}
+        assert self.schema_obj.validate_params()
 
     def test_validate_params_fail(self):
         """Check that False is returned if params don't validate against a schema"""
@@ -158,6 +160,8 @@ class TestSchema(unittest.TestCase):
         self.schema_obj.schema_filename = self.template_schema
         self.schema_obj.load_schema()
         self.schema_obj.input_params = {"fubar": "input"}
+        assert not self.schema_obj.validate_params()
+        self.schema_obj.input_params = {"input": "fubar.foo", "outdir": "results/"}
         assert not self.schema_obj.validate_params()
 
     def test_validate_schema_pass(self):


### PR DESCRIPTION
Addresses #3482 

Pipeline was failing when attempting to use json or other formats other than csv as the input. nf-schema is capable of handling json/tsv/yaml input files, this PR allows a template-synced pipeline to be able to take advantage of that.

Looking forward to hearing your thoughts!

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Documentation in `docs` is updated
