### PR TITLE
Fix incompatible Docker Daemon Version in Devcontainer

### DIFF
--- a/.devcontainer/build-devcontainer/devcontainer.json
+++ b/.devcontainer/build-devcontainer/devcontainer.json
@@ -14,7 +14,8 @@
     },
 
     "remoteEnv": {
-        "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}"
+        "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",
+        "DOCKER_API_VERSION": "1.43"
     },
 
     "remoteUser": "root",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### General
 
+- Fix incompatible Docker Daemon Version in Devcontainer ([#4029](https://github.com/nf-core/tools/pull/4029))
+
 ### Linting
 
 ### Modules


### PR DESCRIPTION
* Fixes DOCKER_API_VERSION to 1.43 
* This is intended as a fix, while the docker server on github codespaces machines is not updated. API version before 1.44 are deprecated! (see: https://docs.docker.com/reference/api/engine/)

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
