### PR TITLE
bugfix: add recursive function to make versions as a string in pipeline snapshot. 

### DIFF
--- a/nf_core/pipeline-template/subworkflows/nf-core/utils_nfcore_pipeline/main.nf
+++ b/nf_core/pipeline-template/subworkflows/nf-core/utils_nfcore_pipeline/main.nf
@@ -77,9 +77,20 @@ def getWorkflowVersion() {
 //
 // Get software versions for pipeline
 //
+def stringifyVersionData(value) {
+    if (value instanceof Map) {
+        return value.collectEntries { tool, version -> [tool, stringifyVersionData(version)] }
+    }
+
+    return value == null ? null : value.toString()
+}
+
+
 def processVersionsFromYAML(yaml_file) {
     def yaml = new org.yaml.snakeyaml.Yaml()
-    def versions = yaml.load(yaml_file).collectEntries { k, v -> [k.tokenize(':')[-1], v] }
+    def versions = yaml.load(yaml_file).collectEntries { process, tools ->
+        [process.tokenize(':')[-1], stringifyVersionData(tools)]
+    }
     return yaml.dumpAsMap(versions).trim()
 }
 

--- a/nf_core/pipeline-template/subworkflows/nf-core/utils_nfcore_pipeline/tests/main.function.nf.test
+++ b/nf_core/pipeline-template/subworkflows/nf-core/utils_nfcore_pipeline/tests/main.function.nf.test
@@ -123,4 +123,49 @@ nextflow_function {
             )
         }
     }
+
+
+    test("Test softwareVersionsToYAML - list") {
+        function "softwareVersionsToYAML"
+
+        when {
+            function {
+                """
+                input[0] = [
+                    [ 'tool1', 1.2 ],
+                    [ 'tool2', 1.2.3 ],
+                    [ 'tool3', 1 ],
+                    [ 'tool3', "1" ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert function.success },
+                { assert snapshot(function.result).match() }
+            )
+        }
+    }
+
+    test("Test softwareVersionsToYAML - YAML") {
+        function "softwareVersionsToYAML"
+
+        when {
+            function {
+                """
+                input[0] = file(params.modules_testdata_base_path + 'generic/config/config_template.yte.yaml', checkIfExists: true)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert function.success },
+                { assert snapshot(function.result).match() }
+            )
+        }
+    }
 }
+


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/main/.github/CONTRIBUTING.md
-->

The current implementation of `processVersionsFromYAML` would automatically infer the type of versions. So if a version was `1.85` it would save it to the snapshot as a `float` same for `1` as an `int`. 

This addition avoids this by parsing them all as a `string`.  

## PR checklist

- [X] This comment contains a description of changes (with reason)
- [X] `CHANGELOG.md` is updated
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] Documentation in `docs` is updated
