### PR TITLE
Fix get_wf_files to use git ls-files

### DIFF
--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -6,7 +6,6 @@ import ast
 import concurrent.futures
 import datetime
 import errno
-import fnmatch
 import hashlib
 import io
 import json
@@ -1671,27 +1670,10 @@ def set_wd(path: Path) -> Generator[None, None, None]:
 
 
 def get_wf_files(wf_path: Path):
-    """Return a list of all files in a directory (ignores .gitigore files)"""
+    """Return a list of all files in a directory (respects .gitignore)"""
 
-    wf_files = []
-
-    ignore = [".git/*"]
     try:
-        with open(Path(wf_path, ".gitignore")) as f:
-            for line in f.read().splitlines():
-                if not line or line.startswith("#"):
-                    continue
-                # Make trailing-slash patterns match their entire subtree
-                line = re.sub("/$", "/*", line)
-                ignore.append(line)
-    except FileNotFoundError:
-        pass
-
-    for path in Path(wf_path).rglob("*"):
-        rpath = str(path.relative_to(wf_path))
-        if any(fnmatch.fnmatch(rpath, pattern) for pattern in ignore):
-            continue
-        if path.is_file():
-            wf_files.append(str(path))
-
-    return wf_files
+        git_ls_files = subprocess.check_output(["git", "ls-files"], cwd=wf_path).splitlines()
+        return [str(Path(wf_path) / fn.decode("utf-8")) for fn in git_ls_files if (Path(wf_path) / fn.decode("utf-8")).is_file()]
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return [str(p) for p in Path(wf_path).rglob("*") if p.is_file() and ".git" not in p.parts]

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -1670,10 +1670,12 @@ def set_wd(path: Path) -> Generator[None, None, None]:
 
 
 def get_wf_files(wf_path: Path):
-    """Return a list of all files in a directory (respects .gitignore)"""
-
-    try:
-        git_ls_files = subprocess.check_output(["git", "ls-files"], cwd=wf_path).splitlines()
-        return [str(Path(wf_path) / fn.decode("utf-8")) for fn in git_ls_files if (Path(wf_path) / fn.decode("utf-8")).is_file()]
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return [str(p) for p in Path(wf_path).rglob("*") if p.is_file() and ".git" not in p.parts]
+    """Return a list of all files in a directory (respects .gitignore via git ls-files)"""
+    git_ls_files = subprocess.check_output(
+        ["git", "ls-files"],
+        cwd=wf_path,
+        stderr=subprocess.DEVNULL,
+    ).splitlines()
+    return [
+        str(Path(wf_path) / fn.decode("utf-8")) for fn in git_ls_files if (Path(wf_path) / fn.decode("utf-8")).is_file()
+    ]

--- a/tests/pipelines/lint/test_if_empty_null.py
+++ b/tests/pipelines/lint/test_if_empty_null.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 
 import yaml
@@ -33,6 +34,7 @@ class TestLintIfEmptyNull(TestLint):
                     "| ifEmpty(null)\n",
                 ]
             )
+        subprocess.check_call(["git", "add", "docs/test.txt"], cwd=self.new_pipeline)
         lint_obj = nf_core.pipelines.lint.PipelineLint(self.new_pipeline)
         lint_obj._load()
         result = lint_obj.pipeline_if_empty_null()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 """Tests covering for utility functions."""
 
 import os
+import subprocess
 from pathlib import Path
 from unittest import mock
 
@@ -228,9 +229,9 @@ class TestUtils(TestPipelines):
     @with_temporary_folder
     def test_get_wf_files(self, tmpdir):
         tmpdir = Path(tmpdir)
+        subprocess.check_call(["git", "init"], cwd=tmpdir)
         (tmpdir / ".gitignore").write_text(".nextflow*\nwork/\nresults/\n")
         for rpath in [
-            ".git/should-ignore-1",
             "work/should-ignore-2",
             "results/should-ignore-3",
             ".nextflow.should-ignore-4",
@@ -240,6 +241,10 @@ class TestUtils(TestPipelines):
             p = tmpdir / rpath
             p.parent.mkdir(exist_ok=True)
             p.touch()
+        subprocess.check_call(
+            ["git", "add", ".gitignore", "dir1/should-match-1", "should-match-2"],
+            cwd=tmpdir,
+        )
         files = nf_core.utils.get_wf_files(tmpdir)
         files = sorted(str(Path(f).relative_to(tmpdir)) for f in files)
         assert files == [".gitignore", "dir1/should-match-1", "should-match-2"]


### PR DESCRIPTION
## Description

`get_wf_files()` uses `fnmatch` to filter files based on `.gitignore` patterns, but `fnmatch` does not implement gitignore semantics correctly. For example, a `.gitignore` entry `work/` should match `scripts/work/` at any depth, but `fnmatch.fnmatch("scripts/work/file", "work/*")` returns `False`. This causes `pipeline_if_empty_null` (the only caller) to walk and open every file in untracked directories — freezing indefinitely on pipelines with large Nextflow work directories.

Replace the manual `.gitignore` parsing + `fnmatch` approach with `git ls-files`, which natively respects all `.gitignore` rules. This matches the existing `Pipeline.list_files()` method that already uses this approach.