### PR TITLE
added helpful comment for common gotcha - prefix scoping

### DIFF
--- a/nf_core/module-template/main.nf
+++ b/nf_core/module-template/main.nf
@@ -78,6 +78,9 @@ process {{ component_name_underscore|upper }} {
     script:
     def args = task.ext.args ?: ''
     {% if has_meta -%}
+    // TODO nf-core: The $prefix variable as defined below is ONLY available within the script block.
+    //               If $prefix is required elsewhere (eg in output block), remove the def keyword.
+    //               For further information on variable scope see https://midnighter.github.io/nextflow-gotchas/gotchas/variable-scope/
     def prefix = task.ext.prefix ?: "${meta.id}"
     {%- endif %}
     {% if not_empty_template -%}


### PR DESCRIPTION
A common gotcha when creating a new module using the nf-core template is the `prefix` variable is created using `def` keyword, which creates a local variable (in this case the `script` block).

```
output:
    tuple val(meta), path("${prefix}.perfile.tsv"),     optional:true, emit: summary

    script:
    ...
    def prefix = task.ext.prefix ?: "${meta.id}"
```

But common usage of `prefix` extends outside of local scope. The gotcha is the combination of using `def` and a nextflow `process` containing multiple scoping blocks.

This tiny pull request adds a comment to assist and remind people of this gotcha. 

## PR checklist

- [X] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated -> I have not updated changelog.md, is this needed for such a tiny change?


