### PR TITLE
Always prettify modules.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Modules
 
 - Template: have a `main:` section in workflow even when modules are skipped ([#4043](https://github.com/nf-core/tools/pull/4043))
+- Always prettify modules.json ([#4063](https://github.com/nf-core/tools/pull/4063))
 
 ### Subworkflows
 

--- a/nf_core/components/install.py
+++ b/nf_core/components/install.py
@@ -132,6 +132,9 @@ class ComponentInstall(ComponentCommand):
             )
             modules_json.load()
             modules_json.update(self.component_type, self.modules_repo, component, current_version, self.installed_by)
+            if not silent:
+                modules_json.load()
+                modules_json.dump(run_prettier=True)
             return False
         try:
             version = self.get_version(component, self.current_sha, self.prompt, current_version, self.modules_repo)

--- a/nf_core/components/remove.py
+++ b/nf_core/components/remove.py
@@ -151,6 +151,10 @@ class ComponentRemove(ComponentCommand):
             )
             removed_components.append(component)
 
+        # Prettify modules.json file after all changes have been made
+        modules_json.load()
+        modules_json.dump(run_prettier=True)
+
         if removed:
             if self.component_type == "subworkflows":
                 removed_by = component

--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -823,7 +823,7 @@ class ModulesJson:
             )
         self.modules_json["repos"][repo_url][component_type][install_dir][component_name]["patch"] = str(patch_filename)
         if write_file:
-            self.dump()
+            self.dump(run_prettier=True)
 
     def remove_patch_entry(self, module_name, repo_url, install_dir, write_file=True):
         if self.modules_json is None:
@@ -835,7 +835,7 @@ class ModulesJson:
         except KeyError:
             log.warning("No patch entry in 'modules.json' to remove")
         if write_file:
-            self.dump()
+            self.dump(run_prettier=True)
 
     def get_patch_fn(self, component_type, component_name, repo_url, install_dir):
         """


### PR DESCRIPTION
I got a bit tired of having to re-run prettier after nf-core commands because they change the layout of `modules.json` (especially around `installed_by`).

This is a patch to make prettier the default write mode for modules.json

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/main/.github/CONTRIBUTING.md
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
