### PR TITLE
Linting: do not check pytest_modules.yml file, deprecating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@
 ### Linting
 
 - ignore files in gitignore also for pipeline_if_empty_null lint test ([#3722](https://github.com/nf-core/tools/pull/3722))
+- do not check pytest_modules.yml file, deprecating ([#3748](https://github.com/nf-core/tools/pull/3748))
 
 ### Modules
 
 - Support modules with `exec:` blocks ([#3633](https://github.com/nf-core/tools/pull/3633))
 - feat: nf-core modules bump-version supports specifying the toolkit ([#3608](https://github.com/nf-core/tools/pull/3608))
-- Linting: do not check pytest_modules.yml file, deprecating ([#3748](https://github.com/nf-core/tools/pull/3748))
 
 ### Subworkflows
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Support modules with `exec:` blocks ([#3633](https://github.com/nf-core/tools/pull/3633))
 - feat: nf-core modules bump-version supports specifying the toolkit ([#3608](https://github.com/nf-core/tools/pull/3608))
+- Linting: do not check pytest_modules.yml file, deprecating ([#3748](https://github.com/nf-core/tools/pull/3748))
 
 ### Subworkflows
 

--- a/nf_core/commands_modules.py
+++ b/nf_core/commands_modules.py
@@ -183,7 +183,7 @@ def modules_create(
     'modules/local/tool_subtool.nf'
 
     If the specified directory is a clone of nf-core/modules, it creates or modifies files
-    in 'modules/', 'tests/modules' and 'tests/config/pytest_modules.yml'
+    in 'modules/' and 'tests/modules'
     """
     # Combine two bool flags into one variable
     has_meta = None

--- a/nf_core/commands_subworkflows.py
+++ b/nf_core/commands_subworkflows.py
@@ -18,7 +18,7 @@ def subworkflows_create(ctx, subworkflow, directory, author, force, migrate_pyte
     'subworkflows/local/<subworkflow_name>.nf'
 
     If the specified directory is a clone of nf-core/modules, it creates or modifies files
-    in 'subworkflows/', 'tests/subworkflows' and 'tests/config/pytest_modules.yml'
+    in 'subworkflows/' and 'tests/subworkflows'
     """
     from nf_core.subworkflows import SubworkflowCreate
 

--- a/nf_core/components/create.py
+++ b/nf_core/components/create.py
@@ -48,7 +48,7 @@ class ComponentCreate(ComponentCommand):
         conda_name: Optional[str] = None,
         conda_version: Optional[str] = None,
         empty_template: bool = False,
-        migrate_pytest: bool = False,
+        migrate_pytest: bool = False,  # TODO: Deprecate this flag in the future
     ):
         super().__init__(component_type, directory)
         self.directory = directory

--- a/nf_core/modules/lint/module_tests.py
+++ b/nf_core/modules/lint/module_tests.py
@@ -7,8 +7,6 @@ import logging
 import re
 from pathlib import Path
 
-import yaml
-
 from nf_core.components.lint import LintExceptionError
 from nf_core.components.nfcore_component import NFCoreComponent
 
@@ -225,37 +223,6 @@ def module_tests(_, module: NFCoreComponent, allow_missing: bool = False):
                         module.nftest_main_nf,
                     )
                 )
-
-    # Check pytest_modules.yml does not contain entries for modules with nf-test
-    pytest_yml_path = module.base_dir / "tests" / "config" / "pytest_modules.yml"
-    if pytest_yml_path.is_file() and not is_pytest:
-        try:
-            with open(pytest_yml_path) as fh:
-                pytest_yml = yaml.safe_load(fh)
-                if module.component_name in pytest_yml.keys():
-                    module.failed.append(
-                        (
-                            "test_pytest_yml",
-                            "module with nf-test should not be listed in pytest_modules.yml",
-                            pytest_yml_path,
-                        )
-                    )
-                else:
-                    module.passed.append(
-                        (
-                            "test_pytest_yml",
-                            "module with  nf-test not in pytest_modules.yml",
-                            pytest_yml_path,
-                        )
-                    )
-        except FileNotFoundError:
-            module.warned.append(
-                (
-                    "test_pytest_yml",
-                    "Could not open pytest_modules.yml file",
-                    pytest_yml_path,
-                )
-            )
 
     # Check that the old test directory does not exist
     if not is_pytest:

--- a/nf_core/subworkflows/lint/subworkflow_tests.py
+++ b/nf_core/subworkflows/lint/subworkflow_tests.py
@@ -7,8 +7,6 @@ import logging
 import re
 from pathlib import Path
 
-import yaml
-
 from nf_core.components.lint import LintExceptionError
 from nf_core.components.nfcore_component import NFCoreComponent
 
@@ -255,37 +253,6 @@ def subworkflow_tests(_, subworkflow: NFCoreComponent, allow_missing: bool = Fal
                         subworkflow.nftest_main_nf,
                     )
                 )
-
-    # Check pytest_modules.yml does not contain entries for subworkflows with nf-test
-    pytest_yml_path = subworkflow.base_dir / "tests" / "config" / "pytest_modules.yml"
-    if pytest_yml_path.is_file() and not is_pytest:
-        try:
-            with open(pytest_yml_path) as fh:
-                pytest_yml = yaml.safe_load(fh)
-                if "subworkflows/" + subworkflow.component_name in pytest_yml.keys():
-                    subworkflow.failed.append(
-                        (
-                            "test_pytest_yml",
-                            "subworkflow with nf-test should not be listed in pytest_modules.yml",
-                            pytest_yml_path,
-                        )
-                    )
-                else:
-                    subworkflow.passed.append(
-                        (
-                            "test_pytest_yml",
-                            "subworkflow with  nf-test not in pytest_modules.yml",
-                            pytest_yml_path,
-                        )
-                    )
-        except FileNotFoundError:
-            subworkflow.warned.append(
-                (
-                    "test_pytest_yml",
-                    "Could not open pytest_modules.yml file",
-                    pytest_yml_path,
-                )
-            )
 
     # Check that the old test directory does not exist
     if not is_pytest:


### PR DESCRIPTION
We don't have Pytests in nf-core/modules anymore, so the pytest_modules.yml file can be deprecated.