### PR TITLE
fix changelog bot failing after linting step

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -73,6 +73,7 @@ jobs:
 
       - name: Run pre-commit rules with prek
         uses: j178/prek-action@53276d8b0d10f8b6672aa85b4588c6921d0370cc # v2
+        continue-on-error: true
         with:
           extra-args: --config .pre-commit-config.yaml --all-files
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,9 +51,9 @@
 - Ensure release linting happens on branch named main ([#4121](https://github.com/nf-core/tools/pull/4121))
 - Add linting for meta and ext keys ([#4127](https://github.com/nf-core/tools/pull/4127))
 - Add strict syntax linting to template with pre-commit ([#4128](https://github.com/nf-core/tools/pull/4128))
-- lint against the correct repo ([#4140](https://github.com/nf-core/tools/pull/4140))
+- Lint against the correct repo ([#4140](https://github.com/nf-core/tools/pull/4140))
 - Fix false positive matches to words like text in ext key linting ([#4142](https://github.com/nf-core/tools/pull/4142))
-- fix changelog bot failing after linting step ([#4155](https://github.com/nf-core/tools/pull/4155))
+- Fix changelog bot failing after linting step ([#4155](https://github.com/nf-core/tools/pull/4155))
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Add strict syntax linting to template with pre-commit ([#4128](https://github.com/nf-core/tools/pull/4128))
 - lint against the correct repo ([#4140](https://github.com/nf-core/tools/pull/4140))
 - Fix false positive matches to words like text in ext key linting ([#4142](https://github.com/nf-core/tools/pull/4142))
+- fix changelog bot failing after linting step ([#4155](https://github.com/nf-core/tools/pull/4155))
 
 ### Modules
 


### PR DESCRIPTION
the bot action seems to remove the prettier spacing from the table while reading it, leading to a failing linting step, where it tries to fix it again. Therefor not failing when linting should fix this.