### PR TITLE
Subworkflow patch

### DIFF
--- a/nf_core/components/info.py
+++ b/nf_core/components/info.py
@@ -165,7 +165,7 @@ class ComponentInfo(ComponentCommand):
             self.meta = self.get_remote_yaml()
 
         # Could not find the meta
-        if self.meta is False:
+        if self.meta is None:
             raise UserWarning(f"Could not find {self.component_type[:-1]} '{self.component}'")
 
         return self.generate_component_info_help()

--- a/nf_core/subworkflows/lint/subworkflow_changes.py
+++ b/nf_core/subworkflows/lint/subworkflow_changes.py
@@ -42,7 +42,13 @@ def subworkflow_changes(subworkflow_lint_object, subworkflow):
                 with open(tempdir / file, "w") as fh:
                     fh.writelines(lines)
         except LookupError:
-            # This error is already reported by subworkflow_patch, so just return
+            subworkflow.failed.append(
+                (
+                    "subworkflow_patch",
+                    "Subworkflow patch cannot be cleanly applied",
+                    f"{subworkflow.component_dir}",
+                )
+            )
             return
     else:
         tempdir = subworkflow.component_dir


### PR DESCRIPTION
Hello,

One of our pipelines had a faulty subworkflow patch and I investigated why it wasn't reported by `nf-core pipelines lint`.

The main problem is that the `LookupError` was ignored. I don't know what "This error is already reported by subworkflow_patch" is referring to. It certainly wasn't working ! So here I propose to directly log an error.

The other problem is I think unrelated, but I found that while debugging. As far as I can tell, `self.meta` cannot be `False`. It can be `None`, though.

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/main/.github/CONTRIBUTING.md
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
