### PR TITLE
feat: nf-core modules bump-version supports specifying the toolkit

### DIFF
--- a/nf_core/modules/bump_versions.py
+++ b/nf_core/modules/bump_versions.py
@@ -105,7 +105,10 @@ class ModuleVersionBumper(ComponentCommand):
                 raise nf_core.modules.modules_utils.ModuleExceptionError(
                     "You cannot specify a tool and request all tools to be bumped."
                 )
-            nfcore_modules = [m for m in nfcore_modules if m.component_name == module]
+            if module.endswith("/"):
+                nfcore_modules = [m for m in nfcore_modules if m.component_name.startswith(module)]
+            else:
+                nfcore_modules = [m for m in nfcore_modules if m.component_name == module]
             if len(nfcore_modules) == 0:
                 raise nf_core.modules.modules_utils.ModuleExceptionError(
                     f"Could not find the specified module: '{module}'"


### PR DESCRIPTION
Tools like picard, fgbio, and samtools all have sub-commands.  It is onerous to have to update them all individually using nf-core modules bump-version.  This change allows the module name to update to have a trailing forward slash, which will be interpreted as specifying that all subcommands should be updated.  E.g. nf-core modules bump-version samtools/

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/main/.github/CONTRIBUTING.md
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
