### PR TITLE
Fix `--help` with strict syntax mode

### DIFF
--- a/nf_core/pipeline-template/subworkflows/nf-core/utils_nfschema_plugin/main.nf
+++ b/nf_core/pipeline-template/subworkflows/nf-core/utils_nfschema_plugin/main.nf
@@ -38,7 +38,7 @@ workflow UTILS_NFSCHEMA_PLUGIN {
         }
         log.info paramsHelp(
             help_options,
-            params.help instanceof String ? params.help : "",
+            (params.help instanceof String && params.help != "true") ? params.help : "",
         )
         exit 0
     }


### PR DESCRIPTION
Fix parsing error from Nextflow strict syntax mode, affecting a bunch of pipelines.

See https://github.com/nf-core/rnavar/pull/278 for initial repro and fix.