### PR TITLE
don't read param expressions with spaces as params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### General
 
+- don't read param expressions with spaces as params ([#3674](https://github.com/nf-core/tools/pull/3674))
+
 ## [v3.3.2 - Tungsten Tamarin Patch 2](https://github.com/nf-core/tools/releases/tag/3.3.2) - [2025-07-08]
 
 ### Template

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -326,7 +326,7 @@ def fetch_wf_config(wf_path: Path, cache_config: bool = True) -> dict:
     if result is not None:
         nfconfig_raw, _ = result
         nfconfig = nfconfig_raw.decode("utf-8")
-        multiline_key_value_pattern = re.compile(r"(^|\n)([^\n=]+?)\s*=\s*((?:(?!\n[^\n=]+?\s*=).)*)", re.DOTALL)
+        multiline_key_value_pattern = re.compile(r"(^|\n)([^\n=\s]+?)\s*=\s*((?:(?!\n[^\n=]+?\s*=).)*)", re.DOTALL)
 
         for config_match in multiline_key_value_pattern.finditer(nfconfig):
             k = config_match.group(2).strip()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -216,3 +216,11 @@ class TestUtils(TestPipelines):
             with nf_core.utils.set_wd(self.tmp_dir):
                 raise Exception
         assert wd_before_context == Path().resolve()
+
+    @mock.patch("nf_core.utils.run_cmd")
+    def test_fetch_wf_config(self, mock_run_cmd):
+        """Test the fetch_wf_config() regular expression to read config params."""
+        mock_run_cmd.return_value = (b"params.param1 ? 'a=b' : ''\nparams.param2 = foo", b"mock")
+        config = nf_core.utils.fetch_wf_config(".", False)
+        assert len(config.keys()) == 1
+        assert "params.param2" in list(config.keys())


### PR DESCRIPTION
Close https://github.com/nf-core/tools/issues/3672

https://regex101.com/r/xuh0TQ/1
The expressions that contain spaces are not read as if they were param variables.