### PR TITLE
Add Host Requirements to Devcontainer Config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,5 +10,11 @@
     "onCreateCommand": "./.devcontainer/setup.sh",
 
     "remoteUser": "root",
-    "privileged": true
+    "privileged": true,
+
+    "hostRequirements": {
+        "cpus": 4,
+        "memory": "16gb",
+        "storage": "32gb"
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Remove workflow.trace from nf-test snapshot ([#3721](https://github.com/nf-core/tools/pull/3721))
 - Add GHA to update template nf-test snapshots ([#3723](https://github.com/nf-core/tools/pull/3723))
 - Fix backwards compatibility with python 3.9 in use of Enum ([#3736](https://github.com/nf-core/tools/pull/3736))
+- impr: Add hostRequirements to run with 4CPUs and 16GB ram by default … ([#3746](https://github.com/nf-core/tools/pull/3746))
 
 ## [v3.3.2 - Tungsten Tamarin Patch 2](https://github.com/nf-core/tools/releases/tag/3.3.2) - [2025-07-08]
 


### PR DESCRIPTION
Adds a `hostRequirements` section to the devcontainer configuration.

````
        "cpus": 4,
        "memory": "16gb",
        "storage": "32gb"
````

This leads to using the larger (free-tier) machine type available in Codespaces by default.

Locally, these seem to behave like "soft" requirements. If your machine does not satisfy these, you see an alert window like this:
<img width="305" height="295" alt="Screenshot 2025-09-05 at 14 38 04" src="https://github.com/user-attachments/assets/f192bde7-bb54-4ee8-93ea-90cd66f907e3" />


## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
