### PR TITLE
switch to gitlab module to test with old version syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Template: have a `main:` section in workflow even when modules are skipped ([#4043](https://github.com/nf-core/tools/pull/4043))
 - Always prettify modules.json ([#4063](https://github.com/nf-core/tools/pull/4063))
 - Update nf-test module template to topics ([#4113](https://github.com/nf-core/tools/pull/4113))
+- switch to gitlab module to test with old version syntax ([#4126](https://github.com/nf-core/tools/pull/4126))
 
 ### Subworkflows
 

--- a/tests/modules/lint/test_main_nf.py
+++ b/tests/modules/lint/test_main_nf.py
@@ -147,7 +147,6 @@ class TestMainNfLinting(TestModules):
         )
         assert len(module_lint.passed) > 0
 
-
         # Lint a module known to have topics as output in main.nf
         module_lint = nf_core.modules.lint.ModuleLint(directory=self.pipeline_dir)
         module_lint.lint(print_results=False, module="bamstats/generalstats")

--- a/tests/modules/lint/test_main_nf.py
+++ b/tests/modules/lint/test_main_nf.py
@@ -138,15 +138,15 @@ class TestMainNfLinting(TestModules):
         """Test that main_nf version emit and topics check works correctly"""
 
         self.mods_install_gitlab_nftest.install("fastqc")
-        # Lint a module installed from the gitlab test branch; gitlab test modules
+        # Lint a module installed from the gitlab test branch; gitlab test modules that is known to have versions YAML in main.nf
         module_lint = nf_core.modules.lint.ModuleLint(directory=self.pipeline_dir)
         module_lint.lint(print_results=False, module="fastqc")
-        assert len(module_lint.failed) == 0
-        assert len(module_lint.passed) > 0
-
+        assert len(module_lint.failed) == 0, f"Linting failed with {[x.__dict__ for x in module_lint.failed]}"
         assert any(w.lint_test in ("main_nf_version_emit", "main_nf_version_topic") for w in module_lint.warned), (
             f"Expected warning about missing version topic, got {[w.message for w in module_lint.warned]}"
         )
+        assert len(module_lint.passed) > 0
+
 
         # Lint a module known to have topics as output in main.nf
         module_lint = nf_core.modules.lint.ModuleLint(directory=self.pipeline_dir)

--- a/tests/modules/lint/test_main_nf.py
+++ b/tests/modules/lint/test_main_nf.py
@@ -137,23 +137,23 @@ class TestMainNfLinting(TestModules):
     def test_topics_and_emits_version_check(self):
         """Test that main_nf version emit and topics check works correctly"""
 
-        self.mods_install.install("bioawk")
-        # Lint a module known to have versions YAML in main.nf (for now)
+        self.mods_install_gitlab_nftest.install("fastqc")
+        # Lint a module installed from the gitlab test branch; gitlab test modules
         module_lint = nf_core.modules.lint.ModuleLint(directory=self.pipeline_dir)
-        module_lint.lint(print_results=False, module="bioawk")
-        assert len(module_lint.failed) == 0, f"Linting failed with {[x.__dict__ for x in module_lint.failed]}"
-        assert len(module_lint.warned) == 2, (
-            f"Linting warned with {[x.__dict__ for x in module_lint.warned]}, expected 2 warnings"
-        )
+        module_lint.lint(print_results=False, module="fastqc")
+        assert len(module_lint.failed) == 0
         assert len(module_lint.passed) > 0
+
+        assert any(w.lint_test in ("main_nf_version_emit", "main_nf_version_topic") for w in module_lint.warned), (
+            f"Expected warning about missing version topic, got {[w.message for w in module_lint.warned]}"
+        )
 
         # Lint a module known to have topics as output in main.nf
         module_lint = nf_core.modules.lint.ModuleLint(directory=self.pipeline_dir)
         module_lint.lint(print_results=False, module="bamstats/generalstats")
         assert len(module_lint.failed) == 0, f"Linting failed with {[x.__dict__ for x in module_lint.failed]}"
-        assert len(module_lint.warned) == 0, (
-            f"Linting warned with {[x.__dict__ for x in module_lint.warned]}, expected 1 warning"
-        )
+        assert len(module_lint.warned) == 0, f"Expected 0 warnings, got {[x.__dict__ for x in module_lint.warned]}"
+
         assert len(module_lint.passed) > 0
 
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -14,7 +14,6 @@ import nf_core.modules.create
 import nf_core.modules.install
 import nf_core.modules.modules_repo
 import nf_core.modules.remove
-import nf_core.pipelines.create.create
 from nf_core import __version__
 from nf_core.pipelines.lint_utils import run_prettier_on_file
 from nf_core.utils import NFCoreYamlConfig
@@ -23,6 +22,7 @@ from .utils import (
     GITLAB_BRANCH_TEST_BRANCH,
     GITLAB_BRANCH_TEST_OLD_SHA,
     GITLAB_DEFAULT_BRANCH,
+    GITLAB_NFTEST_BRANCH,
     GITLAB_URL,
     OLD_TRIMGALORE_BRANCH,
     OLD_TRIMGALORE_SHA,
@@ -148,6 +148,13 @@ class TestModules(unittest.TestCase):
             remote_url=GITLAB_URL,
             branch=GITLAB_BRANCH_TEST_BRANCH,
             sha=GITLAB_BRANCH_TEST_OLD_SHA,
+        )
+        self.mods_install_gitlab_nftest = nf_core.modules.install.ModuleInstall(
+            self.pipeline_dir,
+            prompt=False,
+            force=False,
+            remote_url=GITLAB_URL,
+            branch=GITLAB_NFTEST_BRANCH,
         )
 
         # Set up remove objects


### PR DESCRIPTION
Closes #4125 

`bioawk` was recently switched to the new topic syntax, but we used this module to check for the old sytnax.

To avoid trying to find modules without topics in the main nf-core modules repo, I instead test the topic version linting against out test repo on gitlab, which has more stable modules (i.e. they only change if we need to).

This PR also adds a helper function to install a module from the branch on gitlab that has modules with nf-test to avoid getting more linting warnings than necessary.