### PR TITLE
linting: capture correct error for invalid .nf-core.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 - fix failing pytest for lint after samtools topic conversion ([#4026](https://github.com/nf-core/tools/pull/4026))
 - fix incorrect unqoting of `val()` version numbers ([#4042](https://github.com/nf-core/tools/pull/4042))
+- capture correct error for invalid .nf-core.yml ([#4080](https://github.com/nf-core/tools/pull/4080))
 
 ### Modules
 

--- a/nf_core/commands_modules.py
+++ b/nf_core/commands_modules.py
@@ -113,7 +113,7 @@ def modules_update(
         exit_status = module_install.update(tool)
         if not exit_status and install_all:
             sys.exit(1)
-    except (UserWarning, LookupError) as e:
+    except (UserWarning, LookupError, AssertionError) as e:
         log.error(e)
         sys.exit(1)
 

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -1464,7 +1464,9 @@ def load_tools_config(directory: str | Path = ".") -> tuple[Path | None, NFCoreY
     except ValidationError as e:
         error_message = f"Config file '{config_fn}' is invalid"
         for error in e.errors():
-            error_message += f"\n{error['loc'][0]}: {error['msg']}\ninput: {error['input']}"
+            error_message += (
+                f"\n{'.'.join(str(loc) for loc in error['loc'])}: {error['msg']}\nGot instead: {error['input']}"
+            )
         raise AssertionError(error_message)
 
     wf_config = fetch_wf_config(Path(directory))

--- a/tests/pipelines/test_lint.py
+++ b/tests/pipelines/test_lint.py
@@ -123,6 +123,28 @@ class TestPipelinesLint(TestLint):
         assert not saved_json["has_tests_ignored"]
         assert not saved_json["has_tests_failed"]
 
+    def test_load_tools_config_malformed_lint(self):
+        """load_tools_config raises AssertionError for invalid lint config
+
+        pipeline_todos is typed bool | None but given a list value,
+        which should fail pydantic validation.
+        """
+        new_pipeline = self._make_pipeline_copy()
+        nf_core_yml_path = Path(new_pipeline, ".nf-core.yml")
+        with open(nf_core_yml_path) as fh:
+            config = yaml.safe_load(fh)
+        if "lint" not in config or config["lint"] is None:
+            config["lint"] = {}
+        config["lint"]["pipeline_todos"] = ["README.md", "main.nf"]
+        with open(nf_core_yml_path, "w") as fh:
+            yaml.dump(config, fh)
+
+        with self.assertRaises(AssertionError) as cm:
+            nf_core.utils.load_tools_config(new_pipeline)
+        assert "is invalid" in str(cm.exception)
+        assert "lint.pipeline_todos" in str(cm.exception)
+        assert "Got instead" in str(cm.exception)
+
     def test_wrap_quotes(self):
         md = self.lint_obj._wrap_quotes(["one", "two", "three"])
         assert md == "`one` or `two` or `three`"


### PR DESCRIPTION
Closes #3573 

New error output (e.g. for scnanoseq) is
```
ERROR    Config file '.nf-core.yml' is invalid
         lint.pipeline_todos: Input should be a valid boolean
         Got instead: ['README.md', 'main.nf']
```