### PR TITLE
Template: add additional fusion specific exit codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@
 - Fix lint: preserve underscores for subworkflow includes via full path ([#4074](https://github.com/nf-core/tools/pull/4074))
 - update modules and subworkflows in template ([#4077](https://github.com/nf-core/tools/pull/4077))
 
-### Pipeline template
+### Template
 
 - Remove webhook notifications (hook_url, slackreport, adaptivecard) ([#4051](https://github.com/nf-core/tools/pull/4051)).
   - Use specific nextflow plugins instead:
@@ -80,6 +80,7 @@
     - [nf-teams](https://github.com/nvnieuwk/nf-teams)
 - Add `.lineage/` directory to the template .gitignore ([#4075](https://github.com/nf-core/tools/pull/4075)).
 - Fix nf-core tools version to what is specified in `.nf-core.yml` for the GitHub workflow `download_pipeline.yml` ([#4124](https://github.com/nf-core/tools/pull/4124)).
+- Add additional fusion specific exit codes ([#4180](https://github.com/nf-core/tools/pull/4180))
 
 #### Version updates
 

--- a/nf_core/pipeline-template/conf/base.config
+++ b/nf_core/pipeline-template/conf/base.config
@@ -15,7 +15,7 @@ process {
     memory = { 6.GB   * task.attempt }
     time   = { 4.h    * task.attempt }
 
-    errorStrategy = { task.exitStatus in ((130..145) + 104 + 175) ? 'retry' : 'finish' }
+    errorStrategy = { task.exitStatus in ((130..145) + 104 + (175..177)) ? 'retry' : 'finish' }
     maxRetries    = 1
     maxErrors     = '-1'
 

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -87,9 +87,7 @@ process {
     memory = { 6.GB * task.attempt }
     time   = { 4.h  * task.attempt }
 
-    // 175 signals that the Pipeline had an unrecoverable error while
-    // restoring a Snapshot via Fusion Snapshots.
-    errorStrategy = { task.exitStatus in ((130..145) + 104 + 175) ? 'retry' : 'finish' }
+    errorStrategy = { task.exitStatus in ((130..145) + 104 + (175..177)) ? 'retry' : 'finish' }
     maxRetries    = 1
     maxErrors     = '-1'
 }

--- a/tests/data/mock_pipeline_containers/conf/base.config
+++ b/tests/data/mock_pipeline_containers/conf/base.config
@@ -15,7 +15,7 @@ process {
     memory = { 6.GB   * task.attempt }
     time   = { 4.h    * task.attempt }
 
-    errorStrategy = { task.exitStatus in ((130..145) + 104 + 175) ? 'retry' : 'finish' }
+    errorStrategy = { task.exitStatus in ((130..145) + 104 + (175..177)) ? 'retry' : 'finish' }
     maxRetries    = 1
     maxErrors     = '-1'
 

--- a/tests/data/mock_pipeline_containers/nextflow.config
+++ b/tests/data/mock_pipeline_containers/nextflow.config
@@ -57,9 +57,7 @@ process {
     memory = { 6.GB * task.attempt }
     time = { 4.h * task.attempt }
 
-    // 175 signals that the Pipeline had an unrecoverable error while
-    // restoring a Snapshot via Fusion Snapshots.
-    errorStrategy = { task.exitStatus in ((130..145) + 104 + 175) ? 'retry' : 'finish' }
+    errorStrategy = { task.exitStatus in ((130..145) + 104 + (175..177)) ? 'retry' : 'finish' }
     maxRetries = 1
     maxErrors = '-1'
 }


### PR DESCRIPTION
based on [comment](https://nfcore.slack.com/archives/C04QR0T3G3H/p1775655885440769) on slack from @FelixKrueger 
> Hi all, I just got off a call with folks from Seqera to nail and fix teething issues with Fusion Snapshots on AWS instances. We noticed that the default errorStrategy of nf-core pipelines does not currently include Fusion Snapshot error codes.
> I propose that errors 175, 176 and 177 get added to the default strategy like so:
errorStrategy = { task.exitStatus in ((130..145) + (175..177) + 104) ? 'retry' : 'finish' }

Continuation from #3564