### PR TITLE
Fix precommit subprocess with high number of files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 testing*
+create-test-lint-wf/
 htmlcov/
 .tox/
 .coverage

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 testing*
 create-test-lint-wf/
+log.txt
 htmlcov/
 .tox/
 .coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - fix failing pytest for lint after samtools topic conversion ([#4026](https://github.com/nf-core/tools/pull/4026))
 - fix incorrect unqoting of `val()` version numbers ([#4042](https://github.com/nf-core/tools/pull/4042))
 - allow versions.yml in the version topics ([#4094](https://github.com/nf-core/tools/pull/4094))
+- run pre-commit on all files when creating pipeline or syncing ([#4097](https://github.com/nf-core/tools/pull/4097))
 
 ### Modules
 

--- a/nf_core/pipelines/create/create.py
+++ b/nf_core/pipelines/create/create.py
@@ -399,7 +399,7 @@ class PipelineCreate:
 
         # Run prettier on files for pipelines sync
         log.debug("Running prettier on pipeline files")
-        run_prettier_on_file([str(f) for f in self.outdir.glob("**/*")])
+        run_prettier_on_file([str(f) for f in self.outdir.glob("**/*")], all_files=True)
 
     def fix_linting(self):
         """

--- a/nf_core/pipelines/create/create.py
+++ b/nf_core/pipelines/create/create.py
@@ -399,7 +399,8 @@ class PipelineCreate:
 
         # Run prettier on files for pipelines sync
         log.debug("Running prettier on pipeline files")
-        run_prettier_on_file([str(f) for f in self.outdir.glob("**/*")], all_files=True)
+        print("test")
+        run_prettier_on_file("**/*")
 
     def fix_linting(self):
         """

--- a/nf_core/pipelines/lint_utils.py
+++ b/nf_core/pipelines/lint_utils.py
@@ -138,11 +138,12 @@ def check_git_repo() -> bool:
         return False
 
 
-def run_prettier_on_file(file: Path | str | list[str]) -> None:
+def run_prettier_on_file(file: Path | str | list[str], all_files: bool = False) -> None:
     """Run the pre-commit hook prettier on a file.
 
     Args:
         file (Path | str): A file identifier as a string or pathlib.Path.
+        all_files (bool): If True, run on all files instead of specific files.
 
     Warns:
         If Prettier is not installed, a warning is logged.
@@ -152,10 +153,13 @@ def run_prettier_on_file(file: Path | str | list[str]) -> None:
 
     nf_core_pre_commit_config = Path(nf_core.__file__).parent / ".pre-commit-prettier-config.yaml"
     args = ["pre-commit", "run", "--config", str(nf_core_pre_commit_config), "prettier"]
-    if isinstance(file, list):
-        args.extend(["--files", *file])
+    if all_files:
+        args.append("--all-files")
     else:
-        args.extend(["--files", str(file)])
+        if isinstance(file, list):
+            args.extend(["--files", *file])
+        else:
+            args.extend(["--files", str(file)])
 
     if is_git:
         try:


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/main/.github/CONTRIBUTING.md
-->

## PR checklist

This PR add `all_files` boolean argument for `run_prettier_on_file` to be ran when running `nf-core pipelines sync` with a high number of changed files.
This allow to avoid `[Errno 7] Argument list too long: 'pre-commit'`

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
