### PR TITLE
fix: macos max arg length error for pre-commit in pipelines sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@
 - fix incorrect unqoting of `val()` version numbers ([#4042](https://github.com/nf-core/tools/pull/4042))
 - allow versions.yml in the version topics ([#4094](https://github.com/nf-core/tools/pull/4094))
 
+### Pipelines
+
+- Fix `[Errno 7] Argument list too long: 'pre-commit'` error during `pipelines sync` on macOS by batching prettier file args and excluding `.git/`, `work/`, and `.nf-test/` from the glob ([#4123](https://github.com/nf-core/tools/pull/4123))
+
 ### Modules
 
 - Template: have a `main:` section in workflow even when modules are skipped ([#4043](https://github.com/nf-core/tools/pull/4043))

--- a/nf_core/pipelines/create/create.py
+++ b/nf_core/pipelines/create/create.py
@@ -397,9 +397,14 @@ class PipelineCreate:
                     yaml.dump(config_yml.model_dump(exclude_none=True), fh, Dumper=custom_yaml_dumper())
                     log.debug(f"Dumping pipeline template yml to pipeline config file '{config_fn.name}'")
 
-        # Run prettier on files for pipelines sync
+        # Run prettier on files for pipelines sync, excluding .git and work dirs
         log.debug("Running prettier on pipeline files")
-        run_prettier_on_file([str(f) for f in self.outdir.glob("**/*")])
+        excluded_dirs = {".git", "work", ".nf-test"}
+        run_prettier_on_file([
+            str(f)
+            for f in self.outdir.glob("**/*")
+            if f.is_file() and not any(part in excluded_dirs for part in f.relative_to(self.outdir).parts)
+        ])
 
     def fix_linting(self):
         """

--- a/nf_core/pipelines/create/create.py
+++ b/nf_core/pipelines/create/create.py
@@ -400,11 +400,13 @@ class PipelineCreate:
         # Run prettier on files for pipelines sync, excluding .git and work dirs
         log.debug("Running prettier on pipeline files")
         excluded_dirs = {".git", "work", ".nf-test"}
-        run_prettier_on_file([
-            str(f)
-            for f in self.outdir.glob("**/*")
-            if f.is_file() and not any(part in excluded_dirs for part in f.relative_to(self.outdir).parts)
-        ])
+        run_prettier_on_file(
+            [
+                str(f)
+                for f in self.outdir.glob("**/*")
+                if f.is_file() and not any(part in excluded_dirs for part in f.relative_to(self.outdir).parts)
+            ]
+        )
 
     def fix_linting(self):
         """

--- a/nf_core/pipelines/lint_utils.py
+++ b/nf_core/pipelines/lint_utils.py
@@ -138,11 +138,30 @@ def check_git_repo() -> bool:
         return False
 
 
+def _run_prettier_once(args: list[str], file_label: str) -> None:
+    """Run a single pre-commit prettier invocation and handle errors."""
+    try:
+        proc = subprocess.run(args, capture_output=True, check=True)
+        log.debug(f"{proc.stdout.decode()}")
+    except subprocess.CalledProcessError as e:
+        if ": SyntaxError: " in e.stdout.decode():
+            log.critical(f"Can't format {file_label} because it has a syntax error.\n{e.stdout.decode()}")
+        elif "files were modified by this hook" in e.stdout.decode():
+            all_lines = [line for line in e.stdout.decode().split("\n")]
+            files = "\n".join(all_lines[3:])
+            log.debug(f"The following files were modified by prettier:\n {files}")
+        else:
+            log.warning(
+                "There was an error running the prettier pre-commit hook.\n"
+                f"STDOUT: {e.stdout.decode()}\nSTDERR: {e.stderr.decode()}"
+            )
+
+
 def run_prettier_on_file(file: Path | str | list[str]) -> None:
     """Run the pre-commit hook prettier on a file.
 
     Args:
-        file (Path | str): A file identifier as a string or pathlib.Path.
+        file (Path | str | list[str]): A file identifier or list of file paths.
 
     Warns:
         If Prettier is not installed, a warning is logged.
@@ -150,31 +169,23 @@ def run_prettier_on_file(file: Path | str | list[str]) -> None:
 
     is_git = check_git_repo()
 
-    nf_core_pre_commit_config = Path(nf_core.__file__).parent / ".pre-commit-prettier-config.yaml"
-    args = ["pre-commit", "run", "--config", str(nf_core_pre_commit_config), "prettier"]
-    if isinstance(file, list):
-        args.extend(["--files", *file])
-    else:
-        args.extend(["--files", str(file)])
-
-    if is_git:
-        try:
-            proc = subprocess.run(args, capture_output=True, check=True)
-            log.debug(f"{proc.stdout.decode()}")
-        except subprocess.CalledProcessError as e:
-            if ": SyntaxError: " in e.stdout.decode():
-                log.critical(f"Can't format {file} because it has a syntax error.\n{e.stdout.decode()}")
-            elif "files were modified by this hook" in e.stdout.decode():
-                all_lines = [line for line in e.stdout.decode().split("\n")]
-                files = "\n".join(all_lines[3:])
-                log.debug(f"The following files were modified by prettier:\n {files}")
-            else:
-                log.warning(
-                    "There was an error running the prettier pre-commit hook.\n"
-                    f"STDOUT: {e.stdout.decode()}\nSTDERR: {e.stderr.decode()}"
-                )
-    else:
+    if not is_git:
         log.debug("Not in a git repository, skipping pre-commit hook.")
+        return
+
+    nf_core_pre_commit_config = Path(nf_core.__file__).parent / ".pre-commit-prettier-config.yaml"
+    base_args = ["pre-commit", "run", "--config", str(nf_core_pre_commit_config), "prettier"]
+
+    if isinstance(file, list):
+        # Run in batches to avoid exceeding OS argument length limits (macOS ARG_MAX)
+        batch_size = 100
+        for i in range(0, len(file), batch_size):
+            batch = file[i : i + batch_size]
+            args = [*base_args, "--files", *batch]
+            _run_prettier_once(args, f"batch {i // batch_size + 1}")
+    else:
+        args = [*base_args, "--files", str(file)]
+        _run_prettier_once(args, str(file))
 
 
 def dump_json_with_prettier(file_name, file_content):

--- a/tests/modules/lint/test_main_nf.py
+++ b/tests/modules/lint/test_main_nf.py
@@ -138,12 +138,12 @@ class TestMainNfLinting(TestModules):
         """Test that main_nf version emit and topics check works correctly"""
 
         self.mods_install.install("bioawk")
-        # Lint a module known to have versions YAML in main.nf (for now)
+        # bioawk now uses topics-based version output (previously used old YAML emit style)
         module_lint = nf_core.modules.lint.ModuleLint(directory=self.pipeline_dir)
         module_lint.lint(print_results=False, module="bioawk")
         assert len(module_lint.failed) == 0, f"Linting failed with {[x.__dict__ for x in module_lint.failed]}"
-        assert len(module_lint.warned) == 2, (
-            f"Linting warned with {[x.__dict__ for x in module_lint.warned]}, expected 2 warnings"
+        assert len(module_lint.warned) == 0, (
+            f"Linting warned with {[x.__dict__ for x in module_lint.warned]}, expected 0 warnings"
         )
         assert len(module_lint.passed) > 0
 

--- a/tests/test_lint_utils.py
+++ b/tests/test_lint_utils.py
@@ -63,3 +63,18 @@ def test_run_prettier_on_syntax_error_file(syntax_error_json, caplog):
     nf_core.pipelines.lint_utils.run_prettier_on_file(syntax_error_json)
     expected_critical_log = "SyntaxError: Unexpected token (1:10)"
     assert expected_critical_log in caplog.text
+
+
+def test_run_prettier_on_file_list(temp_git_repo):
+    """Test that run_prettier_on_file handles a list of files (batched execution)."""
+    tmp_git_dir, repo = temp_git_repo
+    files = []
+    for i in range(3):
+        file = tmp_git_dir / f"file_{i}.json"
+        file.write_text(JSON_FORMATTED)
+        repo.git.add(file)
+        files.append(str(file))
+    # Should not raise (previously would raise OSError with large lists)
+    nf_core.pipelines.lint_utils.run_prettier_on_file(files)
+    for f in files:
+        assert open(f).read() == JSON_FORMATTED


### PR DESCRIPTION
## Description

Fixes `[Errno 7] Argument list too long: 'pre-commit' error` during nf-core pipelines sync on macOS.

**Root cause**: render_template() in create.py calls run_prettier_on_file() with the result of self.outdir.glob("**/*"), which includes every file in the repository — including thousands of entries from .git/, work/, and .nf-test/ directories. All of these paths are passed as individual --files arguments to a single pre-commit subprocess call, exceeding macOS's ARG_MAX kernel limit (~1MB).

## Fix (two changes):

1. nf_core/pipelines/lint_utils.py — run_prettier_on_file() now batches file lists into groups of 100 when invoked with a list argument, preventing argument list overflow on any OS.
2. nf_core/pipelines/create/create.py — The glob in render_template() now filters out .git/, work/, and .nf-test/ directories and only passes actual files (not directories) to prettier. These directories are not template output and should never be formatted.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated

I also tested this by running it on https://github.com/fulcrumgenomics/twistcgp.

You can see that commit here: https://github.com/fulcrumgenomics/twistcgp/commit/55429998870cd1a2085185be1a63856b9809b300
