### PR TITLE
Fix #4028: Download platform tags and dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@
 - Update example links in main.nf comments ([#4188](https://github.com/nf-core/tools/pull/4188))
 - use prek instead of pre-commit in all instances ([#4187](https://github.com/nf-core/tools/pull/4187))
 
+### Download
+
+- Fix `nf-core pipelines download --platform` output directory structure and tagging ([#4185](https://github.com/nf-core/tools/pull/4185))
+
 ### Linting
 
 - fix failing pytest for lint after samtools topic conversion ([#4026](https://github.com/nf-core/tools/pull/4026))

--- a/nf_core/pipelines/download/download.py
+++ b/nf_core/pipelines/download/download.py
@@ -258,7 +258,7 @@ class DownloadWorkflow:
 
         # Set an output filename now that we have the outdir
         if self.platform:
-            self.output_filename = self.outdir.parent / (self.outdir.name + ".git")
+            self.output_filename = self.outdir / (self.outdir.name + ".git")
             summary_log.append(f"Output file: '{self.output_filename}'")
         elif self.compress_type is not None:
             self.output_filename = self.outdir.parent / (self.outdir.name + "." + self.compress_type)
@@ -352,7 +352,7 @@ class DownloadWorkflow:
         self.workflow_repo = WorkflowRepo(
             remote_url=f"https://github.com/{self.pipeline}.git",
             revision=self.revision if self.revision else None,
-            commit=self.wf_sha.values() if bool(self.wf_sha) else None,
+            commit=list(self.wf_sha.values()) if bool(self.wf_sha) else None,
             additional_tags=self.additional_tags,
             location=location if location else None,  # manual location is required for the tests to work
             in_cache=False,
@@ -362,7 +362,7 @@ class DownloadWorkflow:
         self.workflow_repo.tidy_tags_and_branches()
 
         # create a bare clone of the modified repository needed for Seqera Platform
-        self.workflow_repo.bare_clone(self.outdir / self.output_filename)
+        self.workflow_repo.bare_clone(self.output_filename)
 
         # extract the required containers
         if self.container_system in {"singularity", "docker"}:

--- a/nf_core/pipelines/download/download.py
+++ b/nf_core/pipelines/download/download.py
@@ -352,7 +352,7 @@ class DownloadWorkflow:
         self.workflow_repo = WorkflowRepo(
             remote_url=f"https://github.com/{self.pipeline}.git",
             revision=self.revision if self.revision else None,
-            commit=list(self.wf_sha.values()) if bool(self.wf_sha) else None,
+            revision_commits=self.wf_sha if bool(self.wf_sha) else None,
             additional_tags=self.additional_tags,
             location=location if location else None,  # manual location is required for the tests to work
             in_cache=False,

--- a/nf_core/pipelines/download/download.py
+++ b/nf_core/pipelines/download/download.py
@@ -258,7 +258,7 @@ class DownloadWorkflow:
 
         # Set an output filename now that we have the outdir
         if self.platform:
-            self.output_filename = self.outdir / (self.outdir.name + ".git")
+            self.output_filename = self.outdir / f"{self.pipeline.split('/')[-1]}.git"
             summary_log.append(f"Output file: '{self.output_filename}'")
         elif self.compress_type is not None:
             self.output_filename = self.outdir.parent / (self.outdir.name + "." + self.compress_type)

--- a/nf_core/pipelines/download/workflow_repo.py
+++ b/nf_core/pipelines/download/workflow_repo.py
@@ -70,6 +70,7 @@ class WorkflowRepo(SyncedRepo):
         self.hide_progress = hide_progress
 
         self.setup_local_repo(remote=remote_url, location=location, in_cache=in_cache)
+        self.revision_to_commit = dict(zip(self.revision, self.commit))
 
         # additional tags to be added to the repository
         self.additional_tags = additional_tags if additional_tags else None
@@ -135,7 +136,9 @@ class WorkflowRepo(SyncedRepo):
         if location:
             self.local_repo_dir = location / self.fullname
         else:
-            self.local_repo_dir = Path(NFCORE_DIR) if not in_cache else Path(NFCORE_CACHE_DIR, self.fullname)
+            self.local_repo_dir = (
+                Path(NFCORE_DIR, self.fullname) if not in_cache else Path(NFCORE_CACHE_DIR, self.fullname)
+            )
 
         try:
             if not self.local_repo_dir.exists():
@@ -202,7 +205,14 @@ class WorkflowRepo(SyncedRepo):
                     self.repo.delete_tag(tag)
 
                 # switch to a revision that should be kept, because deleting heads fails, if they are checked out (e.g. "main")
-                self.checkout(self.revision[0])
+                try:
+                    self.checkout(self.revision[0])
+                except GitCommandError:
+                    fallback_commit = self.revision_to_commit.get(self.revision[0])
+                    if fallback_commit:
+                        self.checkout(fallback_commit)
+                    else:
+                        raise
 
                 # delete unwanted heads/branches from repository
                 for head in heads_to_remove:
@@ -211,8 +221,12 @@ class WorkflowRepo(SyncedRepo):
                 # ensure all desired revisions/branches are available
                 for revision in desired_revisions:
                     if not self.repo.is_valid_object(revision):
-                        self.checkout(revision)
-                        self.repo.create_head(revision, revision)
+                        if (commit := self.revision_to_commit.get(revision)) is None:
+                            self.checkout(revision)
+                            self.repo.create_head(revision, revision)
+                        else:
+                            self.checkout(commit)
+                            self.repo.create_head(revision, commit)
                         if self.repo.head.is_detached:
                             self.repo.head.reset(index=True, working_tree=True)
 

--- a/nf_core/pipelines/download/workflow_repo.py
+++ b/nf_core/pipelines/download/workflow_repo.py
@@ -305,9 +305,9 @@ class WorkflowRepo(SyncedRepo):
         if self.repo:
             try:
                 destination = destination.absolute()
-                destfolder = destination.parent
-                if not destfolder.exists():
-                    destfolder.mkdir(parents=True, exist_ok=True)
+                # Ensure the parent of the destination exists
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                # Remove an potentially existing previous clone
                 if destination.exists():
                     shutil.rmtree(destination)
                 self.repo.clone(str(destination), bare=True)

--- a/nf_core/pipelines/download/workflow_repo.py
+++ b/nf_core/pipelines/download/workflow_repo.py
@@ -13,10 +13,7 @@ import nf_core
 import nf_core.modules.modules_utils
 from nf_core.pipelines.download.utils import DownloadError
 from nf_core.synced_repo import RemoteProgressbar, SyncedRepo
-from nf_core.utils import (
-    NFCORE_CACHE_DIR,
-    NFCORE_DIR,
-)
+from nf_core.utils import NFCORE_CACHE_DIR, NFCORE_DIR
 
 log = logging.getLogger(__name__)
 
@@ -35,7 +32,7 @@ class WorkflowRepo(SyncedRepo):
         self,
         remote_url,
         revision,
-        commit,
+        revision_commits,
         additional_tags,
         location=None,
         hide_progress=False,
@@ -59,18 +56,12 @@ class WorkflowRepo(SyncedRepo):
             self.revision = [*revision]
         else:
             self.revision = []
-        if isinstance(commit, str):
-            self.commit = [commit]
-        elif isinstance(commit, list):
-            self.commit = [*commit]
-        else:
-            self.commit = []
+        self.revision_to_commit: dict[str, str] = dict(revision_commits) if isinstance(revision_commits, dict) else {}
         self.fullname = nf_core.modules.modules_utils.repo_full_name_from_remote(self.remote_url)
         self.retries = 0  # retries for setting up the locally cached repository
         self.hide_progress = hide_progress
 
         self.setup_local_repo(remote=remote_url, location=location, in_cache=in_cache)
-        self.revision_to_commit = dict(zip(self.revision, self.commit))
 
         # additional tags to be added to the repository
         self.additional_tags = additional_tags if additional_tags else None
@@ -235,16 +226,21 @@ class WorkflowRepo(SyncedRepo):
                     if self.repo.is_valid_object("latest"):
                         # "latest" exists as tag but not as branch
                         self.repo.create_head("latest", "latest")  # create a new head for latest
-                        self.checkout("latest")
                     else:
                         # desired revisions may contain arbitrary branch names that do not correspond to valid semantic versioning patterns.
                         valid_versions = [
                             Version(v) for v in desired_revisions if re.match(r"\d+\.\d+(?:\.\d+)*(?:[\w\-_])*", v)
                         ]
-                        # valid versions sorted in ascending order, last will be aliased as "latest".
-                        latest = sorted(valid_versions)[-1]
-                        self.repo.create_head("latest", str(latest))
-                        self.checkout(latest)
+                        # If no semantic versions are available (e.g. SHA-only revisions), fall back to the first
+                        # requested revision and its mapped commit.
+                        if valid_versions:
+                            latest_ref = str(sorted(valid_versions)[-1])
+                        elif self.revision:
+                            latest_ref = self.revision_to_commit.get(self.revision[0], self.revision[0])
+                        else:
+                            raise DownloadError("No revision available to create required 'latest' branch.")
+                        self.repo.create_head("latest", latest_ref)
+                    self.checkout("latest")
                     if self.repo.head.is_detached:
                         self.repo.head.reset(index=True, working_tree=True)
 

--- a/nf_core/pipelines/download/workflow_repo.py
+++ b/nf_core/pipelines/download/workflow_repo.py
@@ -304,11 +304,12 @@ class WorkflowRepo(SyncedRepo):
     def bare_clone(self, destination: Path):
         if self.repo:
             try:
-                destfolder = destination.parent.absolute()
+                destination = destination.absolute()
+                destfolder = destination.parent
                 if not destfolder.exists():
-                    destfolder.mkdir()
+                    destfolder.mkdir(parents=True, exist_ok=True)
                 if destination.exists():
                     shutil.rmtree(destination)
-                self.repo.clone(str(destfolder), bare=True)
+                self.repo.clone(str(destination), bare=True)
             except (OSError, GitCommandError, InvalidGitRepositoryError) as e:
                 log.error(f"[red]Failure to create the pipeline download[/]\n{e}\n")

--- a/tests/pipelines/download/test_download.py
+++ b/tests/pipelines/download/test_download.py
@@ -388,7 +388,7 @@ class DownloadTest(unittest.TestCase):
         assert isinstance(download_obj.outdir, Path)
         assert bool(re.search(r"nf-core-rnaseq_\d{4}-\d{2}-\d{1,2}_\d{1,2}-\d{1,2}", str(download_obj.outdir), re.S))
 
-        download_obj.output_filename = download_obj.outdir.with_suffix(".git")
+        download_obj.output_filename = download_obj.outdir / "rnaseq.git"
         download_obj.download_workflow_platform(location=tmp_dir)
 
         assert download_obj.workflow_repo
@@ -478,7 +478,7 @@ class DownloadTest(unittest.TestCase):
             ) = nf_core.utils.get_repo_releases_branches(download_obj.pipeline, wfs)
 
             download_obj.get_revision_hash()
-            download_obj.output_filename = f"{download_obj.outdir}.git"
+            download_obj.output_filename = download_obj.outdir / "rnaseq.git"
             download_obj.download_workflow_platform(location=tmp_dir)
 
             assert download_obj.workflow_repo


### PR DESCRIPTION
This pull request fixes the issues described in #4028. It 

- Corrects the `self.output_filename`
- Removes the parent from `bare_clone()` to ensure that the clone is actually inside the subdirectory named pipeline.git.
- Introduces an edge case handling in `tidy_tags_and_branches()` to avoid erroring out. 

Regarding the poor test coverage: I would like to defer this to #2940, when the whole logic must be reworked anyway. I don't really have time for it, but I can test if AI can actually help there. 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
