### PR TITLE
fix(lint): skip correct_meta_outputs for dynamic path() values

### DIFF
--- a/nf_core/modules/lint/meta_yml.py
+++ b/nf_core/modules/lint/meta_yml.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -11,6 +12,10 @@ from nf_core.components.components_differ import ComponentsDiffer
 from nf_core.components.lint import ComponentLint, LintExceptionError
 from nf_core.components.nfcore_component import NFCoreComponent
 from nf_core.utils import unquote
+
+# Output paths that are bare variable refs or pure ``${var}`` GStrings are
+# resolved at runtime in the script: block and can't be reconciled statically.
+DYNAMIC_PATH_RE = re.compile(r"^(?:\$\{[a-zA-Z_]\w*\}|[a-zA-Z_]\w*)$")
 
 if TYPE_CHECKING:
     from nf_core.modules.lint import ModuleLint
@@ -219,6 +224,11 @@ def meta_yml(module_lint_object: ModuleLint, module: NFCoreComponent, allow_miss
         if "output" in meta_yaml:
             correct_outputs = obtain_outputs(module_lint_object, module.outputs)
             meta_outputs = obtain_outputs(module_lint_object, meta_yaml["output"])
+            dynamic_channels = _channels_with_dynamic_paths(module.outputs)
+            if dynamic_channels:
+                log.debug(f"Skipping comparison for dynamic-path channels: {sorted(dynamic_channels)}")
+                correct_outputs = _drop_channels(correct_outputs, dynamic_channels)
+                meta_outputs = _drop_channels(meta_outputs, dynamic_channels)
             log.debug(f"Correct outputs: {correct_outputs}")
             log.debug(f"Outputs in `meta.yml`: {meta_outputs}")
             if correct_outputs == meta_outputs:
@@ -376,6 +386,33 @@ def obtain_outputs(_, outputs: dict | list) -> dict | list:
         return [{k: v} for k, v in formatted_outputs.items()]
     else:
         return formatted_outputs
+
+
+def _channels_with_dynamic_paths(raw_outputs: dict) -> set[str]:
+    """Return channel names whose ``path(...)`` values are bare variables or
+    pure ``${var}`` GStrings.
+
+    Operates on the raw ``module.outputs`` dict (with ``_keyword`` info) so it
+    can target only ``path`` elements and ignore ``val``/``eval`` keys that
+    happen to look like identifiers.
+    """
+    dynamic = set()
+    for channel_name, channel_elements in raw_outputs.items():
+        for element in channel_elements:
+            entries = element if isinstance(element, list) else [element]
+            for entry in entries:
+                key, info = next(iter(entry.items()))
+                if info.get("_keyword") == "path" and DYNAMIC_PATH_RE.match(unquote(key)):
+                    dynamic.add(channel_name)
+                    break
+    return dynamic
+
+
+def _drop_channels(formatted_outputs: dict | list, channel_names: set[str]) -> dict | list:
+    """Return ``formatted_outputs`` with the given channels removed."""
+    if isinstance(formatted_outputs, list):
+        return [d for d in formatted_outputs if not any(k in channel_names for k in d)]
+    return {k: v for k, v in formatted_outputs.items() if k not in channel_names}
 
 
 def obtain_topics(_, topics: dict) -> dict:

--- a/nf_core/modules/lint/meta_yml.py
+++ b/nf_core/modules/lint/meta_yml.py
@@ -388,14 +388,17 @@ def obtain_outputs(_, outputs: dict | list) -> dict | list:
         return formatted_outputs
 
 
-def _channels_with_dynamic_paths(raw_outputs: dict) -> set[str]:
+def _channels_with_dynamic_paths(raw_outputs: dict | list) -> set[str]:
     """Return channel names whose ``path(...)`` values are bare variables or
     pure ``${var}`` GStrings.
 
     Operates on the raw ``module.outputs`` dict (with ``_keyword`` info) so it
     can target only ``path`` elements and ignore ``val``/``eval`` keys that
-    happen to look like identifiers.
+    happen to look like identifiers. Subworkflows expose outputs as a flat
+    ``list[str]`` with no keyword info, so this returns an empty set there.
     """
+    if not isinstance(raw_outputs, dict):
+        return set()
     return {name for name, elements in raw_outputs.items() if _has_dynamic_path(elements)}
 
 

--- a/nf_core/modules/lint/meta_yml.py
+++ b/nf_core/modules/lint/meta_yml.py
@@ -15,7 +15,7 @@ from nf_core.utils import unquote
 
 # Output paths that are bare variable refs or pure ``${var}`` GStrings are
 # resolved at runtime in the script: block and can't be reconciled statically.
-DYNAMIC_PATH_RE = re.compile(r"^(?:\$\{[a-zA-Z_]\w*\}|[a-zA-Z_]\w*)$")
+_DYNAMIC_PATH_RE = re.compile(r"^(?:\$\{[a-zA-Z_]\w*\}|[a-zA-Z_]\w*)$")
 
 if TYPE_CHECKING:
     from nf_core.modules.lint import ModuleLint
@@ -396,20 +396,21 @@ def _channels_with_dynamic_paths(raw_outputs: dict) -> set[str]:
     can target only ``path`` elements and ignore ``val``/``eval`` keys that
     happen to look like identifiers.
     """
-    dynamic = set()
-    for channel_name, channel_elements in raw_outputs.items():
-        for element in channel_elements:
-            entries = element if isinstance(element, list) else [element]
-            for entry in entries:
-                key, info = next(iter(entry.items()))
-                if info.get("_keyword") == "path" and DYNAMIC_PATH_RE.match(unquote(key)):
-                    dynamic.add(channel_name)
-                    break
-    return dynamic
+    return {name for name, elements in raw_outputs.items() if _has_dynamic_path(elements)}
+
+
+def _has_dynamic_path(channel_elements: list) -> bool:
+    for element in channel_elements:
+        entries = element if isinstance(element, list) else [element]
+        for entry in entries:
+            key = next(iter(entry))
+            info = entry[key]
+            if info.get("_keyword") == "path" and _DYNAMIC_PATH_RE.match(unquote(key)):
+                return True
+    return False
 
 
 def _drop_channels(formatted_outputs: dict | list, channel_names: set[str]) -> dict | list:
-    """Return ``formatted_outputs`` with the given channels removed."""
     if isinstance(formatted_outputs, list):
         return [d for d in formatted_outputs if not any(k in channel_names for k in d)]
     return {k: v for k, v in formatted_outputs.items() if k not in channel_names}

--- a/tests/modules/lint/test_meta_yml.py
+++ b/tests/modules/lint/test_meta_yml.py
@@ -217,6 +217,42 @@ class TestMetaYml(TestModules):
             f"Version element should have type: string (since it's val()), but got type: {version_meta['type']}"
         )
 
+    def test_modules_meta_yml_dynamic_output_path_skipped(self):
+        """`correct_meta_outputs` should not flag mismatches for ``path`` outputs
+        that are bare variables or pure ``${var}`` GStrings, since those are
+        resolved in the script: block and cannot be reconciled statically."""
+        from nf_core.modules.lint.meta_yml import _channels_with_dynamic_paths
+
+        raw_outputs = {
+            "reads": [
+                [
+                    {"meta": {"_keyword": "val"}},
+                    {"reads_glob": {"_keyword": "path"}},
+                ]
+            ],
+            "log": [
+                [
+                    {"meta": {"_keyword": "val"}},
+                    {"${report_glob}": {"_keyword": "path"}},
+                ]
+            ],
+            "static": [
+                [
+                    {"meta": {"_keyword": "val"}},
+                    {"*.bam": {"_keyword": "path"}},
+                ]
+            ],
+            "versions": [
+                [
+                    {"${task.process}": {"_keyword": "val"}},
+                    {"trimgalore": {"_keyword": "val"}},
+                    {"trim_galore --version": {"_keyword": "eval"}},
+                ]
+            ],
+        }
+        dynamic = _channels_with_dynamic_paths(raw_outputs)
+        assert dynamic == {"reads", "log"}, f"Expected {{'reads', 'log'}}, got {dynamic}"
+
     def test_modules_meta_yml_no_input_section(self):
         """Test that lint --fix does not crash when meta.yml has no input section (e.g. parameter-only modules)"""
         meta_yml_path = self.bpipe_test_module_path / "meta.yml"

--- a/tests/modules/lint/test_meta_yml.py
+++ b/tests/modules/lint/test_meta_yml.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import yaml
 
 import nf_core.modules.lint
+from nf_core.modules.lint.meta_yml import _channels_with_dynamic_paths
 
 from ...test_modules import TestModules
 
@@ -218,11 +219,9 @@ class TestMetaYml(TestModules):
         )
 
     def test_modules_meta_yml_dynamic_output_path_skipped(self):
-        """`correct_meta_outputs` should not flag mismatches for ``path`` outputs
-        that are bare variables or pure ``${var}`` GStrings, since those are
-        resolved in the script: block and cannot be reconciled statically."""
-        from nf_core.modules.lint.meta_yml import _channels_with_dynamic_paths
-
+        """`correct_meta_outputs` should flag only ``path`` outputs whose value
+        is a bare variable or pure ``${var}`` GString, ignoring ``val``/``eval``
+        keys that happen to look like identifiers."""
         raw_outputs = {
             "reads": [
                 [
@@ -250,8 +249,7 @@ class TestMetaYml(TestModules):
                 ]
             ],
         }
-        dynamic = _channels_with_dynamic_paths(raw_outputs)
-        assert dynamic == {"reads", "log"}, f"Expected {{'reads', 'log'}}, got {dynamic}"
+        assert _channels_with_dynamic_paths(raw_outputs) == {"reads", "log"}
 
     def test_modules_meta_yml_no_input_section(self):
         """Test that lint --fix does not crash when meta.yml has no input section (e.g. parameter-only modules)"""


### PR DESCRIPTION
## RFC: should `correct_meta_outputs` allow dynamic `path()` arguments?

Today `correct_meta_outputs` does literal string comparison between `path(...)` arguments in main.nf and the keys in meta.yml. This means the only legal output declaration is a single static glob (or partial-GString) that meta.yml can mirror exactly.

That works for almost every module, but it forces output globs to be expressible as one static pattern. For modules where the right glob is conditional on input meta — e.g.:

```nextflow
output:
tuple val(meta), path("${reads_glob}"), emit: reads

script:
def reads_glob = meta.single_end ? "${prefix}_trimmed.fq.gz"
                                 : "${prefix}_{1,2}_val_{1,2}.fq.gz"
```

— there's no static glob that works without either matching files the channel shouldn't carry, or silently dropping legitimate ones (bash globs have no negative lookbehind). The triggering example is [nf-core/modules#11317](https://github.com/nf-core/modules/pull/11317) (trimgalore, distinguishing PE intermediate `*_<N>_trimmed.fq.gz` from SE final `*_trimmed.fq.gz`).

## Proposal

When the entire `path()` argument is *just* a variable reference — `path(reads_glob)` or `path("${reads_glob}")` — skip that channel from the meta.yml comparison rather than failing it. Recognised via:

```python
_DYNAMIC_PATH_RE = re.compile(r"^(?:\$\{[a-zA-Z_]\w*\}|[a-zA-Z_]\w*)$")
```

Anchored, so partial GStrings (`${prefix}.bam`, `${prefix}_fastqc.html`, `${prefix}*.fq.gz`) and static globs are unaffected and keep validating literally. `val(...)` and `eval(...)` are unaffected regardless of their argument shape.

## What's lost

For channels declared this way, lint can no longer verify meta.yml documents the right pattern — meta.yml could be wrong and we wouldn't catch it.

## Why not "resolve and check the set"

I considered parsing the `script:` block to expand `reads_glob` to its possible values and comparing each against meta.yml. Two problems:

1. nf-core/tools has no Groovy AST parser; all existing main.nf parsing is ad-hoc regex.
2. meta.yml's schema is one pattern slot per tuple position, with no way to declare "this slot is one of {A, B}". Even with full resolution, the comparison has nowhere to land.

So a proper fix would also need a meta.yml schema RFC (alternatives per channel position, or per-mode output blocks). That's bigger than this PR.

## Question for review

- Is "skip dynamic-only `path()` from `correct_meta_outputs`" an acceptable position pending a schema-level fix?
- Or would the project rather refuse this pattern entirely and force module authors to find a static-glob workaround (subdir + mv, broader patterns + filtering at the consumer, etc.)?

If the answer is the second, this PR should be closed and [nf-core/modules#11317](https://github.com/nf-core/modules/pull/11317) replaced with [nf-core/modules#11315](https://github.com/nf-core/modules/pull/11315) (subdir+mv).

## Test plan

- [x] Unit test verifies only `path(...)` entries with bare-identifier or pure-`${var}` arguments are flagged; `val(...)`/`eval(...)` are unaffected.
- [x] Existing `tests/modules/lint/test_meta_yml.py` passes (10/10; the 1 skipped is a pre-existing dev failure).
- [x] Verified against [nf-core/modules#11317](https://github.com/nf-core/modules/pull/11317): trimgalore passes `correct_meta_outputs` with this patch.
- [x] mypy clean under repo pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)