### PR TITLE
Make jobs automatically resubmit for exit code 175

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - run nf-test tests on runsOn runners ([#3525](https://github.com/nf-core/tools/pull/3525))
 - Include the centralized nf-core configs also in offline mode, if a local copy is available. ([#3491](https://github.com/nf-core/tools/pull/3491))
 - downgrade nf-schema to fix CI tests ([#3544](https://github.com/nf-core/tools/pull/3544))
+- Make jobs automatically resubmit for exit code 175 ([#3564](https://github.com/nf-core/tools/pull/3564))
 
 ### Linting
 

--- a/nf_core/pipeline-template/conf/base.config
+++ b/nf_core/pipeline-template/conf/base.config
@@ -15,7 +15,7 @@ process {
     memory = { 6.GB   * task.attempt }
     time   = { 4.h    * task.attempt }
 
-    errorStrategy = { task.exitStatus in ((130..145) + 104) ? 'retry' : 'finish' }
+    errorStrategy = { task.exitStatus in ((130..145) + 104 + 175) ? 'retry' : 'finish' }
     maxRetries    = 1
     maxErrors     = '-1'
 

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -83,7 +83,7 @@ process {
     memory = { 6.GB * task.attempt }
     time   = { 4.h  * task.attempt }
 
-    errorStrategy = { task.exitStatus in ((130..145) + 104) ? 'retry' : 'finish' }
+    errorStrategy = { task.exitStatus in ((130..145) + 104 + 175) ? 'retry' : 'finish' }
     maxRetries    = 1
     maxErrors     = '-1'
 }

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -83,6 +83,8 @@ process {
     memory = { 6.GB * task.attempt }
     time   = { 4.h  * task.attempt }
 
+    // 175 signals that the Pipeline had an unrecoverable error while
+    // restoring a Snapshot via Fusion Snapshots.
     errorStrategy = { task.exitStatus in ((130..145) + 104 + 175) ? 'retry' : 'finish' }
     maxRetries    = 1
     maxErrors     = '-1'


### PR DESCRIPTION
When a pipeline's whole Linux process tree is in the process of being snapshotted via Fusion Snapshots and encounters an unrecoverable error the Fusion Snapshots runtime emits a specific exit code (175) to signal that to Nextflow.

This PR makes sure that users creating pipelines out of the template are including the exit code in their retry strategy.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
