### PR TITLE
Update error message for rocrate_readme_sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Parallelize pytest runs and speed up coverage step ([#3635](https://github.com/nf-core/tools/pull/3635))
 - Update gitpod/workspace-base Docker digest to 77021d8 ([#3649](https://github.com/nf-core/tools/pull/3649))
 - Update pre-commit hook astral-sh/ruff-pre-commit to v0.12.1 ([#3648](https://github.com/nf-core/tools/pull/3648))
+- Fix `rocrate_readme_sync` error message when lint fails ([#3652](https://github.com/nf-core/tools/pull/3652))
 
 ## [v3.3.1 - Tungsten Tamarin Patch](https://github.com/nf-core/tools/releases/tag/3.3.1) - [2025-06-02]
 

--- a/nf_core/pipelines/lint/rocrate_readme_sync.py
+++ b/nf_core/pipelines/lint/rocrate_readme_sync.py
@@ -64,7 +64,7 @@ def rocrate_readme_sync(self):
             fixed.append("Mismatch fixed: RO-Crate description updated from `README.md`.")
         else:
             failed.append(
-                "The RO-Crate descriptions do not match the README.md content. Use `nf-core lint --fix rocrate_readme_sync` to update."
+                "The RO-Crate descriptions do not match the README.md content. Use `nf-core pipelines lint --fix rocrate_readme_sync` to update."
             )
             could_fix = True
     else:

--- a/tests/pipelines/lint/test_rocrate_readme_sync.py
+++ b/tests/pipelines/lint/test_rocrate_readme_sync.py
@@ -27,7 +27,7 @@ class TestLintROcrateReadmeSync(TestLint):
         results = self.lint_obj.rocrate_readme_sync()
         assert len(results.get("failed", [])) == 1
         assert (
-            "The RO-Crate descriptions do not match the README.md content. Use `nf-core lint --fix rocrate_readme_sync` to update."
+            "The RO-Crate descriptions do not match the README.md content. Use `nf-core pipelines lint --fix rocrate_readme_sync` to update."
             in results.get("failed", [])
         )
 


### PR DESCRIPTION
The error message for `RO-Crate` lint was not updated: `nf-core lint --fix rocrate_readme_sync` instead `nf-core pipelines lint --fix rocrate_readme_sync`

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
