### PR TITLE
MAINT: configbuilder validate infra fields

### DIFF
--- a/nf_core/configs/create/finalinfradetails.py
+++ b/nf_core/configs/create/finalinfradetails.py
@@ -69,8 +69,6 @@ class FinalInfraDetails(Screen):
                 "cachedir",
                 "/path/to/cache/dir",
                 "Define a global cache direcotry.",
-                f"NXF_{self.container_system.upper()}_CACHEDIR" if self.container_system is not None else "",
-                "Define a global cache directory.",
                 classes="",
                 default=self._get_set_directory(f"NXF_{self.container_system.upper()}_CACHEDIR") if self.container_system is not None else "",
             )
@@ -83,7 +81,6 @@ class FinalInfraDetails(Screen):
         yield TextInput(
             "scratch_dir",
             "Scratch directory",
-            "If you have to use a specific scratch direcotry, specify it. ",
             "If you have to use a specific scratch directory, specify it.",
             classes="",
         )

--- a/nf_core/configs/create/finalinfradetails.py
+++ b/nf_core/configs/create/finalinfradetails.py
@@ -71,20 +71,20 @@ class FinalInfraDetails(Screen):
             yield TextInput(
                 "cachedir",
                 f"NXF_{self.container_system.upper()}_CACHEDIR" if self.container_system is not None else "",
-                "Define a global cache direcotry.",
+                "Define a global cache directory.",
                 classes="",
                 default=self._get_set_directory(f"NXF_{self.container_system.upper()}_CACHEDIR") if self.container_system is not None else "",
             )
         yield TextInput(
             "igenomes_cachedir",
             "iGenomes cache directory",
-            "If you have an iGenomes cache direcotry, specify it.",
+            "If you have an iGenomes cache directory, specify it.",
             classes="hide" if not self.parent.NFCORE_CONFIG else "",
         )
         yield TextInput(
             "scratch_dir",
             "Scratch directory",
-            "If you have to use a specific scratch direcotry, specify it.",
+            "If you have to use a specific scratch directory, specify it.",
             classes="",
         )
         with Horizontal(classes="ghrepo-cols"):

--- a/nf_core/configs/create/finalinfradetails.py
+++ b/nf_core/configs/create/finalinfradetails.py
@@ -11,7 +11,8 @@ from textual.widgets import Button, Footer, Header, Input, Markdown, Static, Swi
 from nf_core.configs.create.utils import (
     TextInput,
     ConfigsCreateConfig,
-    init_context
+    init_context,
+    SUPPORTED_CONTAINERS
 )
 from nf_core.utils import add_hide_class, remove_hide_class
 
@@ -107,7 +108,7 @@ class FinalInfraDetails(Screen):
     def _get_container_systems(self) -> list[str]:
         """Get the available container systems to use for software handling."""
         module_system_used = self._detect_module_system()
-        container_systems = ["singularity", "docker", "apptainer", "charliecloud", "podman", "sarus", "shifter"]
+        container_systems = SUPPORTED_CONTAINERS
         available_systems = []
         if module_system_used:
             for system in container_systems:

--- a/nf_core/configs/create/finalinfradetails.py
+++ b/nf_core/configs/create/finalinfradetails.py
@@ -37,6 +37,7 @@ class FinalInfraDetails(Screen):
         self.container_system_list = self._get_container_systems()
         self.container_system = self.container_system_list[0] if self.container_system_list else None
 
