### PR TITLE
Simplify nextflow_schema.json title to just pipeline name

### DIFF
--- a/nf_core/pipeline-template/nextflow_schema.json
+++ b/nf_core/pipeline-template/nextflow_schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/{{ name }}/{{ default_branch }}/nextflow_schema.json",
-    "title": "{{ name }} pipeline parameters",
+    "title": "{{ name }}",
     "description": "{{ description }}",
     "type": "object",
     "$defs": {

--- a/nf_core/pipeline-template/subworkflows/nf-core/utils_nfschema_plugin/tests/nextflow_schema.json
+++ b/nf_core/pipeline-template/subworkflows/nf-core/utils_nfschema_plugin/tests/nextflow_schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/./master/nextflow_schema.json",
-    "title": ". pipeline parameters",
+    "title": ".",
     "description": "",
     "type": "object",
     "$defs": {

--- a/nf_core/pipelines/lint/schema_lint.py
+++ b/nf_core/pipelines/lint/schema_lint.py
@@ -31,7 +31,7 @@ def schema_lint(self):
 
         * ``$schema``: ``https://json-schema.org/draft-07/schema`` or ``https://json-schema.org/draft/2020-12/schema``
         * ``$id``: URL to the raw schema file, eg. ``https://raw.githubusercontent.com/YOURPIPELINE/master/nextflow_schema.json``
-        * ``title``: ``YOURPIPELINE pipeline parameters``
+        * ``title``: ``YOURPIPELINE``
         * ``description``: The pipeline config ``manifest.description``
     * That the ``input`` property is defined and has a mimetype. A list of common mimetypes can be found `here <https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types>`_.
 
@@ -42,7 +42,7 @@ def schema_lint(self):
        {
          "$schema": "https://json-schema.org/draft-07/schema",
          "$id": "https://raw.githubusercontent.com/YOURPIPELINE/master/nextflow_schema.json",
-         "title": "YOURPIPELINE pipeline parameters",
+         "title": "YOURPIPELINE",
          "description": "This pipeline is for testing",
          "properties": {
            "first_param": { "type": "string" }
@@ -64,7 +64,7 @@ def schema_lint(self):
        {
          "$schema": "https://json-schema.org/draft/2020-12/schema",
          "$id": "https://raw.githubusercontent.com/YOURPIPELINE/master/nextflow_schema.json",
-         "title": "YOURPIPELINE pipeline parameters",
+         "title": "YOURPIPELINE",
          "description": "This pipeline is for testing",
          "properties": {
            "first_param": { "type": "string" }

--- a/nf_core/pipelines/schema.py
+++ b/nf_core/pipelines/schema.py
@@ -515,7 +515,7 @@ class PipelineSchema:
                     f"Schema `$id` should be `{id_attr}` or {id_attr.replace('/main/', '/master/')}. \n Found `{self.schema['$id']}`"
                 )
 
-            title_attr = "{} pipeline parameters".format(self.pipeline_manifest["name"].strip("\"'"))
+            title_attr = self.pipeline_manifest["name"].strip("\"'")
             if self.schema["title"] != title_attr:
                 raise AssertionError(f"Schema `title` should be `{title_attr}`\n Found: `{self.schema['title']}`")
 

--- a/tests/pipelines/test_schema.py
+++ b/tests/pipelines/test_schema.py
@@ -223,7 +223,7 @@ class TestSchema(unittest.TestCase):
         self.schema_obj.pipeline_manifest["description"] = "Test pipeline"
         self.schema_obj.make_skeleton_schema()
         self.schema_obj.validate_schema(self.schema_obj.schema)
-        assert self.schema_obj.schema["title"] == "nf-core/test pipeline parameters"
+        assert self.schema_obj.schema["title"] == "nf-core/test"
 
     def test_make_skeleton_schema_absent_name(self):
         """Test making a new schema skeleton"""
@@ -231,7 +231,7 @@ class TestSchema(unittest.TestCase):
         self.schema_obj.pipeline_manifest["description"] = "Test pipeline"
         self.schema_obj.make_skeleton_schema()
         self.schema_obj.validate_schema(self.schema_obj.schema)
-        assert self.schema_obj.schema["title"] == "wf pipeline parameters"
+        assert self.schema_obj.schema["title"] == "wf"
 
     def test_get_wf_params(self):
         """Test getting the workflow parameters from a pipeline"""


### PR DESCRIPTION
## Summary

- Remove " pipeline parameters" suffix from the `nextflow_schema.json` title attribute
- The title now just contains the pipeline name (e.g., `nf-core/rnaseq` instead of `nf-core/rnaseq pipeline parameters`)

## Changes

- Updated template `nextflow_schema.json` title from `{{ name }} pipeline parameters` to `{{ name }}`
- Updated schema validation in `schema.py` to expect just the pipeline name
- Updated lint documentation examples in `schema_lint.py`
- Updated test assertions in `test_schema.py`
- Updated test schema in `utils_nfschema_plugin`