### PR TITLE
Update dead link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Basic pipeline level nf-test tests ([#3469](https://github.com/nf-core/tools/pull/3469))
 - Add Bluesky badge to readme ([#3475](https://github.com/nf-core/tools/pull/3475))
 - Run awsfulltest after release, and with dev revision on PRs to master ([#3485](https://github.com/nf-core/tools/pull/3485))
+- Fix dead link ([#3505](https://github.com/nf-core/tools/pull/3505))
 
 ### Linting
 


### PR DESCRIPTION
While going through the list of todos for nf-core/seqinspector I found a dead link. The link is now fixed.

## PR checklist

- [X] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
