### PR TITLE
changelog bot: don't write the output from git diff into GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -62,7 +62,11 @@ jobs:
       - name: Check if CHANGELOG.md actually changed
         id: file_changed
         run: |
-          file_changed=$(git diff --exit-code ${GITHUB_WORKSPACE}/CHANGELOG.md || echo "changed=TRUE")
+          # Show the diff for debugging
+          git diff ${GITHUB_WORKSPACE}/CHANGELOG.md
+
+          # Check if file has unstaged changes
+          [ -n "$(git diff -- ${GITHUB_WORKSPACE}/CHANGELOG.md)" ] && file_changed="TRUE" || file_changed="FALSE"
 
           echo "File changed: $file_changed"
           echo "changed=$file_changed" >> $GITHUB_OUTPUT

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -63,7 +63,7 @@ jobs:
         id: file_changed
         run: |
           # Show the diff for debugging
-          git diff ${GITHUB_WORKSPACE}/CHANGELOG.md
+          git diff -- ${GITHUB_WORKSPACE}/CHANGELOG.md
 
           # Check if file has unstaged changes
           [ -n "$(git diff -- ${GITHUB_WORKSPACE}/CHANGELOG.md)" ] && file_changed="TRUE" || file_changed="FALSE"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -49,14 +49,9 @@ jobs:
         env:
           COMMENT: ${{ github.event.comment.body }}
           GH_TOKEN: ${{ secrets.NF_CORE_BOT_AUTH_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.issue.title || github.event.pull_request.title }}
         run: |
-          if [[ "${{ github.event_name }}" == "issue_comment" ]]; then
-            export PR_NUMBER='${{ github.event.issue.number }}'
-            export PR_TITLE='${{ github.event.issue.title }}'
-          elif [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
-            export PR_NUMBER='${{ github.event.pull_request.number }}'
-            export PR_TITLE='${{ github.event.pull_request.title }}'
-          fi
           python ${GITHUB_WORKSPACE}/.github/workflows/changelog.py
 
       - name: Check if CHANGELOG.md actually changed


### PR DESCRIPTION
the old approach wrote a multi-line string into GITHUB_OUTPUT which is now failing. 

Instead, I just check if the output of git diff is empty now or not.