### PR TITLE
Added high-level diagrams

### DIFF
--- a/.codeboarding/CLI_Interface.md
+++ b/.codeboarding/CLI_Interface.md
@@ -1,0 +1,251 @@
+```mermaid
+
+graph LR
+
+    CLI_Interface["CLI Interface"]
+
+    Command_Dispatcher_Modules["Command Dispatcher Modules"]
+
+    Module_Management_Commands["Module Management Commands"]
+
+    Pipeline_Management_Commands["Pipeline Management Commands"]
+
+    Subworkflow_Management_Commands["Subworkflow Management Commands"]
+
+    Component_Command_Base["Component Command Base"]
+
+    Utility_Functions["Utility Functions"]
+
+    Synchronized_Repository["Synchronized Repository"]
+
+    CLI_Interface -- "delegates command handling to" --> Command_Dispatcher_Modules
+
+    Command_Dispatcher_Modules -- "dispatches requests to" --> Module_Management_Commands
+
+    Command_Dispatcher_Modules -- "dispatches requests to" --> Pipeline_Management_Commands
+
+    Command_Dispatcher_Modules -- "dispatches requests to" --> Subworkflow_Management_Commands
+
+    Module_Management_Commands -- "inherits from" --> Component_Command_Base
+
+    Subworkflow_Management_Commands -- "inherits from" --> Component_Command_Base
+
+    Module_Management_Commands -- "interacts with" --> Synchronized_Repository
+
+    Pipeline_Management_Commands -- "interacts with" --> Synchronized_Repository
+
+    Module_Management_Commands -- "utilizes" --> Utility_Functions
+
+    Pipeline_Management_Commands -- "utilizes" --> Utility_Functions
+
+    Subworkflow_Management_Commands -- "utilizes" --> Utility_Functions
+
+    CLI_Interface -- "utilizes" --> Utility_Functions
+
+    click CLI_Interface href "https://github.com/nf-core/tools/blob/main/.codeboarding//CLI_Interface.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+Abstract Components Overview of the nf-core tool.
+
+
+
+### CLI Interface [[Expand]](./CLI_Interface.md)
+
+This is the entry point of the application, responsible for parsing command-line arguments and dispatching them to the appropriate command handlers. It acts as the presentation layer, translating user input into actionable requests.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/__main__.py" target="_blank" rel="noopener noreferrer">`nf_core.__main__`</a>
+
+
+
+
+
+### Command Dispatcher Modules
+
+This component represents the collection of modules responsible for defining and dispatching specific nf-core commands. The CLI Interface uses these modules to map command-line arguments to the appropriate execution logic for modules, pipelines, and subworkflows.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/commands_modules.py" target="_blank" rel="noopener noreferrer">`nf_core.commands_modules`</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/commands_pipelines.py" target="_blank" rel="noopener noreferrer">`nf_core.commands_pipelines`</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/commands_subworkflows.py" target="_blank" rel="noopener noreferrer">`nf_core.commands_subworkflows`</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/commands_test_datasets.py" target="_blank" rel="noopener noreferrer">`nf_core.commands_test_datasets`</a>
+
+
+
+
+
+### Module Management Commands
+
+This component encompasses specific command implementations for managing nf-core modules, such as creation, installation, linting, listing, patching, and updating. These command classes inherit from Component Command Base or its specialized subclasses.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/modules/create.py#L7-L33" target="_blank" rel="noopener noreferrer">`nf_core.modules.create.ModuleCreate` (7:33)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/modules/install.py#L3-L25" target="_blank" rel="noopener noreferrer">`nf_core.modules.install.ModuleInstall` (3:25)</a>
+
+- `nf_core.modules.lint.ModuleLint`
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/modules/list.py#L9-L18" target="_blank" rel="noopener noreferrer">`nf_core.modules.list.ModuleList` (9:18)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/modules/patch.py#L7-L9" target="_blank" rel="noopener noreferrer">`nf_core.modules.patch.ModulePatch` (7:9)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/modules/remove.py#L7-L9" target="_blank" rel="noopener noreferrer">`nf_core.modules.remove.ModuleRemove` (7:9)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/modules/update.py#L3-L33" target="_blank" rel="noopener noreferrer">`nf_core.modules.update.ModuleUpdate` (3:33)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/modules/bump_versions.py" target="_blank" rel="noopener noreferrer">`nf_core.modules.bump_versions.ModuleVersionBumper`</a>
+
+
+
+
+
+### Pipeline Management Commands
+
+This component handles specific command implementations for operations related to nf-core pipelines, such as creation, downloading, linting, and schema validation. Unlike module and subworkflow commands, these commands do not directly inherit from Component Command Base.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/create/create.py" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.create.create.PipelineCreate`</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/download.py#L85-L1574" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.download.DownloadWorkflow` (85:1574)</a>
+
+- `nf_core.pipelines.lint.PipelineLint`
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/schema.py#L25-L1015" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.schema.PipelineSchema` (25:1015)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/sync.py#L40-L503" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.sync.PipelineSync` (40:503)</a>
+
+
+
+
+
+### Subworkflow Management Commands
+
+Similar to module management, this component focuses on specific command implementations for the creation, installation, linting, listing, patching, and updating of nf-core subworkflows. These command classes inherit from Component Command Base or its specialized subclasses.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/subworkflows/create.py#L7-L23" target="_blank" rel="noopener noreferrer">`nf_core.subworkflows.create.SubworkflowCreate` (7:23)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/subworkflows/install.py#L3-L25" target="_blank" rel="noopener noreferrer">`nf_core.subworkflows.install.SubworkflowInstall` (3:25)</a>
+
+- `nf_core.subworkflows.lint.SubworkflowLint`
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/subworkflows/list.py#L9-L18" target="_blank" rel="noopener noreferrer">`nf_core.subworkflows.list.SubworkflowList` (9:18)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/subworkflows/patch.py#L7-L9" target="_blank" rel="noopener noreferrer">`nf_core.subworkflows.patch.SubworkflowPatch` (7:9)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/subworkflows/remove.py#L7-L9" target="_blank" rel="noopener noreferrer">`nf_core.subworkflows.remove.SubworkflowRemove` (7:9)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/subworkflows/update.py#L3-L33" target="_blank" rel="noopener noreferrer">`nf_core.subworkflows.update.SubworkflowUpdate` (3:33)</a>
+
+
+
+
+
+### Component Command Base
+
+This is a foundational class (ComponentCommand) providing shared logic and utilities specifically for managing nf-core components (modules and subworkflows). It implements common operations and interactions with the repository structure.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/components/components_command.py#L16-L294" target="_blank" rel="noopener noreferrer">`nf_core.components.components_command.ComponentCommand` (16:294)</a>
+
+
+
+
+
+### Utility Functions
+
+This component provides a collection of general-purpose utility functions used across various parts of the nf-core tool, such as file I/O, GitHub API interactions, and configuration handling.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py" target="_blank" rel="noopener noreferrer">`nf_core.utils`</a>
+
+
+
+
+
+### Synchronized Repository
+
+This component handles the synchronization and management of local copies of remote nf-core repositories (e.g., for modules or pipelines).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/synced_repo.py#L59-L498" target="_blank" rel="noopener noreferrer">`nf_core.synced_repo.SyncedRepo` (59:498)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Core_Utilities_Configuration.md
+++ b/.codeboarding/Core_Utilities_Configuration.md
@@ -1,0 +1,229 @@
+```mermaid
+
+graph LR
+
+    nf_core_utils_NFCoreYamlConfig["nf_core.utils.NFCoreYamlConfig"]
+
+    nf_core_utils_NFCoreTemplateConfig["nf_core.utils.NFCoreTemplateConfig"]
+
+    nf_core_utils_NFCoreYamlLintConfig["nf_core.utils.NFCoreYamlLintConfig"]
+
+    nf_core_utils_GitHubAPISession["nf_core.utils.GitHubAPISession"]
+
+    nf_core_utils_run_cmd["nf_core.utils.run_cmd"]
+
+    nf_core_utils_fetch_wf_config["nf_core.utils.fetch_wf_config"]
+
+    nf_core_utils_setup_nfcore_cachedir["nf_core.utils.setup_nfcore_cachedir"]
+
+    nf_core_utils_setup_requests_cachedir["nf_core.utils.setup_requests_cachedir"]
+
+    nf_core_utils_get_first_available_path["nf_core.utils.get_first_available_path"]
+
+    nf_core_utils_NFCoreTemplateConfig -- "inherits from" --> nf_core_utils_NFCoreYamlConfig
+
+    nf_core_utils_NFCoreYamlLintConfig -- "inherits from" --> nf_core_utils_NFCoreYamlConfig
+
+    nf_core_pipelines_create_utils_CreateConfig -- "uses" --> nf_core_utils_NFCoreTemplateConfig
+
+    nf_core_components_components_command_ComponentCommand -- "uses" --> nf_core_utils_NFCoreYamlLintConfig
+
+    nf_core_pipelines_sync_PipelineSync -- "uses" --> nf_core_utils_GitHubAPISession
+
+    nf_core_utils_GitHubAPISession -- "utilizes" --> nf_core_utils_setup_requests_cachedir
+
+    nf_core_utils_fetch_wf_config -- "uses" --> nf_core_utils_run_cmd
+
+    nf_core_utils_Pipeline__load -- "uses" --> nf_core_utils_fetch_wf_config
+
+    nf_core_utils_setup_requests_cachedir -- "calls" --> nf_core_utils_setup_nfcore_cachedir
+
+    nf_core_utils_GitHubAPISession -- "uses" --> nf_core_utils_setup_requests_cachedir
+
+    nf_core_utils_NFCoreYamlConfig -- "uses" --> nf_core_utils_get_first_available_path
+
+    nf_core_utils_NFCoreTemplateConfig -- "uses" --> nf_core_utils_get_first_available_path
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `Core Utilities & Configuration` subsystem serves as the foundational layer for the `nf-core` project, providing essential general-purpose utility functions and robust configuration management capabilities. It embodies the project's architectural bias towards a modular, layered design with centralized configuration and efficient external integrations.
+
+
+
+### nf_core.utils.NFCoreYamlConfig
+
+This is the abstract base class for all YAML-based configurations within `nf-core`. It provides the core functionality for loading, parsing, and accessing data from YAML files, enabling the project's configuration-driven design. It ensures a consistent approach to managing application settings and dynamic parameters.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py" target="_blank" rel="noopener noreferrer">`nf_core.utils.NFCoreYamlConfig`</a>
+
+
+
+
+
+### nf_core.utils.NFCoreTemplateConfig
+
+Specializes `NFCoreYamlConfig` to handle configurations specifically related to `nf-core` templates. This component is crucial for managing template-specific settings, ensuring the templating engine has access to necessary parameters for generating new pipelines or modules.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py" target="_blank" rel="noopener noreferrer">`nf_core.utils.NFCoreTemplateConfig`</a>
+
+
+
+
+
+### nf_core.utils.NFCoreYamlLintConfig
+
+Another specialization of `NFCoreYamlConfig`, this class manages configurations for linting YAML files. It defines and applies linting rules, ensuring consistency and adherence to standards in configuration files across the project.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py" target="_blank" rel="noopener noreferrer">`nf_core.utils.NFCoreYamlLintConfig`</a>
+
+
+
+
+
+### nf_core.utils.GitHubAPISession
+
+This component is responsible for managing authenticated and robust interactions with the GitHub API. It handles API requests, retries for transient errors, and various authentication methods. It's critical for features like pipeline updates, module management, and listing available resources from GitHub.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py" target="_blank" rel="noopener noreferrer">`nf_core.utils.GitHubAPISession`</a>
+
+
+
+
+
+### nf_core.utils.run_cmd
+
+A low-level but essential utility function for executing arbitrary shell commands. This function provides the capability for the `nf-core` application to interact with the underlying operating system, enabling it to run external tools, Nextflow commands, or other system-level operations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py" target="_blank" rel="noopener noreferrer">`nf_core.utils.run_cmd`</a>
+
+
+
+
+
+### nf_core.utils.fetch_wf_config
+
+This utility function is specifically designed to fetch workflow configurations, often by executing external commands (likely Nextflow commands). It acts as an abstraction over `run_cmd` for a specific, common purpose, simplifying the retrieval of workflow-specific settings.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py" target="_blank" rel="noopener noreferrer">`nf_core.utils.fetch_wf_config`</a>
+
+
+
+
+
+### nf_core.utils.setup_nfcore_cachedir
+
+A general utility for setting up and managing the primary `nf-core` data caching directory. This function ensures that the application has a designated, persistent location for storing various cached data, contributing to overall performance and efficiency by reducing redundant computations or network calls.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py" target="_blank" rel="noopener noreferrer">`nf_core.utils.setup_nfcore_cachedir`</a>
+
+
+
+
+
+### nf_core.utils.setup_requests_cachedir
+
+Manages the setup and configuration of a caching directory specifically for HTTP requests made by the `requests` library. This improves performance by storing frequently accessed web data locally, reducing the need for repeated network calls, especially for GitHub API interactions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py" target="_blank" rel="noopener noreferrer">`nf_core.utils.setup_requests_cachedir`</a>
+
+
+
+
+
+### nf_core.utils.get_first_available_path
+
+This utility function helps in determining the first existing path from a given list of potential file or directory paths. This is useful for flexible file and directory lookups, allowing the application to try multiple locations for a resource or configuration file.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py" target="_blank" rel="noopener noreferrer">`nf_core.utils.get_first_available_path`</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Pipeline_Management_Schema.md
+++ b/.codeboarding/Pipeline_Management_Schema.md
@@ -1,0 +1,235 @@
+```mermaid
+
+graph LR
+
+    PipelineCreate["PipelineCreate"]
+
+    PipelineVersionBumper["PipelineVersionBumper"]
+
+    PipelineLint["PipelineLint"]
+
+    DownloadWorkflow["DownloadWorkflow"]
+
+    ParamsFileBuilder["ParamsFileBuilder"]
+
+    Launch["Launch"]
+
+    Workflows["Workflows"]
+
+    ROCrate["ROCrate"]
+
+    PipelineSync["PipelineSync"]
+
+    PipelineSchema["PipelineSchema"]
+
+    PipelineLint -- "Utilizes" --> PipelineSchema
+
+    Workflows -- "Utilizes" --> DownloadWorkflow
+
+    ParamsFileBuilder -- "Utilizes" --> PipelineSchema
+
+    Workflows -- "Utilizes" --> ParamsFileBuilder
+
+    Launch -- "Utilizes" --> PipelineSchema
+
+    Workflows -- "Utilizes" --> Launch
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+Abstract Components Overview of Nextflow Pipelines
+
+
+
+### PipelineCreate
+
+Orchestrates the creation of new Nextflow pipelines. This involves interactive prompts for pipeline details, generating the initial directory structure, and populating template files based on user input.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/create/create.py" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.create.create`</a>
+
+
+
+
+
+### PipelineVersionBumper
+
+Manages the process of updating the version of an existing Nextflow pipeline. This includes modifying relevant files (e.g., nextflow.config, pyproject.toml) and ensuring version consistency across the pipeline's metadata.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/bump_version.py" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.bump_version`</a>
+
+
+
+
+
+### PipelineLint
+
+Performs comprehensive linting and validation checks on Nextflow pipelines to ensure adherence to nf-core guidelines, best practices, and schema definitions. It aggregates various sub-checks for code quality, configuration, and schema compliance.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+
+
+
+
+### DownloadWorkflow
+
+Handles the downloading of Nextflow pipelines from remote repositories (e.g., GitHub), including specific versions or branches. It manages the local caching and integrity of downloaded pipelines, ensuring they are ready for use.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/download.py" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.download`</a>
+
+
+
+
+
+### ParamsFileBuilder
+
+Generates parameter files (e.g., params.json, params.yaml) for Nextflow pipelines based on their defined schemas. This component simplifies pipeline configuration by providing a structured way to define and validate input parameters.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/params_file.py" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.params_file`</a>
+
+
+
+
+
+### Launch
+
+Manages the launching and execution of Nextflow pipelines. It integrates with the schema component to validate parameters before execution, ensuring that the pipeline receives valid inputs.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/launch.py" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.launch`</a>
+
+
+
+
+
+### Workflows
+
+Provides functionality to list available Nextflow pipelines, both locally (discovered in the current directory or specified paths) and from remote nf-core repositories. It acts as an entry point for various pipeline-related operations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/list.py" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.list`</a>
+
+
+
+
+
+### ROCrate
+
+Handles the generation and management of Research Object (RO) Crates for Nextflow pipelines. RO-Crates package research data, code, and metadata into a single, FAIR-compliant archive, enhancing reproducibility and sharing.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/rocrate.py" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.rocrate`</a>
+
+
+
+
+
+### PipelineSync
+
+Synchronizes local Nextflow pipelines with their upstream nf-core templates. This allows pipeline developers to easily update their custom pipelines with the latest changes and features from the official nf-core templates.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/sync.py" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.sync`</a>
+
+
+
+
+
+### PipelineSchema
+
+Defines, validates, builds, and documents schemas for Nextflow pipeline parameters. This is a critical component for ensuring that pipelines receive valid inputs, generating user-friendly documentation, and enabling automated parameter file generation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/schema.py" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.schema`</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Repository_Sync_Services.md
+++ b/.codeboarding/Repository_Sync_Services.md
@@ -1,0 +1,93 @@
+```mermaid
+
+graph LR
+
+    Repository_Abstraction["Repository Abstraction"]
+
+    Module_Repository_Manager["Module Repository Manager"]
+
+    Pipeline_Repository_Manager["Pipeline Repository Manager"]
+
+    Module_Repository_Manager -- "inherits from" --> Repository_Abstraction
+
+    Pipeline_Repository_Manager -- "inherits from" --> Repository_Abstraction
+
+    Module_Repository_Manager -- "interacts with" --> ComponentCommand
+
+    Pipeline_Repository_Manager -- "interacts with" --> DownloadWorkflow
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `Repository & Sync Services` subsystem is a cornerstone of `nf-core`, providing the essential capabilities for interacting with Git repositories to manage both `nf-core` modules and pipelines. It adheres to the project's architectural bias by maintaining a clear separation of concerns, with a foundational abstraction layer for Git operations and specialized components built upon it.
+
+
+
+### Repository Abstraction
+
+This is the foundational component, embodied by the `nf_core.synced_repo.SyncedRepo` class. It provides generic, low-level functionalities for interacting with Git repositories. Its responsibilities include cloning repositories, fetching updates, checking out specific branches or commits (SHAs), and verifying the integrity and state of the local repository against its remote counterpart. It acts as the base class for all specialized repository managers within `nf-core`, ensuring consistent and reliable Git interactions across the application.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/synced_repo.py#L59-L498" target="_blank" rel="noopener noreferrer">`nf_core.synced_repo.SyncedRepo` (59:498)</a>
+
+
+
+
+
+### Module Repository Manager
+
+This component, represented by `nf_core.modules.modules_repo.ModulesRepo`, extends the `Repository Abstraction` (`nf_core.synced_repo.SyncedRepo`) to specifically manage `nf-core` modules. It provides specialized functionalities for setting up, installing, updating, and verifying modules, leveraging the underlying Git synchronization capabilities inherited from its parent class. It is a critical component for all `nf-core modules` CLI commands, ensuring that module-specific operations are handled correctly within the Git repository context.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/modules/modules_repo.py#L20-L153" target="_blank" rel="noopener noreferrer">`nf_core.modules.modules_repo.ModulesRepo` (20:153)</a>
+
+
+
+
+
+### Pipeline Repository Manager
+
+Similar to the `Module Repository Manager`, this component, implemented as `nf_core.pipelines.download.WorkflowRepo`, extends the `Repository Abstraction` (`nf_core.synced_repo.SyncedRepo`) but focuses on managing `nf-core` pipelines. Its primary responsibility is to facilitate the downloading and checking out of specific pipeline versions from remote Git repositories. This component is essential for the `nf-core download` command, enabling users to obtain and manage `nf-core` pipelines locally.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/download.py#L1577-L1850" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.download.WorkflowRepo` (1577:1850)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Test_Data_Management.md
+++ b/.codeboarding/Test_Data_Management.md
@@ -1,0 +1,143 @@
+```mermaid
+
+graph LR
+
+    Test_Dataset_CLI_Interface["Test Dataset CLI Interface"]
+
+    Test_Dataset_Core_Logic["Test Dataset Core Logic"]
+
+    GitHub_API_Client["GitHub API Client"]
+
+    Application_Configuration["Application Configuration"]
+
+    Shared_Utilities["Shared Utilities"]
+
+    Test_Dataset_CLI_Interface -- "uses" --> Test_Dataset_Core_Logic
+
+    Test_Dataset_CLI_Interface -- "uses" --> Shared_Utilities
+
+    Test_Dataset_Core_Logic -- "uses" --> GitHub_API_Client
+
+    Test_Dataset_Core_Logic -- "uses" --> Application_Configuration
+
+    Test_Dataset_Core_Logic -- "uses" --> Shared_Utilities
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+This subsystem facilitates the listing, searching, and potentially downloading of test datasets required for pipeline and component testing. It primarily interacts with remote GitHub repositories to retrieve dataset information and download URLs.
+
+
+
+### Test Dataset CLI Interface
+
+This component serves as the user-facing interface for the test data management subsystem. It provides the command-line entry points for listing and searching available test datasets, translating user commands into calls to the core logic. It embodies the Command Pattern by encapsulating user actions into distinct commands.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/test_datasets/list.py#L1-L999999" target="_blank" rel="noopener noreferrer">`nf_core.test_datasets.list` (1:999999)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/test_datasets/search.py#L1-L999999" target="_blank" rel="noopener noreferrer">`nf_core.test_datasets.search` (1:999999)</a>
+
+
+
+
+
+### Test Dataset Core Logic
+
+This is the central application logic component for test data management. It encapsulates the business rules and data access mechanisms for interacting with remote GitHub repositories. Its responsibilities include constructing GitHub API requests, parsing responses, and extracting relevant information about test datasets (e.g., branches, file lists, download URLs). This component represents the core domain logic of the subsystem.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/test_datasets/test_datasets_utils.py#L1-L999999" target="_blank" rel="noopener noreferrer">`nf_core.test_datasets.test_datasets_utils` (1:999999)</a>
+
+
+
+
+
+### GitHub API Client
+
+This shared infrastructure component provides a robust and centralized mechanism for authenticating and managing HTTP requests to the GitHub API. It handles API tokens, rate limiting, and general network communication, ensuring efficient and authorized access to GitHub resources. It acts as a dedicated External API Integration layer.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py#L1-L999999" target="_blank" rel="noopener noreferrer">`nf_core.utils.GitHubAPISession` (1:999999)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py#L1-L999999" target="_blank" rel="noopener noreferrer">`nf_core.utils.GithubApiEndpoints` (1:999999)</a>
+
+
+
+
+
+### Application Configuration
+
+This shared infrastructure component is responsible for loading, parsing, and providing access to various YAML-based configurations used across the nf-core project. It ensures that the application can dynamically adapt its behavior based on predefined settings and user preferences, supporting a Configuration-driven Design.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py#L1-L999999" target="_blank" rel="noopener noreferrer">`nf_core.utils.NFCoreYamlConfig` (1:999999)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py#L1-L999999" target="_blank" rel="noopener noreferrer">`nf_core.utils.NFCoreTemplateConfig` (1:999999)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py#L1-L999999" target="_blank" rel="noopener noreferrer">`nf_core.utils.NFCoreYamlLintConfig` (1:999999)</a>
+
+
+
+
+
+### Shared Utilities
+
+This broad, shared infrastructure component encompasses a collection of common utility functions and helper methods that are widely used across the entire nf-core project. This includes functionalities like file system operations, path resolution, logging, string manipulation, and general data processing. It promotes code reusability across different components.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py#L1-L999999" target="_blank" rel="noopener noreferrer">`nf_core.utils` (1:999999)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,253 @@
+```mermaid
+
+graph LR
+
+    CLI_Interface["CLI Interface"]
+
+    Component_Lifecycle_Management["Component Lifecycle Management"]
+
+    Pipeline_Management_Schema["Pipeline Management & Schema"]
+
+    Repository_Sync_Services["Repository & Sync Services"]
+
+    Core_Utilities_Configuration["Core Utilities & Configuration"]
+
+    Test_Data_Management["Test Data Management"]
+
+    CLI_Interface -- "calls" --> Component_Lifecycle_Management
+
+    CLI_Interface -- "calls" --> Pipeline_Management_Schema
+
+    CLI_Interface -- "calls" --> Test_Data_Management
+
+    CLI_Interface -- "utilizes" --> Core_Utilities_Configuration
+
+    Component_Lifecycle_Management -- "utilizes" --> Repository_Sync_Services
+
+    Component_Lifecycle_Management -- "utilizes" --> Core_Utilities_Configuration
+
+    Pipeline_Management_Schema -- "utilizes" --> Repository_Sync_Services
+
+    Pipeline_Management_Schema -- "utilizes" --> Core_Utilities_Configuration
+
+    Repository_Sync_Services -- "relies on" --> Core_Utilities_Configuration
+
+    Test_Data_Management -- "utilizes" --> Core_Utilities_Configuration
+
+    click CLI_Interface href "https://github.com/nf-core/tools/blob/main/.codeboarding//CLI_Interface.md" "Details"
+
+    click Pipeline_Management_Schema href "https://github.com/nf-core/tools/blob/main/.codeboarding//Pipeline_Management_Schema.md" "Details"
+
+    click Repository_Sync_Services href "https://github.com/nf-core/tools/blob/main/.codeboarding//Repository_Sync_Services.md" "Details"
+
+    click Core_Utilities_Configuration href "https://github.com/nf-core/tools/blob/main/.codeboarding//Core_Utilities_Configuration.md" "Details"
+
+    click Test_Data_Management href "https://github.com/nf-core/tools/blob/main/.codeboarding//Test_Data_Management.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `tools` project, functioning as a CLI Application, SDK/Framework Helper Tool, and Developer Tool, exhibits a modular and layered architecture. The core components are designed to manage Nextflow pipelines and reusable components (modules and subworkflows), with clear separation between the user interface, domain logic, and underlying utility services.
+
+
+
+### CLI Interface [[Expand]](./CLI_Interface.md)
+
+The primary user interaction layer, responsible for parsing command-line arguments and dispatching requests to the appropriate application logic. It acts as the presentation layer, translating user commands into calls to the core functionalities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/__main__.py" target="_blank" rel="noopener noreferrer">`nf_core.__main__`</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/commands_modules.py" target="_blank" rel="noopener noreferrer">`nf_core.commands_modules`</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/commands_pipelines.py" target="_blank" rel="noopener noreferrer">`nf_core.commands_pipelines`</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/commands_subworkflows.py" target="_blank" rel="noopener noreferrer">`nf_core.commands_subworkflows`</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/commands_test_datasets.py" target="_blank" rel="noopener noreferrer">`nf_core.commands_test_datasets`</a>
+
+
+
+
+
+### Component Lifecycle Management
+
+Manages the full lifecycle of reusable Nextflow components (modules and subworkflows), including creation, installation, updating, removal, listing, information retrieval, patching, version bumping, and linting. It provides a unified interface for managing these workflow building blocks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/components/components_command.py" target="_blank" rel="noopener noreferrer">`nf_core.components.components_command`</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/components/create.py" target="_blank" rel="noopener noreferrer">`nf_core.components.create.ComponentCreate`</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/components/install.py#L29-L348" target="_blank" rel="noopener noreferrer">`nf_core.components.install.ComponentInstall` (29:348)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/components/update.py#L25-L1021" target="_blank" rel="noopener noreferrer">`nf_core.components.update.ComponentUpdate` (25:1021)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/components/remove.py#L17-L188" target="_blank" rel="noopener noreferrer">`nf_core.components.remove.ComponentRemove` (17:188)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/components/list.py#L14-L175" target="_blank" rel="noopener noreferrer">`nf_core.components.list.ComponentList` (14:175)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/components/info.py#L23-L377" target="_blank" rel="noopener noreferrer">`nf_core.components.info.ComponentInfo` (23:377)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/components/patch.py#L16-L233" target="_blank" rel="noopener noreferrer">`nf_core.components.patch.ComponentPatch` (16:233)</a>
+
+- `nf_core.components.lint.ComponentLint`
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/modules/create.py#L7-L33" target="_blank" rel="noopener noreferrer">`nf_core.modules.create.ModuleCreate` (7:33)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/modules/install.py#L3-L25" target="_blank" rel="noopener noreferrer">`nf_core.modules.install.ModuleInstall` (3:25)</a>
+
+- `nf_core.modules.lint.ModuleLint`
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/subworkflows/create.py#L7-L23" target="_blank" rel="noopener noreferrer">`nf_core.subworkflows.create.SubworkflowCreate` (7:23)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/subworkflows/install.py#L3-L25" target="_blank" rel="noopener noreferrer">`nf_core.subworkflows.install.SubworkflowInstall` (3:25)</a>
+
+- `nf_core.subworkflows.lint.SubworkflowLint`
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/modules/bump_versions.py" target="_blank" rel="noopener noreferrer">`nf_core.modules.bump_versions.ModuleVersionBumper`</a>
+
+
+
+
+
+### Pipeline Management & Schema [[Expand]](./Pipeline_Management_Schema.md)
+
+Handles the complete lifecycle of Nextflow pipelines, encompassing creation, version bumping, linting, downloading, parameter file generation, launching, listing, RO-Crate generation, and synchronization. It also includes the definition, validation, building, and documentation of pipeline schemas to ensure parameter adherence.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/create/create.py" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.create.create.PipelineCreate`</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/bump_version.py" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.bump_version`</a>
+
+- `nf_core.pipelines.lint.PipelineLint`
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/download.py#L85-L1574" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.download.DownloadWorkflow` (85:1574)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/params_file.py#L73-L287" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.params_file.ParamsFileBuilder` (73:287)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/launch.py#L23-L739" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.launch.Launch` (23:739)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/list.py#L75-L274" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.list.Workflows` (75:274)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/rocrate.py#L60-L363" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.rocrate.ROCrate` (60:363)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/sync.py#L40-L503" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.sync.PipelineSync` (40:503)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/create_logo.py#L12-L111" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.create_logo` (12:111)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py" target="_blank" rel="noopener noreferrer">`nf_core.utils.Pipeline`</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/schema.py#L25-L1015" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.schema.PipelineSchema` (25:1015)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/create/utils.py#L39-L89" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.create.utils.CreateConfig` (39:89)</a>
+
+
+
+
+
+### Repository & Sync Services [[Expand]](./Repository_Sync_Services.md)
+
+Provides core functionalities for interacting with Git repositories, including cloning, checking out branches/commits, and managing local repository states. It also encapsulates the synchronization logic for keeping local repositories up-to-date with remote sources.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/synced_repo.py#L59-L498" target="_blank" rel="noopener noreferrer">`nf_core.synced_repo.SyncedRepo` (59:498)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/modules/modules_repo.py#L20-L153" target="_blank" rel="noopener noreferrer">`nf_core.modules.modules_repo.ModulesRepo` (20:153)</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/pipelines/download.py#L1577-L1850" target="_blank" rel="noopener noreferrer">`nf_core.pipelines.download.WorkflowRepo` (1577:1850)</a>
+
+
+
+
+
+### Core Utilities & Configuration [[Expand]](./Core_Utilities_Configuration.md)
+
+A foundational layer offering general-purpose utility functions, including file I/O operations, loading and managing application configurations (YAML/JSON), interacting with the GitHub API, executing external commands, and other common helper functions used across the application.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py" target="_blank" rel="noopener noreferrer">`nf_core.utils`</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py" target="_blank" rel="noopener noreferrer">`nf_core.utils.NFCoreYamlConfig`</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py" target="_blank" rel="noopener noreferrer">`nf_core.utils.NFCoreTemplateConfig`</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py" target="_blank" rel="noopener noreferrer">`nf_core.utils.NFCoreYamlLintConfig`</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/utils.py" target="_blank" rel="noopener noreferrer">`nf_core.utils.GitHubAPISession`</a>
+
+
+
+
+
+### Test Data Management [[Expand]](./Test_Data_Management.md)
+
+Facilitates the listing, searching, and potentially downloading of test datasets required for pipeline and component testing. It primarily interacts with remote GitHub repositories to retrieve dataset information and download URLs.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/test_datasets/list.py" target="_blank" rel="noopener noreferrer">`nf_core.test_datasets.list`</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/test_datasets/search.py" target="_blank" rel="noopener noreferrer">`nf_core.test_datasets.search`</a>
+
+- <a href="https://github.com/nf-core/tools/blob/main/nf_core/test_datasets/test_datasets_utils.py" target="_blank" rel="noopener noreferrer">`nf_core.test_datasets.test_datasets_utils`</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
In this PR, I'm introducing diagram-first documentation to help users quickly understand the main flow of the project by visualizing abstract components and their interactions. This approach is especially useful for scientists and researchers who typically focus on specific parts of a codebase—often the methods rather than the infrastructure. The diagrams provide clear entry points into the pipeline, making it easier to edit components with full context.

To see how it renders check here: https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/tools/on_boarding.md

We’ve also published a GitHub Action that keeps the diagrams in sync with code changes. I'd be happy to help integrate that here if there’s interest (meaning adding the action and using it properly with `generate-api-docs.sh`).

Would love your feedback, and happy to connect to explore how this could be useful for nf-core!

Full disclosure: we're exploring this as part of an early-stage startup idea.


## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] Documentation in `docs` is updated
