### PR TITLE
Fix collectFile cache issue causing software version inconsistencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Update gitpod/workspace-base Docker digest to 77021d8 ([#3649](https://github.com/nf-core/tools/pull/3649))
 - Update pre-commit hook astral-sh/ruff-pre-commit to v0.12.1 ([#3648](https://github.com/nf-core/tools/pull/3648))
 - Update error message for rocrate_readme_sync ([#3652](https://github.com/nf-core/tools/pull/3652))
+- Fix collectFile cache issue causing software version inconsistencies ([#3654](https://github.com/nf-core/tools/pull/3654))
 
 ## [v3.3.1 - Tungsten Tamarin Patch](https://github.com/nf-core/tools/releases/tag/3.3.1) - [2025-06-02]
 

--- a/nf_core/pipeline-template/workflows/pipeline.nf
+++ b/nf_core/pipeline-template/workflows/pipeline.nf
@@ -55,7 +55,8 @@ workflow {{ short_name|upper }} {
             storeDir: "${params.outdir}/pipeline_info",
             name: {% if is_nfcore %}'nf_core_'  + {% endif %} '{{ short_name }}_software_' {% if multiqc %} + 'mqc_' {% endif %} + 'versions.yml',
             sort: true,
-            newLine: true
+            newLine: true,
+            cache: false
         ).set { ch_collated_versions }
 
 {% if multiqc %}


### PR DESCRIPTION
## Summary
- Adds `cache: false` parameter to `collectFile()` call for software versions collection in pipeline template
- Prevents inconsistencies in software version reporting when using Nextflow resume function

## Problem
When `collectFile()` uses `storeDir` with caching enabled, it can lead to missing or additional processes listed in software version reports across multiple pipeline runs with resume. This happens because:

1. First run caches software versions in results directory
2. Second run with different parameters (e.g., `--skip_gprofiler`) creates new cached versions 
3. Third run with resume may use inconsistent cached data from different runs

## Solution
Adding `cache: false` to the `collectFile()` call ensures software versions are always collected fresh and consistent with the actual processes that ran.

## Test plan
- [x] Verify template syntax is correct
- [x] Pre-commit hooks pass
- [ ] CI tests pass
- [ ] Generated pipelines work correctly with resume functionality

Fixes #3653

🤖 Generated with [Claude Code](https://claude.ai/code)