### PR TITLE
fix: Remove dependency on dev branch of tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@
 - Update test-datasets list subcommand to output plain text urls and paths for easy copying [#3720](https://github.com/nf-core/tools/pull/3720)
 - Remove workflow.trace from nf-test snapshot ([#3721](https://github.com/nf-core/tools/pull/3721))
 - Add GHA to update template nf-test snapshots ([#3723](https://github.com/nf-core/tools/pull/3723))
-- fix: Remove dependency on dev branch of tools ([#3734](https://github.com/nf-core/tools/pull/3734))
 
 ## [v3.3.2 - Tungsten Tamarin Patch 2](https://github.com/nf-core/tools/releases/tag/3.3.2) - [2025-07-08]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Template
 
+- Update the `download_pipeline` workflow to remove dependency on `dev` branch of tools ([#3734](https://github.com/nf-core/tools/pull/3734))
+
 ### Linting
 
 - ignore files in gitignore also for pipeline_if_empty_null lint test ([#3722](https://github.com/nf-core/tools/pull/3722))

--- a/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
+++ b/nf_core/pipeline-template/.github/workflows/download_pipeline.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install git+https://github.com/nf-core/tools.git@dev
+          pip install git+https://github.com/nf-core/tools.git
 
       - name: Make a cache directory for the container images
         run: |


### PR DESCRIPTION
Fixes https://github.com/nf-core/tools/issues/3732

Changes the `download_pipeline.yml` workflow of the pipeline template to no longer use the `dev` branch when installing `tools`.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
