### PR TITLE
Fix false positive matches to words like text in ext key linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Ensure release linting happens on branch named main ([#4121](https://github.com/nf-core/tools/pull/4121))
 - Add linting for meta and ext keys ([#4127](https://github.com/nf-core/tools/pull/4127))
 - Add strict syntax linting to template with pre-commit ([#4128](https://github.com/nf-core/tools/pull/4128))
+- Fix false positive matches to words like text in ext key linting ([#4142](https://github.com/nf-core/tools/pull/4142))
 
 ### Modules
 

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -286,7 +286,7 @@ def check_script_section(self, lines):
     permitted_meta_keys = {"id", "single_end"}
     invalid_meta_keys = [
         f"{prefix}{key}"
-        for prefix, key in re.findall(r"(meta\d*\.)(\w+)\b(?!\()", script)
+        for prefix, key in re.findall(r"\b(meta\d*\.)(\w+)\b(?!\()", script)
         if key not in permitted_meta_keys
     ]
     if not invalid_meta_keys:
@@ -305,7 +305,7 @@ def check_script_section(self, lines):
     permitted_ext_keys = {"ext.args", "ext.prefix", "ext.use_gpu"}
     invalid_ext_keys = [
         key
-        for key in re.findall(r"ext\.\w+", script)
+        for key in re.findall(r"\bext\.\w+", script)
         if key not in permitted_ext_keys and not re.match(r"^ext\.args([2-9]|\d{2,})$", key)
     ]
     if not invalid_ext_keys:

--- a/tests/modules/lint/test_main_nf.py
+++ b/tests/modules/lint/test_main_nf.py
@@ -637,3 +637,16 @@ def test_validate_ext_keys():
         ],
     )
     assert len(mock_lint.failed) == 0
+
+    # Check false positive matches, e.g. text.tokenize()
+    mock_lint.passed, mock_lint.failed = [], []
+    check_script_section(
+        mock_lint,
+        [
+            """
+    def header = file(reference).text.tokenize('\n').first()
+    def input = context.trim()
+    """
+        ],
+    )
+    assert len(mock_lint.failed) == 0


### PR DESCRIPTION
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/main/.github/CONTRIBUTING.md
-->

## Description

Fixes false positive matches to words like text or context in ext key linting #4127 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
