### PR TITLE
TEMPLATE - add trainling slash for pipelines_testdata_base_path

### DIFF
--- a/nf_core/pipeline-template/tests/nextflow.config
+++ b/nf_core/pipeline-template/tests/nextflow.config
@@ -8,7 +8,7 @@
 // Or any resources requirements
 params {
     modules_testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/'
-    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/{{ short_name }}'
+    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/{{ short_name }}/'
 }
 
 aws.client.anonymous = true // fixes S3 access issues on self-hosted runners


### PR DESCRIPTION
from @vagkaratzas

> Would it be too much pain to put a slash at the end of pipelines_testdata_base_path in tests/nextflow.config, in the next template update? Currently it's different to the modules_testdata_base_path above. Would be nice to have uniformity in tests throughout conf/ tests/  and modules-subworkflows tests. I've left a relevant though-comment on this PR: https://github.com/nf-core/methylseq/pull/558#discussion_r2253615940

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/main/.github/CONTRIBUTING.md
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
