### PR TITLE
Add row wrapping for long lines in search result table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - chore(deps): update python:3.12-slim docker digest to bae1a06 ([#3558](https://github.com/nf-core/tools/pull/3558))
 - Update CI to test template pipelines with nf-test ([#3559](https://github.com/nf-core/tools/pull/3559))
 - chore(deps): update pre-commit hook astral-sh/ruff-pre-commit to v0.11.9 ([#3563](https://github.com/nf-core/tools/pull/3563))
+- Add row wrapping for long lines in search result table ([#3566](https://github.com/nf-core/tools/pull/3566))
 
 ## [v3.2.1 - Pewter Pangolin Patch](https://github.com/nf-core/tools/releases/tag/3.2.1) - [2025-04-29]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@
 - Changing retrieval of file extension from EDAM ([#3512](https://github.com/nf-core/tools/pull/3512))
 - Refactor adding EDAM ontologies and allowing detect more patterns (e.g., versions.yml) ([#3519](https://github.com/nf-core/tools/pull/3519))
 - Add offline configs test action ([#3524](https://github.com/nf-core/tools/pull/3524))
-- Adds `test-datasets` subcommand for listing/searching files in the nf-core/test-datasets repo from the cli ([#3487](https://github.com/nf-core/tools/issues/3487), [#3548](https://github.com/nf-core/tools/pull/3548))
+- Adds `test-datasets` subcommand for listing/searching files in the nf-core/test-datasets repo from the cli ([#3487](https://github.com/nf-core/tools/issues/3487), [#3548](https://github.com/nf-core/tools/pull/3548), [#3566](https://github.com/nf-core/tools/pull/3566))
 - Update pre-commit hook astral-sh/ruff-pre-commit to v0.11.2 ([#3521](https://github.com/nf-core/tools/pull/3521))
 - Fix indentation in included_configs API docs ([#3523](https://github.com/nf-core/tools/pull/3523))
 - chore(deps): update python:3.12-slim docker digest to a866731 ([#3527](https://github.com/nf-core/tools/pull/3527))
@@ -77,7 +77,6 @@
 - chore(deps): update python:3.12-slim docker digest to bae1a06 ([#3558](https://github.com/nf-core/tools/pull/3558))
 - Update CI to test template pipelines with nf-test ([#3559](https://github.com/nf-core/tools/pull/3559))
 - chore(deps): update pre-commit hook astral-sh/ruff-pre-commit to v0.11.9 ([#3563](https://github.com/nf-core/tools/pull/3563))
-- Add row wrapping for long lines in search result table ([#3566](https://github.com/nf-core/tools/pull/3566))
 
 ## [v3.2.1 - Pewter Pangolin Patch](https://github.com/nf-core/tools/releases/tag/3.2.1) - [2025-04-29]
 

--- a/nf_core/test_datasets/search.py
+++ b/nf_core/test_datasets/search.py
@@ -67,6 +67,8 @@ def search_datasets(
         stdout.print(create_download_url(branch, selection))
     else:
         table = rich.table.Table(show_header=False)
+        table.add_column("")
+        table.add_column("", overflow="fold")
         table.add_row("File Name:", selection)
         table.add_row("Nextflow Import:", create_pretty_nf_path(selection, branch == MODULES_BRANCH_NAME))
         table.add_row("Download Link:", create_download_url(branch, selection))


### PR DESCRIPTION
## Description
Changes the output table of the `test-datasets search` sub-command to wrap long one-word rows to essentially avoid ellipsis-cutting URLs.
This change was suggested in [this website PR comment](https://github.com/nf-core/website/pull/3317#issuecomment-2875936343). 
For copy-pasting urls the `-u` flag is still more suitable

Before Changes:
```
% nf-core test-datasets search -b mag minigut_reads
<nf-core logo cut out ...>
Searching files on branch:  mag
┌──────────────────┬────────────────────────────────────────┐
│ File Name:       │ test_data/minigut_reads.fastq.gz       │
│ Nextflow Import: │ params.pipelines_testdata_base_path +  │
│                  │ "test_data/minigut_reads.fastq.gz"     │
│ Download Link:   │ https://raw.githubusercontent.com/nf-… │
└──────────────────┴────────────────────────────────────────┘
```

After Changes: 
```
 % nf-core test-datasets search -b mag minigut_reads
<nf-core logo cut out ...>
Searching files on branch:  mag
┌──────────────────┬────────────────────────────────────────┐
│ File Name:       │ test_data/minigut_reads.fastq.gz       │
│ Nextflow Import: │ params.pipelines_testdata_base_path +  │
│                  │ "test_data/minigut_reads.fastq.gz"     │
│ Download Link:   │ https://raw.githubusercontent.com/nf-c │
│                  │ ore/test-datasets/refs/heads/mag/test_ │
│                  │ data/minigut_reads.fastq.gz            │
└──────────────────┴────────────────────────────────────────┘
```
## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
