### PR TITLE
Fix lint: preserve underscores for subworkflow includes via full path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### Subworkflows
 
 - update test to new upstream subworkflow structure ([#4038](https://github.com/nf-core/tools/pull/4038))
+- Fix lint: preserve underscores for subworkflow includes via full path ([#4074](https://github.com/nf-core/tools/pull/4074))
 
 ### Pipeline template
 

--- a/nf_core/components/components_utils.py
+++ b/nf_core/components/components_utils.py
@@ -162,12 +162,17 @@ def get_components_to_install(
             if match and len(match.groups()) == 2:
                 name, link = match.groups()
                 if link.startswith("../../../"):
-                    name_split = name.lower().split("_")
-                    component_name = "/".join(name_split)
-                    component_dict: dict[str, str] = {
-                        "name": component_name,
-                    }
-                    modules[component_name] = component_dict
+                    if "subworkflows" in link:
+                        component_name = name.lower()
+                        component_dict: dict[str, str] = {"name": component_name}
+                        subworkflows[component_name] = component_dict
+                    else:
+                        name_split = name.lower().split("_")
+                        component_name = "/".join(name_split)
+                        component_dict = {
+                            "name": component_name,
+                        }
+                        modules[component_name] = component_dict
                 elif link.startswith("../"):
                     component_name = name.lower()
                     component_dict = {"name": component_name}

--- a/nf_core/components/components_utils.py
+++ b/nf_core/components/components_utils.py
@@ -162,7 +162,7 @@ def get_components_to_install(
             if match and len(match.groups()) == 2:
                 name, link = match.groups()
                 if link.startswith("../../../"):
-                    if "subworkflows" in link:
+                    if "../subworkflows/" in link:
                         component_name = name.lower()
                         component_dict: dict[str, str] = {"name": component_name}
                         subworkflows[component_name] = component_dict

--- a/tests/components/test_components_utils.py
+++ b/tests/components/test_components_utils.py
@@ -10,6 +10,58 @@ from ..test_components import TestComponents
 from ..utils import mock_biotools_api_calls
 
 
+def test_get_components_to_install_full_path_subworkflow(tmp_path):
+    """Full-path includes pointing to subworkflows should preserve underscores."""
+    main_nf = tmp_path / "main.nf"
+    main_nf.write_text(
+        "include { VCF_GATHER_BCFTOOLS } from '../../../subworkflows/nf-core/vcf_gather_bcftools'\n"
+    )
+    modules, subworkflows = nf_core.components.components_utils.get_components_to_install(tmp_path)
+    assert len(subworkflows) == 1
+    assert subworkflows[0]["name"] == "vcf_gather_bcftools"
+    assert len(modules) == 0
+
+
+def test_get_components_to_install_full_path_module(tmp_path):
+    """Full-path includes pointing to modules should convert underscores to slashes."""
+    main_nf = tmp_path / "main.nf"
+    main_nf.write_text(
+        "include { SAMTOOLS_SORT } from '../../../modules/nf-core/samtools/sort'\n"
+    )
+    modules, subworkflows = nf_core.components.components_utils.get_components_to_install(tmp_path)
+    assert len(modules) == 1
+    assert modules[0]["name"] == "samtools/sort"
+    assert len(subworkflows) == 0
+
+
+def test_get_components_to_install_relative_subworkflow(tmp_path):
+    """Relative includes (../) should be treated as subworkflows with underscores preserved."""
+    main_nf = tmp_path / "main.nf"
+    main_nf.write_text(
+        "include { VCF_GATHER_BCFTOOLS } from '../vcf_gather_bcftools'\n"
+    )
+    modules, subworkflows = nf_core.components.components_utils.get_components_to_install(tmp_path)
+    assert len(subworkflows) == 1
+    assert subworkflows[0]["name"] == "vcf_gather_bcftools"
+    assert len(modules) == 0
+
+
+def test_get_components_to_install_mixed_includes(tmp_path):
+    """A main.nf with both module and subworkflow full-path includes should be parsed correctly."""
+    main_nf = tmp_path / "main.nf"
+    main_nf.write_text(
+        "include { SAMTOOLS_SORT } from '../../../modules/nf-core/samtools/sort'\n"
+        "include { VCF_GATHER_BCFTOOLS } from '../../../subworkflows/nf-core/vcf_gather_bcftools'\n"
+        "include { BAM_MARKDUPLICATES } from '../bam_markduplicates'\n"
+    )
+    modules, subworkflows = nf_core.components.components_utils.get_components_to_install(tmp_path)
+    assert len(modules) == 1
+    assert modules[0]["name"] == "samtools/sort"
+    assert len(subworkflows) == 2
+    sw_names = {sw["name"] for sw in subworkflows}
+    assert sw_names == {"vcf_gather_bcftools", "bam_markduplicates"}
+
+
 class TestTestComponentsUtils(TestComponents):
     def test_get_biotools_id(self):
         """Test getting the bio.tools ID for a tool"""

--- a/tests/components/test_components_utils.py
+++ b/tests/components/test_components_utils.py
@@ -13,9 +13,7 @@ from ..utils import mock_biotools_api_calls
 def test_get_components_to_install_full_path_subworkflow(tmp_path):
     """Full-path includes pointing to subworkflows should preserve underscores."""
     main_nf = tmp_path / "main.nf"
-    main_nf.write_text(
-        "include { VCF_GATHER_BCFTOOLS } from '../../../subworkflows/nf-core/vcf_gather_bcftools'\n"
-    )
+    main_nf.write_text("include { VCF_GATHER_BCFTOOLS } from '../../../subworkflows/nf-core/vcf_gather_bcftools'\n")
     modules, subworkflows = nf_core.components.components_utils.get_components_to_install(tmp_path)
     assert len(subworkflows) == 1
     assert subworkflows[0]["name"] == "vcf_gather_bcftools"
@@ -25,9 +23,7 @@ def test_get_components_to_install_full_path_subworkflow(tmp_path):
 def test_get_components_to_install_full_path_module(tmp_path):
     """Full-path includes pointing to modules should convert underscores to slashes."""
     main_nf = tmp_path / "main.nf"
-    main_nf.write_text(
-        "include { SAMTOOLS_SORT } from '../../../modules/nf-core/samtools/sort'\n"
-    )
+    main_nf.write_text("include { SAMTOOLS_SORT } from '../../../modules/nf-core/samtools/sort'\n")
     modules, subworkflows = nf_core.components.components_utils.get_components_to_install(tmp_path)
     assert len(modules) == 1
     assert modules[0]["name"] == "samtools/sort"
@@ -37,9 +33,7 @@ def test_get_components_to_install_full_path_module(tmp_path):
 def test_get_components_to_install_relative_subworkflow(tmp_path):
     """Relative includes (../) should be treated as subworkflows with underscores preserved."""
     main_nf = tmp_path / "main.nf"
-    main_nf.write_text(
-        "include { VCF_GATHER_BCFTOOLS } from '../vcf_gather_bcftools'\n"
-    )
+    main_nf.write_text("include { VCF_GATHER_BCFTOOLS } from '../vcf_gather_bcftools'\n")
     modules, subworkflows = nf_core.components.components_utils.get_components_to_install(tmp_path)
     assert len(subworkflows) == 1
     assert subworkflows[0]["name"] == "vcf_gather_bcftools"


### PR DESCRIPTION
## Summary

- Fix `get_components_to_install()` to check whether a full-path include (`../../../...`) points to a subworkflow or module before deriving the component name
- Subworkflow includes (containing `subworkflows/` in the path) now preserve underscores and are correctly added to the subworkflows dict
- Module includes continue to convert underscores to slashes as before

## Problem

When a subworkflow includes another subworkflow using the full path:

```groovy
include { VCF_GATHER_BCFTOOLS } from '../../../subworkflows/nf-core/vcf_gather_bcftools'
```

The linter converted the name to `vcf/gather/bcftools` (splitting on underscores), causing a `meta_include` lint failure even when `meta.yml` correctly lists `vcf_gather_bcftools` in components.

This is because the `../../../` path prefix check assumed all full-path includes were modules. Relative subworkflow includes (`../vcf_gather_bcftools`) worked fine since they hit a different code path.

## Context

Encountered in https://github.com/nf-core/modules/pull/10283

Fixes #4073

🤖 Generated with [Claude Code](https://claude.com/claude-code)