### PR TITLE
add `--force` parameter to `modules remove` and `subworkflow remove`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 - update test to new upstream subworkflow structure ([#4038](https://github.com/nf-core/tools/pull/4038))
 - Fix lint: preserve underscores for subworkflow includes via full path ([#4074](https://github.com/nf-core/tools/pull/4074))
 - update modules and subworkflows in template ([#4077](https://github.com/nf-core/tools/pull/4077))
+- add `--force` parameter to `modules remove` and `subworkflow remove` ([#4213](https://github.com/nf-core/tools/pull/4213))
 
 ### Template
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -1135,7 +1135,7 @@ def command_modules_patch(ctx, tool, directory, remove):
     "--force",
     is_flag=True,
     default=False,
-    help="Force removal of the module, even if it is in included in the pipeline.",
+    help="Force removal of the module, even if it is included in the pipeline.",
 )
 def command_modules_remove(ctx, directory, tool, force):
     """

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -1130,11 +1130,18 @@ def command_modules_patch(ctx, tool, directory, remove):
     default=".",
     help=r"Pipeline directory. [dim]\[default: current working directory][/]",
 )
-def command_modules_remove(ctx, directory, tool):
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Force removal of the module, even if it is in included in the pipeline.",
+)
+def command_modules_remove(ctx, directory, tool, force):
     """
     Remove a module from a pipeline.
     """
-    modules_remove(ctx, directory, tool)
+    modules_remove(ctx, directory, tool, force)
 
 
 # nf-core modules create
@@ -1789,11 +1796,18 @@ def subworkflows_patch(ctx, subworkflow, directory, remove):
     default=".",
     help=r"Pipeline directory. [dim]\[default: current working directory][/]",
 )
-def command_subworkflows_remove(ctx, directory, subworkflow):
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Force removal of the subworkflow, even if it is in included in the pipeline.",
+)
+def command_subworkflows_remove(ctx, directory, subworkflow, force):
     """
     Remove a subworkflow from a pipeline.
     """
-    subworkflows_remove(ctx, directory, subworkflow)
+    subworkflows_remove(ctx, directory, subworkflow, force)
 
 
 # nf-core subworkflows update

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -1801,7 +1801,7 @@ def subworkflows_patch(ctx, subworkflow, directory, remove):
     "--force",
     is_flag=True,
     default=False,
-    help="Force removal of the subworkflow, even if it is in included in the pipeline.",
+    help="Force removal of the subworkflow, even if it is included in the pipeline.",
 )
 def command_subworkflows_remove(ctx, directory, subworkflow, force):
     """

--- a/nf_core/commands_modules.py
+++ b/nf_core/commands_modules.py
@@ -143,7 +143,7 @@ def modules_patch(ctx, tool, directory, remove):
         sys.exit(1)
 
 
-def modules_remove(ctx, directory, tool):
+def modules_remove(ctx, directory, tool, force):
     """
     Remove a module from a pipeline.
     """
@@ -156,7 +156,7 @@ def modules_remove(ctx, directory, tool):
             ctx.obj["modules_repo_branch"],
             ctx.obj["modules_repo_no_pull"],
         )
-        module_remove.remove(tool)
+        module_remove.remove(tool, force=force)
     except (UserWarning, LookupError) as e:
         log.critical(e)
         sys.exit(1)

--- a/nf_core/commands_subworkflows.py
+++ b/nf_core/commands_subworkflows.py
@@ -203,7 +203,7 @@ def subworkflows_install(ctx, subworkflow, directory, prompt, force, sha):
         sys.exit(1)
 
 
-def subworkflows_remove(ctx, directory, subworkflow):
+def subworkflows_remove(ctx, directory, subworkflow, force):
     """
     Remove a subworkflow from a pipeline.
     """
@@ -216,7 +216,7 @@ def subworkflows_remove(ctx, directory, subworkflow):
             ctx.obj["modules_repo_branch"],
             ctx.obj["modules_repo_no_pull"],
         )
-        module_remove.remove(subworkflow)
+        module_remove.remove(subworkflow, force=force)
     except (UserWarning, LookupError) as e:
         log.critical(e)
         sys.exit(1)

--- a/nf_core/components/components_command.py
+++ b/nf_core/components/components_command.py
@@ -282,7 +282,7 @@ class ComponentCommand:
         """
         include_stmts: dict[str, list[dict[str, int | str]]] = {}
         if self.repo_type == "pipeline":
-            workflow_files = Path(self.directory, "workflows").glob("*.nf")
+            workflow_files = Path(self.directory, "workflows").rglob("*.nf")
             for workflow_file in workflow_files:
                 with open(workflow_file) as fh, mmap.mmap(fh.fileno(), 0, access=mmap.ACCESS_READ) as s:
                     # Check if component path is in the file using mmap

--- a/nf_core/components/remove.py
+++ b/nf_core/components/remove.py
@@ -181,8 +181,9 @@ class ComponentRemove(ComponentCommand):
                     if dependency_removed:
                         removed_components.append(component_name.replace("/", "_"))
             # print removed dependencies
-            if removed_components:
-                log.info(f"Removed files for '{component}' and its dependencies '{', '.join(removed_components)}'.")
+            dependencies = set(removed_components) - {component}
+            if dependencies:
+                log.info(f"Removed files for '{component}' and its dependencies '{', '.join(dependencies)}'.")
             else:
                 log.info(f"Removed files for '{component}'.")
         else:


### PR DESCRIPTION
We already hint to use it to ignore left over include statements. Now this actually allows that.

Also found a bug where include statements where not found for non-standard workflow directory structures, for example in `workflows/rnaseq/main.nf`