### PR TITLE
remove todo statement from awsfulltest slack channel config

### DIFF
--- a/nf_core/pipeline-template/.github/workflows/awsfulltest.yml
+++ b/nf_core/pipeline-template/.github/workflows/awsfulltest.yml
@@ -41,7 +41,6 @@ jobs:
               enabled = true
               bot {
                 token = '{% raw %}${{ secrets.NFSLACK_BOT_TOKEN }}{% endraw %}'
-                # TODO nf-core: Set the Slack channel for CI notifications
                 channel = '{{ short_name }}'
               }
               onStart {


### PR DESCRIPTION
I don't think it is necessary and breaks the action if one "somehow" forgets to remove it.