### PR TITLE
Include null-safe operator in meta key linting

### DIFF
--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -286,7 +286,7 @@ def check_script_section(self, lines):
     permitted_meta_keys = {"id", "single_end"}
     invalid_meta_keys = [
         f"{prefix}{key}"
-        for prefix, key in re.findall(r"(meta\d*\.)(\w+)\b(?!\()", script)
+        for prefix, key in re.findall(r"(meta\d*\??\.)(\w+)\b(?!\()", script)
         if key not in permitted_meta_keys
     ]
     if not invalid_meta_keys:

--- a/tests/modules/lint/test_main_nf.py
+++ b/tests/modules/lint/test_main_nf.py
@@ -536,6 +536,7 @@ def test_validate_meta_keys():
     def prefix = "${meta.id}"
     def se = meta.single_end
     def id = meta.subMap(['id'])
+    def m2id = meta2?.id
     """
         ],
     )
@@ -549,12 +550,14 @@ def test_validate_meta_keys():
             """
     def sample = meta.sample
     def strand = meta.strandedness
+    def m2opts = meta2?.options
     """
         ],
     )
     assert len(mock_lint.failed) == 1
     assert "meta.sample" in mock_lint.failed[0][2]
     assert "meta.strandedness" in mock_lint.failed[0][2]
+    assert "meta2?.options" in mock_lint.failed[0][2]
 
     # meta2/meta3 with valid keys
     mock_lint.passed, mock_lint.failed = [], []
@@ -562,7 +565,7 @@ def test_validate_meta_keys():
         mock_lint,
         [
             """
-    def id1 = meta.id
+    def id1 = meta?.id
     def id2 = meta2.id
     def se = meta3.single_end
     """


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/main/.github/CONTRIBUTING.md
-->

## Description

#4127 Misses the case where the null safe operator might be used on a meta map. This should detect it.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
