### PR TITLE
fix(lint): use correct config key zenodo_doi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
 - Fix changelog bot failing after linting step ([#4155](https://github.com/nf-core/tools/pull/4155))
 - lint for correct syntax for compressed files in stubs ([#4048](https://github.com/nf-core/tools/pull/4048))
 - fix linting with missing input ([#4202](https://github.com/nf-core/tools/pull/4202))
+- fix(lint): use correct config key zenodo_doi ([#4201](https://github.com/nf-core/tools/pull/4201))
 
 ### Modules
 

--- a/nf_core/pipelines/lint/readme.py
+++ b/nf_core/pipelines/lint/readme.py
@@ -85,7 +85,7 @@ def readme(self):
         else:
             warned.append("README did not have an nf-core template version badge.")
 
-    if "zenodo_doi" not in ignore_configs:
+    if "zenodo_release" not in ignore_configs:
         # Check that zenodo.XXXXXXX has been replaced with the zendo.DOI
         zenodo_re = r"/zenodo\.X+"
         match = re.search(zenodo_re, content)

--- a/nf_core/pipelines/lint/readme.py
+++ b/nf_core/pipelines/lint/readme.py
@@ -38,7 +38,7 @@ def readme(self):
                 readme:
                     - nextflow_badge
                     - nfcore_template_badge
-                    - zenodo_release
+                    - zenodo_doi
 
     """
     passed = []
@@ -85,7 +85,7 @@ def readme(self):
         else:
             warned.append("README did not have an nf-core template version badge.")
 
-    if "zenodo_release" not in ignore_configs:
+    if "zenodo_doi" not in ignore_configs:
         # Check that zenodo.XXXXXXX has been replaced with the zendo.DOI
         zenodo_re = r"/zenodo\.X+"
         match = re.search(zenodo_re, content)


### PR DESCRIPTION
The `readme` lint test checks for `"zenodo_doi"` in the ignore config, but the documented config key in the docstring and docs is `"zenodo_release"`. This means adding `zenodo_release` to the `.nf-core.yml` ignore list has no effect — the warning still appears.

Changed the key in the code to match the documentation.

Fixes #3398
