### PR TITLE
Skip pre-commit in component directories other than local in template

### DIFF
--- a/nf_core/pipeline-template/.pre-commit-config.yaml
+++ b/nf_core/pipeline-template/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
           (?x)^(
               .*ro-crate-metadata.json$|
               modules/(?!local/).*|
-              subworkflow/(?!local/).*|
+              subworkflows/(?!local/).*|
               .*\.snap$
           )$
       - id: end-of-file-fixer

--- a/nf_core/pipeline-template/.pre-commit-config.yaml
+++ b/nf_core/pipeline-template/.pre-commit-config.yaml
@@ -13,15 +13,15 @@ repos:
         exclude: |
           (?x)^(
               .*ro-crate-metadata.json$|
-              modules/nf-core/.*|
-              subworkflows/nf-core/.*|
+              modules/(?!local/).*|
+              subworkflow/(?!local/).*|
               .*\.snap$
           )$
       - id: end-of-file-fixer
         exclude: |
           (?x)^(
               .*ro-crate-metadata.json$|
-              modules/nf-core/.*|
-              subworkflows/nf-core/.*|
+              modules/(?!local/).*|
+              subworkflows/(?!local/).*|
               .*\.snap$
           )$


### PR DESCRIPTION
Tools supports installing modules and subworkflows from other remotes than just nf-core, but these components are not excluded from changes when running pre-commit.

I recently ran into a problem where pre-commit was fixing a git diff created by patching a subworkflow, causing a linting failure as the patch was no longer applicable.

This PR excludes all directories inside modules/ and subworkflows/ except local/ from pre-commit in the pipeline template, allowing files from other remotes to remain unchanged.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
