### PR TITLE
Add `--outdir` parameter fallback to extend container image download support to older pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@
 ### Download
 
 - Fix `nf-core pipelines download --platform` output directory structure and tagging ([#4185](https://github.com/nf-core/tools/pull/4185))
-- Add `nf-core inspect support` for pipelines without a default for the `--outdir` parameter specified in the test profiles ([#4212](https://github.com/nf-core/tools/pull/4212))
+- Add a fallback for `nextflow inspect` for pipelines without a default for the `--outdir` parameter specified in the test profiles ([#4212](https://github.com/nf-core/tools/pull/4212))
 
 ### Linting
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,8 +76,8 @@
 
 ### Download
 
-- Add `nf-core inspect support` for pipelines without an `--outdir` parameter specified in the test profiles ([#4185](https://github.com/nf-core/tools/pull/4185))
 - Fix `nf-core pipelines download --platform` output directory structure and tagging ([#4185](https://github.com/nf-core/tools/pull/4185))
+- Add `nf-core inspect support` for pipelines without a default for the `--outdir` parameter specified in the test profiles ([#4212](https://github.com/nf-core/tools/pull/4212))
 
 ### Linting
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 
 ### Download
 
+- Add `nf-core inspect support` for pipelines without an `--outdir` parameter specified in the test profiles ([#4185](https://github.com/nf-core/tools/pull/4185))
 - Fix `nf-core pipelines download --platform` output directory structure and tagging ([#4185](https://github.com/nf-core/tools/pull/4185))
 
 ### Linting

--- a/nf_core/pipelines/download/download.py
+++ b/nf_core/pipelines/download/download.py
@@ -7,6 +7,7 @@ import os
 import re
 import shutil
 import tarfile
+import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal
@@ -675,10 +676,13 @@ class DownloadWorkflow:
 
         working_dir = Path().absolute()
 
-        def run_nextflow_inspect(additional_params: str = "") -> dict[str, Any]:
+        def run_nextflow_inspect(params_file: Path | None = None) -> dict[str, Any]:
             with intermediate_dir_with_cd(working_dir):
                 executable = "nextflow"
-                cmd_params = f"inspect -format json {profile} {additional_params} {working_dir / workflow_directory / entrypoint}"
+                params_file_arg = f' -params-file "{params_file}"' if params_file is not None else ""
+                cmd_params = (
+                    f"inspect -format json {profile}{params_file_arg} {working_dir / workflow_directory / entrypoint}"
+                )
                 cmd_out = run_cmd(executable, cmd_params)
                 if cmd_out is None:
                     raise DownloadError("Failed to run `nextflow inspect`. Please check your Nextflow installation.")
@@ -689,10 +693,17 @@ class DownloadWorkflow:
         try:
             out_json = run_nextflow_inspect()
         except RuntimeError as e:
-            # Some workflow revisions explicitly require '--outdir'. If this is the only issue,
-            # retry inspect with a throwaway outdir value.
+            # Some workflow revisions explicitly require an outdir parameter. If this is the
+            # only issue, retry inspect with an ephemeral params file that provides one.
             if re.search(r"params\.outdir|--outdir|output directory", str(e), flags=re.IGNORECASE):
-                out_json = run_nextflow_inspect(" --outdir nf-core-tools-inspect")
+                try:
+                    with tempfile.TemporaryDirectory(prefix="nf-core-inspect-") as tmp_dir:
+                        params_file = Path(tmp_dir) / "params.yml"
+                        params_file.write_text('outdir: "nf-core-tools-inspect"\n')
+                        out_json = run_nextflow_inspect(params_file=params_file)
+                except RuntimeError as retry_error:
+                    log.error("Running 'nextflow inspect' failed with the following error")
+                    raise DownloadError(retry_error) from retry_error
             else:
                 log.error("Running 'nextflow inspect' failed with the following error")
                 raise DownloadError(e) from e

--- a/nf_core/pipelines/download/download.py
+++ b/nf_core/pipelines/download/download.py
@@ -679,7 +679,7 @@ class DownloadWorkflow:
         def run_nextflow_inspect(params_file: Path | None = None) -> dict[str, Any]:
             with intermediate_dir_with_cd(working_dir):
                 executable = "nextflow"
-                params_file_arg = f' -params-file "{params_file}"' if params_file is not None else ""
+                params_file_arg = f' -params-file "{params_file}"' if params_file else ""
                 cmd_params = (
                     f"inspect -format json {profile}{params_file_arg} {working_dir / workflow_directory / entrypoint}"
                 )
@@ -695,7 +695,9 @@ class DownloadWorkflow:
         except RuntimeError as e:
             # Some workflow revisions explicitly require an outdir parameter. If this is the
             # only issue, retry inspect with an ephemeral params file that provides one.
-            if re.search(r"params\.outdir|--outdir|output directory", str(e), flags=re.IGNORECASE):
+            if re.search(
+                r"missing required parameter\s*:\s*(?:--outdir|params\.outdir|outdir)\b", str(e), flags=re.IGNORECASE
+            ):
                 try:
                     with tempfile.TemporaryDirectory(prefix="nf-core-inspect-") as tmp_dir:
                         params_file = Path(tmp_dir) / "params.yml"

--- a/nf_core/pipelines/download/download.py
+++ b/nf_core/pipelines/download/download.py
@@ -666,33 +666,42 @@ class DownloadWorkflow:
         log.info(
             f"Fetching container names for workflow revision {revision} using [magenta bold]nextflow inspect[/]. This might take a while."
         )
-        try:
-            # TODO: Select container system via profile. Is this stable enough?
-            # NOTE: We will likely don't need this after the switch to Seqera containers
-            profile_str = f"{self.container_system}"
-            if with_test_containers:
-                profile_str += ",test,test_full"
-            profile = f"-profile {profile_str}" if self.container_system else ""
+        # TODO: Select container system via profile. Is this stable enough?
+        # NOTE: We will likely don't need this after the switch to Seqera containers
+        profile_str = f"{self.container_system}"
+        if with_test_containers:
+            profile_str += ",test,test_full"
+        profile = f"-profile {profile_str}" if self.container_system else ""
 
-            working_dir = Path().absolute()
+        working_dir = Path().absolute()
+
+        def run_nextflow_inspect(additional_params: str = "") -> dict[str, Any]:
             with intermediate_dir_with_cd(working_dir):
-                # Run nextflow inspect
                 executable = "nextflow"
-                cmd_params = f"inspect -format json {profile} {working_dir / workflow_directory / entrypoint}"
+                cmd_params = f"inspect -format json {profile} {additional_params} {working_dir / workflow_directory / entrypoint}"
                 cmd_out = run_cmd(executable, cmd_params)
                 if cmd_out is None:
                     raise DownloadError("Failed to run `nextflow inspect`. Please check your Nextflow installation.")
 
                 out, _ = cmd_out
-                out_json = json.loads(out)
-                # NOTE: Should we save the container name too to have more meta information?
-                named_containers = {proc["name"]: proc["container"] for proc in out_json["processes"]}
-                # We only want to process unique containers
-                self.containers = list(set(named_containers.values()))
+                return json.loads(out)
 
+        try:
+            out_json = run_nextflow_inspect()
         except RuntimeError as e:
-            log.error("Running 'nextflow inspect' failed with the following error")
-            raise DownloadError(e) from e
+            # Some workflow revisions explicitly require '--outdir'. If this is the only issue,
+            # retry inspect with a throwaway outdir value.
+            if re.search(r"params\.outdir|--outdir|output directory", str(e), flags=re.IGNORECASE):
+                out_json = run_nextflow_inspect(" --outdir nf-core-tools-inspect")
+            else:
+                log.error("Running 'nextflow inspect' failed with the following error")
+                raise DownloadError(e) from e
+
+        try:
+            # NOTE: Should we save the container name too to have more meta information?
+            named_containers = {proc["name"]: proc["container"] for proc in out_json["processes"]}
+            # We only want to process unique containers
+            self.containers = list(set(named_containers.values()))
 
         except KeyError as e:
             log.error("Failed to parse output of 'nextflow inspect' to extract containers")

--- a/tests/pipelines/download/test_download.py
+++ b/tests/pipelines/download/test_download.py
@@ -327,7 +327,7 @@ class DownloadTest(unittest.TestCase):
                 has_retried = True
                 raise RuntimeError(
                     """The following invalid input values have been detected:\n
-                 *n Missing required parameter: --outdir
+                 * Missing required parameter: --outdir
                  """
                 )
 

--- a/tests/pipelines/download/test_download.py
+++ b/tests/pipelines/download/test_download.py
@@ -17,12 +17,10 @@ import nf_core.pipelines.download
 import nf_core.pipelines.list
 import nf_core.utils
 from nf_core.pipelines.download import DownloadWorkflow
+from nf_core.pipelines.download.utils import DownloadError
 from nf_core.pipelines.download.workflow_repo import WorkflowRepo
 from nf_core.synced_repo import SyncedRepo
-from nf_core.utils import (
-    NF_INSPECT_MIN_NF_VERSION,
-    check_nextflow_version,
-)
+from nf_core.utils import NF_INSPECT_MIN_NF_VERSION, check_nextflow_version
 
 from ...utils import TEST_DATA_DIR, with_temporary_folder
 
@@ -310,6 +308,55 @@ class DownloadTest(unittest.TestCase):
             f"Containers found in pipeline by `nextflow inspect`: {found_containers}\n"
             f"Containers that should've been found: {ref_container_strs}"
         )
+
+    @mock.patch("nf_core.pipelines.download.download.run_cmd")
+    @mock.patch("nf_core.pipelines.list.Workflows.get_remote_workflows")
+    def test_find_container_images_retries_with_outdir_on_missing_param_error(
+        self, mock_get_remote_workflows, mock_run_cmd
+    ):
+        download_obj = DownloadWorkflow(container_system="docker")
+        workflow_directory = Path("workflow")
+        inspect_payload = json.dumps(
+            {"processes": [{"name": "NFCORE_TEST:STEP", "container": "quay.io/nf-core/test:1.0"}]}
+        ).encode()
+        has_retried = False
+
+        def _run_cmd_side_effect(_executable, cmd_params):
+            nonlocal has_retried
+            if not has_retried:
+                has_retried = True
+                raise RuntimeError(
+                    """The following invalid input values have been detected:\n
+                 *n Missing required parameter: --outdir
+                 """
+                )
+
+            assert "-params-file" in cmd_params
+            params_file_match = re.search(r'-params-file\s+"([^"]+)"', cmd_params)
+            assert params_file_match is not None
+            assert Path(params_file_match.group(1)).read_text() == 'outdir: "nf-core-tools-inspect"\n'
+            assert "--outdir" not in cmd_params
+            return (inspect_payload, b"")
+
+        mock_run_cmd.side_effect = _run_cmd_side_effect
+
+        download_obj.find_container_images(workflow_directory, "dummy-revision")
+
+        assert len(mock_run_cmd.call_args_list) == 2
+        assert set(download_obj.containers) == {"quay.io/nf-core/test:1.0"}
+        mock_get_remote_workflows.assert_called_once()
+
+    @mock.patch("nf_core.pipelines.download.download.run_cmd")
+    @mock.patch("nf_core.pipelines.list.Workflows.get_remote_workflows")
+    def test_find_container_images_raises_on_unexpected_runtime_error(self, mock_get_remote_workflows, mock_run_cmd):
+        download_obj = DownloadWorkflow(container_system="docker")
+        mock_run_cmd.side_effect = RuntimeError("unexpected inspect failure")
+
+        with pytest.raises(DownloadError, match="unexpected inspect failure"):
+            download_obj.find_container_images(Path("workflow"), "dummy-revision")
+
+        assert mock_run_cmd.call_count == 1
+        mock_get_remote_workflows.assert_called_once()
 
     #
     # Tests for the main entry method 'download_workflow'


### PR DESCRIPTION
Since we switched from the regex-based container image extraction to running `nextflow inspect` on the downloaded pipelines, particularly older pipeline revisions caused issues.

By convention nf-core pipelines expect an `--outdir` parameter. If there was no default specified in the _test_ profile of a revision, extraction of the container images failed:

```bash
ERROR    Running 'nextflow inspect' failed with the following error                                                                                                                              
ERROR    Command 'nextflow inspect -format json -profile singularity,test,test_full /home/matthias/.config/nfcore/nf-core/rnaseq/main.nf' returned non-zero error code '1':                      
         > [0;31mThe following invalid input values have been detected:                                                                                                                          
                                                                                                                                                                                                 
         * Missing required parameter: --outdir                                                                                                                                                  
         [0m                                                                                                                                                                                     
          -- Check script '/home/matthias/.config/nfcore/nf-core/rnaseq/main.nf' at line: 52 or see 'null' file for more details                                                                 
         ERROR ~ ERROR: Validation of pipeline parameters failed!  
```

This PR now introduces a silent fallback exactly for this problem. For the user, the retry is silent, so they do not even notice that they can now successfully download a pipeline revision they could previously only obtain by pinning and using an older version of nf-core tools.

To test, e.g. try the following command with this patched version vs. the current dev:

`nf-core pipelines download -r "3.14.0" -s "singularity" -u "amend" -x "none" rnaseq`

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
