### PR TITLE
Patch patch command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Update pre-commit hook pre-commit/mirrors-mypy to v1.17.1 ([#3698](https://github.com/nf-core/tools/pull/3698))
 - Update python:3.13-slim Docker digest to 4c2cf99 ([#3700](https://github.com/nf-core/tools/pull/3700))
 - Validation of meta.yaml in cross-org repos ([#3680](https://github.com/nf-core/tools/pull/3680))
+- Patch patch command ([#3714](https://github.com/nf-core/tools/pull/3714))
 
 ## [v3.3.2 - Tungsten Tamarin Patch 2](https://github.com/nf-core/tools/releases/tag/3.3.2) - [2025-07-08]
 

--- a/nf_core/components/components_differ.py
+++ b/nf_core/components/components_differ.py
@@ -79,7 +79,6 @@ class ComponentsDiffer:
 
         # Loop through all the component files and compute their diffs if needed
         for file in files:
-            log.info(file)
             diff = ComponentsDiffer.get_file_diff(
                 file=file,
                 to_dir=to_dir,
@@ -100,7 +99,7 @@ class ComponentsDiffer:
             ans = "i" if ignore_files[file] else "w"
         else:
             log.warning(
-                f"We failed to read the [bold red]{file}[/] file. Please check that the component's directory contains only text files."
+                f"We failed to read the file: [bold red]{file}[/]. Please check that the component's directory contains only text files."
             )
             ans = questionary.select(
                 "Do you still want to proceed with constructing the diff?",
@@ -380,7 +379,6 @@ class ComponentsDiffer:
             elif diff_status == ComponentsDiffer.DiffEnum.TO_DECODE_FAIL:
                 # We failed to decode the file
                 log.debug(f"'{Path(dsp_to_dir, file)}' failed to be decoded")
-                file_content = "[bold red]Failed to decode[/]"
                 file_content = "[bold red]Failed to decode new file[/]"
             elif diff_status == ComponentsDiffer.DiffEnum.FROM_DECODE_FAIL:
                 # We failed to decode the file

--- a/nf_core/components/patch.py
+++ b/nf_core/components/patch.py
@@ -112,6 +112,7 @@ class ComponentPatch(ComponentCommand):
 
         # Write the patch to a temporary location (otherwise it is printed to the screen later)
         patch_temp_path = tempfile.mktemp()
+        ignore_files = {}  # This dict carries files which we have failed to read, and what we should do with them. Very hacky
         try:
             ComponentsDiffer.write_diff_file(
                 patch_temp_path,
@@ -122,6 +123,7 @@ class ComponentPatch(ComponentCommand):
                 for_git=False,
                 dsp_from_dir=component_relpath,
                 dsp_to_dir=component_relpath,
+                ignore_files=ignore_files,
             )
             log.debug(f"Patch file wrote to a temporary directory {patch_temp_path}")
         except UserWarning:
@@ -144,6 +146,7 @@ class ComponentPatch(ComponentCommand):
             component_current_dir,
             dsp_from_dir=component_current_dir,
             dsp_to_dir=component_current_dir,
+            ignore_files=ignore_files,
         )
 
         # Check if we should remove an old patch file


### PR DESCRIPTION
This PR addresses the issue raised in https://github.com/nf-core/tools/issues/3708. It does this by catching the `UnicodeDecodeError` and prompting the user for an action. This way, the user can more easily see if the undecoded file should be there or not. The user then has the option to include the warning in the diff, if the file should be ignored or if the diff creation should be aborted altogether.

To not prompt several times I've added an ignore list as an attribute to the `print_diff` and `write_diff` functions. This is updated when a an erronenous file is found. If passed to the next function (see `patch.py`) the ignore list is used instead of prompting the user.

A better solution is likely to convert the `ComponentsDiffer` class from a static to a normal class. Then the ignore list, and other things could be attributes of the class instead.

I've also updated the output from the `patch` command which showed the diff several times. Now it prints a panel with all changes instead of printing some with the logger.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
