### PR TITLE
feat(pipeline_template): add .lineage/ to .gitignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
   - Use specific nextflow plugins instead:
     - [nf-slack](https://github.com/seqeralabs/nf-slack)
     - [nf-teams](https://github.com/nvnieuwk/nf-teams)
+- Add `.lineage/` directory to the template .gitignore ([#4075](https://github.com/nf-core/tools/pull/4075)).
 
 #### Version updates
 

--- a/nf_core/pipeline-template/.gitignore
+++ b/nf_core/pipeline-template/.gitignore
@@ -7,3 +7,4 @@ testing/
 testing*
 *.pyc
 null/
+.lineage/


### PR DESCRIPTION
If `lineage.enabled = true`, Nextflow will create a .lineage directory to track the lineage data. This can be helpful for e.g. debugging where caching on resume fails.

This PR just adds this to the pipeline template so it doesn't get accidentally committed. 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
