### PR TITLE
fix incorrect handling of Assertion failure for no_prompt mode

### DIFF
--- a/nf_core/components/components_test.py
+++ b/nf_core/components/components_test.py
@@ -157,6 +157,9 @@ class ComponentsTest(ComponentCommand):  # type: ignore[misc]
             log.debug("nf-test output:\n%s", nftest_out.decode())
             if nftest_err:
                 log.debug("nf-test error:\n%s", nftest_err.decode())
+            if "Different Snapshot:" in nftest_err.decode() and self.update:
+                log.info("Updating snapshot")
+                self.generate_snapshot()
         else:
             # Interactive mode: use Rich formatting
             print("Displaying nf-test output")
@@ -171,10 +174,7 @@ class ComponentsTest(ComponentCommand):  # type: ignore[misc]
                 print("Displaying nf-test error")
             if "Different Snapshot:" in nftest_err.decode():
                 log.error("nf-test failed due to differences in the snapshots")
-                if self.no_prompts:
-                    log.info("Updating snapshot")
-                    self.update = True
-                elif self.update is None:
+                if self.update is None:
                     answer = Confirm.ask(
                         "[bold][blue]?[/] nf-test found differences in the snapshot. Do you want to update it?",
                         default=True,
@@ -221,6 +221,8 @@ class ComponentsTest(ComponentCommand):  # type: ignore[misc]
                 self.obsolete_snapshots = True
             # check if nf-test was successful
             if "Assertion failed:" in nftest_out.decode():
+                if "Different Snapshot:" not in nftest_err.decode():
+                    self.errors.append("Assertion failed.")
                 return False
             elif "No tests to execute." in nftest_out.decode():
                 log.error("Nothing to execute. Is the file 'main.nf.test' missing?")

--- a/tests/components/test_components_generate_snapshot.py
+++ b/tests/components/test_components_generate_snapshot.py
@@ -124,6 +124,26 @@ class TestTestComponentsUtils(TestComponents):
             assert "Single-End" in snap_content
             assert snap_content["Single-End"]["timestamp"] != original_timestamp
 
+    def test_assertion_failure_no_prompts(self):
+        """Assertion failures in no_prompts mode should raise UserWarning, not silently pass"""
+        with set_wd(self.nfcore_modules):
+            test_file = Path("modules", "nf-core-test", "bwa", "mem", "tests", "main.nf.test")
+            original_content = test_file.read_text()
+            test_file.write_text(original_content.replace("then {", "then {\n            assert false", 1))
+            try:
+                snap_generator = ComponentsTest(
+                    component_type="modules",
+                    component_name="bwa/mem",
+                    no_prompts=True,
+                    remote_url=GITLAB_URL,
+                    branch=GITLAB_NFTEST_BRANCH,
+                )
+                with pytest.raises(UserWarning) as e:
+                    snap_generator.run()
+            finally:
+                test_file.write_text(original_content)
+        assert "Assertion failed." in str(e.value)
+
     def test_test_not_found(self):
         """Generate the snapshot for a module in nf-core/modules clone which doesn't contain tests"""
         with set_wd(self.nfcore_modules):


### PR DESCRIPTION
in `no_prompt` mode we never wrote to self.error, which caused `nf-core m test -p` to always be successful.

closes #4227 
