### PR TITLE
Remove workflow.trace from nf-test snapshot

### DIFF
--- a/nf_core/pipeline-template/tests/default.nf.test
+++ b/nf_core/pipeline-template/tests/default.nf.test
@@ -20,8 +20,6 @@ nextflow_pipeline {
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(
-                    // Number of successful tasks
-                    workflow.trace.succeeded().size(),
                     // pipeline versions.yml file for multiqc from which Nextflow version is removed because we test pipelines on multiple Nextflow versions
                     removeNextflowVersion("$outputDir/pipeline_info/{% if is_nfcore %}nf_core_{% endif %}{{ short_name }}_software_mqc_versions.yml"),
                     // All stable path name, with a relative path

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,8 +11,6 @@ types-PyYAML
 types-requests
 types-jsonschema
 types-Markdown
-types-PyYAML
-types-requests
 types-setuptools
 typing_extensions >=4.0.0
 pytest-asyncio
@@ -20,4 +18,3 @@ pytest-textual-snapshot==1.1.0
 pytest-workflow>=2.0.0
 pytest-xdist>=3.7.0
 pytest>=8.0.0
-ruff


### PR DESCRIPTION
Avodi error due to incompatibilities with nf-test and the latest edge release of nextflow https://github.com/askimed/nf-test/issues/320