### PR TITLE
GitHub action for nightly tests with Nextflow from source

### DIFF
--- a/.github/workflows/nextflow-source-test.yml
+++ b/.github/workflows/nextflow-source-test.yml
@@ -1,0 +1,76 @@
+name: Test with Nextflow from source
+
+on:
+  workflow_dispatch: # Manual trigger
+  schedule:
+    # Run at 00:00 UTC on Monday, Wednesday, Friday (2:00 CEST)
+    - cron: "0 0 * * 1,3,5"
+
+jobs:
+  test-with-nextflow-source:
+    runs-on: ubuntu-latest
+    env:
+      NXF_ANSI_LOG: false
+
+    steps:
+      - name: Check out Nextflow
+        uses: actions/checkout@v4
+        with:
+          repository: nextflow-io/nextflow
+          path: nextflow
+
+      - uses: actions/checkout@v4
+        name: Check out nf-core/tools
+        with:
+          ref: dev
+          path: nf-core-tools
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: nf-core-tools/pyproject.toml
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
+      - name: Build Nextflow
+        run: |
+          cd nextflow
+          ./gradlew compile
+          chmod +x nextflow
+          echo "$(pwd)" >> $GITHUB_PATH
+          nextflow -version
+
+      - name: Install nf-core/tools
+        run: |
+          cd nf-core-tools
+          python -m pip install --upgrade pip
+          pip install .
+
+      - name: Create new pipeline
+        run: nf-core pipelines create -n testpipeline -d "This pipeline is for testing" -a "Testing McTestface"
+
+      - name: Run new pipeline
+        run: nextflow run nf-core-testpipeline -profile docker,test --outdir ./results
+
+      - name: Send email on failure
+        if: failure()
+        uses: dsfx3d/action-aws-ses@v1
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: "eu-west-1"
+        with:
+          # to: nextflow-nightly-test-aaaaqbupbi4ikkrdg6b3bemnoq@nfcore.slack.com
+          to: infrastructure@nf-co.re
+          from: core@nf-co.re
+          subject: "Nextflow source test CI failed"
+          body: |
+            The Nextflow source test CI workflow failed!
+
+            See the failed run here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 - switch to using runsOn runners in nf-core/tools repo ([#3537](https://github.com/nf-core/tools/pull/3537))
 - Handling issue with arity #3530 ([#3539](https://github.com/nf-core/tools/pull/3539))
 - chore(deps): update actions/github-script action to v7 ([#3545](https://github.com/nf-core/tools/pull/3545))
+- GitHub action for nightly tests with Nextflow from source ([#3553](https://github.com/nf-core/tools/pull/3553))
 
 ## [v3.2.0 - Pewter Pangolin](https://github.com/nf-core/tools/releases/tag/3.2.0) - [2025-01-27]
 


### PR DESCRIPTION
Build Nextflow from source, create a pipeline from dev and run it. If there's a failure, email Slack.

Untested, because this is GitHub actions.