### PR TITLE
Fix Downloads: Clean up temporary files from singularity pull and set correct file permissions for http downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Remove workflow.trace from nf-test snapshot ([#3721](https://github.com/nf-core/tools/pull/3721))
 - Add GHA to update template nf-test snapshots ([#3723](https://github.com/nf-core/tools/pull/3723))
 - Fix backwards compatibility with python 3.9 in use of Enum ([#3736](https://github.com/nf-core/tools/pull/3736))
+- Fix: temporary files not moved and cleaned up correctly after singula… ([#3749](https://github.com/nf-core/tools/pull/3749))
 
 ## [v3.3.2 - Tungsten Tamarin Patch 2](https://github.com/nf-core/tools/releases/tag/3.3.2) - [2025-07-08]
 

--- a/nf_core/pipelines/download/singularity.py
+++ b/nf_core/pipelines/download/singularity.py
@@ -909,4 +909,4 @@ class FileDownloader:
                         raise DownloadError(f"Downloaded file '{remote_path}' is empty")
 
                 # Set image file permissions to user=read,write,execute group/all=read,execute
-                os.chmod(fh, 0x755)
+                os.chmod(fh.name, 0o755)

--- a/nf_core/pipelines/download/singularity.py
+++ b/nf_core/pipelines/download/singularity.py
@@ -907,3 +907,6 @@ class FileDownloader:
                     # Check that we actually downloaded something
                     if not has_content:
                         raise DownloadError(f"Downloaded file '{remote_path}' is empty")
+
+                # Set image file permissions to user=read,write,execute group/all=read,execute
+                os.chmod(fh, 0x755)

--- a/nf_core/pipelines/download/utils.py
+++ b/nf_core/pipelines/download/utils.py
@@ -76,7 +76,7 @@ def intermediate_file_no_creation(output_path: Path) -> Generator[Path, None, No
     tmp_fn = Path(tmp.name) / "tempfile"
     try:
         yield tmp_fn
-        Path(tmp.name).rename(output_path)
+        tmp_fn.rename(output_path)
         tmp.cleanup()
     except:
         tmp.cleanup()


### PR DESCRIPTION
Fixes https://github.com/nf-core/tools/issues/3742

For those images, where no http download can be used and the `singularity pull` command is used. The temporary files were not properly moved / cleared up after.

Also closes https://github.com/nf-core/tools/issues/3730 by setting the correct file permissions for those images downloaded via http in python.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