+        # TODO: convert to dropdown with contents self.container_system_list
         yield TextInput(
             "container_system",
             "Container system",

--- a/nf_core/configs/create/utils.py
+++ b/nf_core/configs/create/utils.py
@@ -55,19 +55,19 @@ class ConfigsCreateConfig(BaseModel):
     """ Config description """
     config_profile_url: Optional[str] = None
     """ Config institution URL """
-    default_process_ncpus: Optional[int] = None
+    default_process_ncpus: Optional[str] = None
     """ Default number of CPUs """
-    default_process_memgb: Optional[int] = None
+    default_process_memgb: Optional[str] = None
     """ Default amount of memory """
-    default_process_hours: Optional[float] = None
+    default_process_hours: Optional[str] = None
     """ Default walltime - hours """
     custom_process_id: Optional[str] = None
     """" Name or label of a process to configure """
-    custom_process_ncpus: Optional[int] = None
+    custom_process_ncpus: Optional[str] = None
     """ Number of CPUs for process """
-    custom_process_memgb: Optional[int] = None
+    custom_process_memgb: Optional[str] = None
     """ Amount of memory for process """
-    custom_process_hours: Optional[float] = None
+    custom_process_hours: Optional[str] = None
     """ Walltime for process - hours """
     named_process_resources: Optional[dict] = None
     """ Dictionary containing custom resource requirements for named processes """
@@ -85,11 +85,11 @@ class ConfigsCreateConfig(BaseModel):
     """ Modules to load when running processes """
     container_system: Optional[str] = None
     """ The container system the HPC uses """
-    memory: Optional[int] = None
+    memory: Optional[str] = None
     """ The maximum memory available to processes """
-    cpus: Optional[int] = None
+    cpus: Optional[str] = None
     """ The maximum number of CPUs available to processes """
-    time: Optional[float] = None
+    time: Optional[str] = None
     """ The maximum walltime available to processes """
     envvar: Optional[str] = None
     """ An environment variable to hold a custom Nextflow container cachedir """
@@ -99,12 +99,8 @@ class ConfigsCreateConfig(BaseModel):
     """ A cachedir for iGenomes """
     scratch_dir: Optional[str] = None
     """ A scratch directory to use """
-    retries: Optional[int] = None
+    retries: Optional[str] = None
     """ Number of retries for failed jobs """
-    delete_work_dir: Optional[bool] = None
-    """ Whether to delete the work directory on successful pipeline complete """
-    module: Optional[str] = None
-    """ Detected module system """
 
     model_config = ConfigDict(extra="allow")
 
@@ -319,7 +315,7 @@ class ConfigsCreateConfig(BaseModel):
         """
         v = v.strip()
         if v == "":
-            raise ValueError("Cannot be left empty.")
+            return v #optional
 
         if not _PATH_PATTERN.match(v):
             raise ValueError(
@@ -334,7 +330,7 @@ class ConfigsCreateConfig(BaseModel):
     def is_path_or_uri(cls, v: str, info: ValidationInfo) -> str:
         v = v.strip()
         if v == "":
-            raise ValueError("Cannot be left empty.")
+            return v #optional
 
         uri_pattern = re.compile(r"^\w+:\/\/\w+")
         if not _PATH_PATTERN.match(v) and not uri_pattern.match(v):
@@ -345,11 +341,6 @@ class ConfigsCreateConfig(BaseModel):
             )
         return v
     
-    @field_validator("module_system", "module")
-    @classmethod
-    def module_system_valid(cls, v: str, info: ValidationInfo) -> str:
-        ... #TODO
-
     @field_validator("container_system")
     @classmethod
     def container_system_valid(cls, v: str, info: ValidationInfo) -> str:
@@ -359,11 +350,6 @@ class ConfigsCreateConfig(BaseModel):
                 f"Must be one of: {', '.join(SUPPORTED_CONTAINERS)}"
             )
         return v
-
-    @field_validator("delete_work_dir")
-    @classmethod
-    def is_bool(cls, v: str, info: ValidationInfo) -> str:
-        ... #TODO
 
 ## TODO Duplicated from pipelines utils - move to common location if possible (validation seems to be context specific so possibly not)
 class TextInput(Static):

--- a/nf_core/configs/create/utils.py
+++ b/nf_core/configs/create/utils.py
@@ -110,7 +110,7 @@ class ConfigsCreateConfig(BaseModel):
             context=_init_context_var.get(),
         )
 
-    @field_validator("general_config_name")
+    @field_validator("general_config_name", "config_profile_description")
     @classmethod
     def notempty(cls, v: str) -> str:
         """Check that string values are not empty."""
@@ -148,14 +148,6 @@ class ConfigsCreateConfig(BaseModel):
         if context and (not context["is_infrastructure"] and context["is_nfcore"]):
             if v.strip() == "":
                 raise ValueError("Cannot be left empty.")
-        return v
-
-    @field_validator("config_profile_description")
-    @classmethod
-    def notempty_description(cls, v: str) -> str:
-        """Check that description is not empty when."""
-        if v.strip() == "":
-            raise ValueError("Cannot be left empty.")
         return v
 
     @field_validator("config_profile_contact")

--- a/nf_core/configs/create/utils.py
+++ b/nf_core/configs/create/utils.py
@@ -344,6 +344,26 @@ class ConfigsCreateConfig(BaseModel):
                 "or a URI (e.g. s3://ngi-igenomes/igenomes/)"
             )
         return v
+    
+    @field_validator("module_system", "module")
+    @classmethod
+    def module_system_valid(cls, v: str, info: ValidationInfo) -> str:
+        ... #TODO
+
+    @field_validator("container_system")
+    @classmethod
+    def container_system_valid(cls, v: str, info: ValidationInfo) -> str:
+        v = v.strip()
+        if v != "" and v not in SUPPORTED_CONTAINERS:
+            raise ValueError(
+                f"Must be one of: {', '.join(SUPPORTED_CONTAINERS)}"
+            )
+        return v
+
+    @field_validator("delete_work_dir")
+    @classmethod
+    def is_bool(cls, v: str, info: ValidationInfo) -> str:
+        ... #TODO
 
 ## TODO Duplicated from pipelines utils - move to common location if possible (validation seems to be context specific so possibly not)
 class TextInput(Static):

--- a/nf_core/configs/create/utils.py
+++ b/nf_core/configs/create/utils.py
@@ -265,7 +265,7 @@ class ConfigsCreateConfig(BaseModel):
         context = info.context
         if context and context["is_infrastructure"]:
             if v.strip() == "":
-                return v
+                raise ValueError("Cannot be empty.")
             try:
                 v_int = int(v.strip())
             except ValueError:
@@ -281,7 +281,7 @@ class ConfigsCreateConfig(BaseModel):
         context = info.context
         if context and context["is_infrastructure"]:
             if v.strip() == "":
-                return v
+                raise ValueError("Cannot be empty.")
             try:
                 vf = float(v.strip())
             except ValueError:

--- a/nf_core/configs/create/utils.py
+++ b/nf_core/configs/create/utils.py
@@ -171,13 +171,9 @@ class ConfigsCreateConfig(BaseModel):
         if context and context["is_infrastructure"]:
             if v.strip() == "":
                 raise ValueError("Cannot be left empty.")
-            elif v and not re.match(
-                r"^@[a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d])){0,38}$", v
-            ):  ## Regex adapted from: https://github.com/shinnn/github-username-regex
-                raise ValueError("Handle must start with '@'.")
-        else:
-            if not v.strip() == "" and not re.match(r"^@[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$", v):
-                raise ValueError("Handle must start with '@'.")
+        if not v.strip() == "" and not re.match(r"^@[aA-zZ\d](?:[aA-zZ\d]|-(?=[aA-zZ\d])){0,38}$", v):
+            ## Regex adapted from: https://github.com/shinnn/github-username-regex
+            raise ValueError("Handle must start with '@'.")
         return v
 
     @field_validator(

--- a/nf_core/configs/create/utils.py
+++ b/nf_core/configs/create/utils.py
@@ -33,7 +33,8 @@ CONFIG_ISINFRASTRUCTURE_GLOBAL: bool = True
 NFCORE_CONFIG_GLOBAL: bool = True
 INFRA_ISHPC_GLOBAL: bool = False
 _PATH_PATTERN = re.compile(r"(\/|~\/|~$|\$\{?\w+\}?)(.*)")
-
+# Used by finalinfradetails as it already imports create.utils
+SUPPORTED_CONTAINERS = ["singularity", "docker", "apptainer", "charliecloud", "podman", "sarus", "shifter"]
 
 class ConfigsCreateConfig(BaseModel):
     """Pydantic model for the nf-core configs create config."""

--- a/nf_core/configs/create/utils.py
+++ b/nf_core/configs/create/utils.py
@@ -216,7 +216,12 @@ class ConfigsCreateConfig(BaseModel):
     @field_validator("default_process_ncpus", "default_process_memgb", "custom_process_ncpus", "custom_process_memgb")
     @classmethod
     def pos_integer_valid(cls, v: str, info: ValidationInfo) -> str:
-        """Check that integer values are either empty or positive."""
+        """Check that integer values are either empty or positive.
+        
+        This contains the same validation as self.pos_integer_valid_infra().
+        However, keep infrastructure and pipeline methods decoupled for
+        easier refactoring in future.
+        """
         context = info.context
         if context and not context["is_infrastructure"]:
             if v.strip() == "":
@@ -245,10 +250,16 @@ class ConfigsCreateConfig(BaseModel):
                 raise ValueError("Must be a non-negative number.")
         return v
 
-    @field_validator("cpus", "memory")
+    @field_validator("cpus", "memory", "retries")
     @classmethod
     def pos_integer_valid_infra(cls, v: str, info: ValidationInfo) -> str:
-        """Check that integer values are either empty or positive."""
+        """
+        Check that integer values are either empty or positive.
+        
+        This contains the same validation as self.pos_integer_valid().
+        However, keep infrastructure and pipeline methods decoupled for
+        easier refactoring in future.
+        """
         context = info.context
         if context and context["is_infrastructure"]:
             if v.strip() == "":

--- a/nf_core/configs/create/utils.py
+++ b/nf_core/configs/create/utils.py
@@ -32,6 +32,7 @@ def init_context(value: dict[str, Any]) -> Iterator[None]:
 CONFIG_ISINFRASTRUCTURE_GLOBAL: bool = True
 NFCORE_CONFIG_GLOBAL: bool = True
 INFRA_ISHPC_GLOBAL: bool = False
+_PATH_PATTERN = re.compile(r"(\/|~\/|~$|\$\{?\w+\}?)(.*)")
 
 
 class ConfigsCreateConfig(BaseModel):
@@ -296,6 +297,47 @@ class ConfigsCreateConfig(BaseModel):
         if context and context["is_infrastructure"] and context["is_hpc"]:
             if v.strip() == "":
                 raise ValueError("Cannot be left empty.")
+        return v
+    
+    @field_validator("cachedir", "scratch_dir")
+    @classmethod
+    def is_path_ondisk(cls, v: str, info: ValidationInfo) -> str:
+        """
+        Check that a path looks valid. Does not check if it exists.
+
+        Skip if field is empty.
+
+        Accept:
+            - absolute paths (^/.+)
+            - env var prefixed paths (${INFRA_SPECIFIC_VAR}/..., ${HOME}/..., ${projectDir})
+            - tilde-prefixed paths (~/...)
+        """
+        v = v.strip()
+        if v == "":
+            raise ValueError("Cannot be left empty.")
+
+        if not _PATH_PATTERN.match(v):
+            raise ValueError(
+                "Must be an absolute path (/data/scratch), "
+                "a path relative to home (~/scratch), "
+                "or a path with an environmental variable (e.g. ${DIR}/scratch)"
+            )
+        return v
+
+    @field_validator("igenomes_cachedir")
+    @classmethod
+    def is_path_or_uri(cls, v: str, info: ValidationInfo) -> str:
+        v = v.strip()
+        if v == "":
+            raise ValueError("Cannot be left empty.")
+
+        uri_pattern = re.compile(r"^\w+:\/\/\w+")
+        if not _PATH_PATTERN.match(v) and not uri_pattern.match(v):
+            raise ValueError(
+                "Must be an absolute path with optional environmental variables "
+                "(e.g. /data/cache, ~/cache, ${DIR}/cache), "
+                "or a URI (e.g. s3://ngi-igenomes/igenomes/)"
+            )
         return v
 
 ## TODO Duplicated from pipelines utils - move to common location if possible (validation seems to be context specific so possibly not)

--- a/nf_core/configs/create/utils.py
+++ b/nf_core/configs/create/utils.py
@@ -179,9 +179,9 @@ class ConfigsCreateConfig(BaseModel):
         if context and context["is_infrastructure"]:
             if v.strip() == "":
                 raise ValueError("Cannot be left empty.")
-            elif not re.match(
-                r"^@[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$", v
-            ):  ## Regex from: https://github.com/shinnn/github-username-regex
+            elif v and not re.match(
+                r"^@[a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d])){0,38}$", v
+            ):  ## Regex adapted from: https://github.com/shinnn/github-username-regex
                 raise ValueError("Handle must start with '@'.")
         else:
             if not v.strip() == "" and not re.match(r"^@[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$", v):

--- a/nf_core/configs/create/utils.py
+++ b/nf_core/configs/create/utils.py
@@ -350,6 +350,14 @@ class ConfigsCreateConfig(BaseModel):
                 f"Must be one of: {', '.join(SUPPORTED_CONTAINERS)}"
             )
         return v
+    
+    @field_validator("module_system")
+    @classmethod
+    def module_system(cls, v: str, info: ValidationInfo) -> str:
+        #TODO: placeholder validator until functionality is finished
+        return v
+    
+
 
 ## TODO Duplicated from pipelines utils - move to common location if possible (validation seems to be context specific so possibly not)
 class TextInput(Static):

--- a/nf_core/configs/create/utils.py
+++ b/nf_core/configs/create/utils.py
@@ -55,19 +55,19 @@ class ConfigsCreateConfig(BaseModel):
     """ Config description """
     config_profile_url: Optional[str] = None
     """ Config institution URL """
-    default_process_ncpus: Optional[str] = None
+    default_process_ncpus: Optional[int] = None
     """ Default number of CPUs """
-    default_process_memgb: Optional[str] = None
+    default_process_memgb: Optional[int] = None
     """ Default amount of memory """
-    default_process_hours: Optional[str] = None
+    default_process_hours: Optional[float] = None
     """ Default walltime - hours """
     custom_process_id: Optional[str] = None
     """" Name or label of a process to configure """
-    custom_process_ncpus: Optional[str] = None
+    custom_process_ncpus: Optional[int] = None
     """ Number of CPUs for process """
-    custom_process_memgb: Optional[str] = None
+    custom_process_memgb: Optional[int] = None
     """ Amount of memory for process """
-    custom_process_hours: Optional[str] = None
+    custom_process_hours: Optional[float] = None
     """ Walltime for process - hours """
     named_process_resources: Optional[dict] = None
     """ Dictionary containing custom resource requirements for named processes """
@@ -85,11 +85,11 @@ class ConfigsCreateConfig(BaseModel):
     """ Modules to load when running processes """
     container_system: Optional[str] = None
     """ The container system the HPC uses """
-    memory: Optional[str] = None
+    memory: Optional[int] = None
     """ The maximum memory available to processes """
-    cpus: Optional[str] = None
+    cpus: Optional[int] = None
     """ The maximum number of CPUs available to processes """
-    time: Optional[str] = None
+    time: Optional[float] = None
     """ The maximum walltime available to processes """
     envvar: Optional[str] = None
     """ An environment variable to hold a custom Nextflow container cachedir """
@@ -99,8 +99,12 @@ class ConfigsCreateConfig(BaseModel):
     """ A cachedir for iGenomes """
     scratch_dir: Optional[str] = None
     """ A scratch directory to use """
-    retries: Optional[str] = None
+    retries: Optional[int] = None
     """ Number of retries for failed jobs """
+    delete_work_dir: Optional[bool] = None
+    """ Whether to delete the work directory on successful pipeline complete """
+    module: Optional[str] = None
+    """ Detected module system """
 
     model_config = ConfigDict(extra="allow")
 


### PR DESCRIPTION
## Summary

- Declared all infrastructure form fields (`scheduler`, `queue`, `module_system`, `container_system`, `memory`, `cpus`, `time`, `cachedir`, `igenomes_cachedir`, `scratch_dir`, `retries`, `delete_work_dir`, `module`) as attributes of `ConfigsCreateConfig`.
- Added context-aware validators for all infrastructure fields. Rules are only enforced when the relevant context flags (`is_infrastructure`, `is_hpc`) are `True`.
- Added `_PATH_PATTERN` module-level regex for reusable path format validation — accepts absolute, `~/`, and `$VAR/`-prefixed paths without requiring disk existence.
- Added path/URI validator for `igenomes_cachedir` — accepts file paths and `s3://`-style URIs.
- Added numeric validators for resource limit fields:
  - `memory`
  - `cpus`
  - `retries` (positive integer)
  - `time` (non-negative float)
- Added container system validation against the `SUPPORTED_CONTAINERS` list (optional field; empty allowed).
- Moved `SUPPORTED_CONTAINERS` from `__init__.py` to `utils.py` to resolve a circular import.
- Added placeholder validator for `module_system` (free-form module names; full validation deferred pending finalised functionality).

---

## Field Coverage

| Screen | Field | Declared | Validator | Rule |
|------|------|------|------|------|
| `basic_details` | `general_config_name` | ✓ | `notempty` | Required |
| `basic_details` | `config_profile_description` | ✓ | `notempty` | Required |
| `basic_details` | `config_profile_contact` | ✓ | `notempty_contact` | Required when infrastructure |
| `basic_details` | `config_profile_handle` | ✓ | `handle_prefix` | Required when infrastructure; `@username` format |
| `basic_details` | `config_profile_url` | ✓ | `url_prefix` | Required when infrastructure; valid URL |
| `basic_details` | `config_pipeline_name` | ✓ | `nfcore_name_valid` | Required when nf-core pipeline |
| `basic_details` | `config_pipeline_path` | ✓ | `path_valid` | Required when custom pipeline; must exist on disk |
| `hpc_customisation` | `scheduler` | ✓ | `nonemtpy_hpc_details` | Required when HPC |
| `hpc_customisation` | `queue` | ✓ | `nonemtpy_hpc_details` | Required when HPC |
| `hpc_customisation` | `module_system` | ✓ | `module_system` *(placeholder)* | Any string; full validation TBD |
| `final_infra_details` | `container_system` | ✓ | `container_system_valid` | Optional; must be in `SUPPORTED_CONTAINERS` if set |
| `final_infra_details` | `memory` | ✓ | `pos_integer_valid_infra` | Required when infrastructure; positive integer |
| `final_infra_details` | `cpus` | ✓ | `pos_integer_valid_infra` | Required when infrastructure; positive integer |
| `final_infra_details` | `retries` | ✓ | `pos_integer_valid_infra` | Required when infrastructure; positive integer |
| `final_infra_details` | `time` | ✓ | `non_neg_float_valid_infra` | Required when infrastructure; non-negative number |
| `final_infra_details` | `cachedir` | ✓ | `is_path_ondisk` | Optional; valid path format |
| `final_infra_details` | `scratch_dir` | ✓ | `is_path_ondisk` | Optional; valid path format |
| `final_infra_details` | `igenomes_cachedir` | ✓ | `is_path_or_uri` | Optional; valid path or URI |
| `final_infra_details` | `delete_work_dir` | ✓ | n/a *(Switch)* | Optional `bool`; set directly from widget |
| `final_infra_details` | `module` | ✓ | n/a *(auto-detected)* | Optional `bool`; set from `_detect_module_system()` |

---

## Checklist

- [x] All `hpc_customisation` fields declared in `ConfigsCreateConfig`
- [x] All `final_infra_details` fields declared in `ConfigsCreateConfig`
- [x] `nfcore_question` — no form fields (button-only screen); no model attributes required
- [x] `basic_details` — all fields declared and validated
- [x] Validators added for all infrastructure config text fields
- [x] Validators are context-gated (`is_infrastructure`, `is_hpc`) where appropriate
- [ ] `module_system` validator is a placeholder — full validation pending finalised module system functionality