### PR TITLE
Allow task.ext.prefix2 in modules linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - fix linting with missing input ([#4202](https://github.com/nf-core/tools/pull/4202))
 - fix(lint): use correct config key zenodo_doi ([#4201](https://github.com/nf-core/tools/pull/4201))
 - add missing lint test documentation and add pre-commit check for them ([#4052](https://github.com/nf-core/tools/pull/4052))
+- Allow `prefix2` for the ext keys linting ([#4234](https://github.com/nf-core/tools/pull/4234))
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@
 - .noop ([#4236](https://github.com/nf-core/tools/pull/4236))
 
 ### Linting
-- Allow `prefix2` for the ext keys linting ([#4234](https://github.com/nf-core/tools/pull/4234))
 
 ### Modules
+
+- https://github.com/nf-core/website/pull/4182 ([#4234](https://github.com/nf-core/tools/pull/4234))
 
 ### Subworkflows
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - .noop ([#4236](https://github.com/nf-core/tools/pull/4236))
 
 ### Linting
+- Allow `prefix2` for the ext keys linting ([#4234](https://github.com/nf-core/tools/pull/4234))
 
 ### Modules
 
@@ -79,7 +80,6 @@
 - fix linting with missing input ([#4202](https://github.com/nf-core/tools/pull/4202))
 - fix(lint): use correct config key zenodo_doi ([#4201](https://github.com/nf-core/tools/pull/4201))
 - add missing lint test documentation and add pre-commit check for them ([#4052](https://github.com/nf-core/tools/pull/4052))
-- Allow `prefix2` for the ext keys linting ([#4234](https://github.com/nf-core/tools/pull/4234))
 
 ### Modules
 

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -324,7 +324,7 @@ def check_script_section(self, lines):
     invalid_ext_keys = [
         key
         for key in re.findall(r"\bext\.\w+", script)
-        if key not in permitted_ext_keys and not re.match(r"^ext\.args([2-9]|\d{2,})$", key)
+        if key not in permitted_ext_keys and not re.match(r"^ext\.(args|prefix)([2-9]|\d{2,})$", key)
     ]
     if not invalid_ext_keys:
         self.passed.append(("main_nf", "main_nf_ext_key", "All 'ext' keys are valid", self.main_nf))

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -320,11 +320,11 @@ def check_script_section(self, lines):
         )
 
     # Validate ext keys
-    permitted_ext_keys = {"ext.args", "ext.prefix", "ext.use_gpu"}
+    permitted_ext_keys = {"ext.args", "ext.prefix", "ext.prefix2", "ext.use_gpu"}
     invalid_ext_keys = [
         key
         for key in re.findall(r"\bext\.\w+", script)
-        if key not in permitted_ext_keys and not re.match(r"^ext\.(args|prefix)([2-9]|\d{2,})$", key)
+        if key not in permitted_ext_keys and not re.match(r"^ext\.args([2-9]|\d{2,})$", key)
     ]
     if not invalid_ext_keys:
         self.passed.append(("main_nf", "main_nf_ext_key", "All 'ext' keys are valid", self.main_nf))

--- a/tests/modules/lint/test_main_nf.py
+++ b/tests/modules/lint/test_main_nf.py
@@ -1062,6 +1062,20 @@ def test_validate_ext_keys():
     )
     assert len(mock_lint.failed) == 0
 
+    # ext.prefixN where N >= 2 should be valid
+    mock_lint.passed, mock_lint.failed = [], []
+    check_script_section(
+        mock_lint,
+        [
+            """
+    def prefix2 = task.ext.prefix2 ?: ''
+    def prefix10 = task.ext.prefix10 ?: ''
+    def prefix99 = task.ext.prefix99 ?: ''
+    """
+        ],
+    )
+    assert len(mock_lint.failed) == 0
+
     # Check false positive matches, e.g. text.tokenize()
     mock_lint.passed, mock_lint.failed = [], []
     check_script_section(

--- a/tests/modules/lint/test_main_nf.py
+++ b/tests/modules/lint/test_main_nf.py
@@ -1062,19 +1062,34 @@ def test_validate_ext_keys():
     )
     assert len(mock_lint.failed) == 0
 
-    # ext.prefixN where N >= 2 should be valid
+    # ext.prefix2 should be valid, but not other numbers
     mock_lint.passed, mock_lint.failed = [], []
     check_script_section(
         mock_lint,
         [
             """
     def prefix2 = task.ext.prefix2 ?: ''
-    def prefix10 = task.ext.prefix10 ?: ''
-    def prefix99 = task.ext.prefix99 ?: ''
     """
         ],
     )
     assert len(mock_lint.failed) == 0
+
+    # ext.prefix1 or ext.prefix3+ should be invalid
+    mock_lint.passed, mock_lint.failed = [], []
+    check_script_section(
+        mock_lint,
+        [
+            """
+    def prefix1 = task.ext.prefix1 ?: ''
+    def prefix3 = task.ext.prefix3 ?: ''
+    def prefix22 = task.ext.prefix22 ?: ''
+    """
+        ],
+    )
+    assert len(mock_lint.failed) == 1
+    assert "ext.prefix1" in mock_lint.failed[0][2]
+    assert "ext.prefix3" in mock_lint.failed[0][2]
+    assert "ext.prefix22" in mock_lint.failed[0][2]
 
     # Check false positive matches, e.g. text.tokenize()
     mock_lint.passed, mock_lint.failed = [], []

--- a/tests/modules/lint/test_main_nf.py
+++ b/tests/modules/lint/test_main_nf.py
@@ -1041,6 +1041,9 @@ def test_validate_ext_keys():
     def args1 = task.ext.args1 ?: ''
     def custom = task.ext.custom ?: ''
     def suffix = task.ext.suffix ?: '.bam'
+    def prefix1 = task.ext.prefix1 ?: ''
+    def prefix3 = task.ext.prefix3 ?: ''
+    def prefix22 = task.ext.prefix22 ?: ''
     """
         ],
     )

--- a/tests/modules/lint/test_main_nf.py
+++ b/tests/modules/lint/test_main_nf.py
@@ -1025,6 +1025,7 @@ def test_validate_ext_keys():
     def args2 = task.ext.args2 ?: ''
     def args3 = task.ext.args3 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def prefix2 = task.ext.prefix2 ?: ''
     def use_gpu = task.ext.use_gpu ? '--gpu' : ''
     """
         ],
@@ -1047,6 +1048,9 @@ def test_validate_ext_keys():
     assert "ext.args1" in mock_lint.failed[0][2]
     assert "ext.custom" in mock_lint.failed[0][2]
     assert "ext.suffix" in mock_lint.failed[0][2]
+    assert "ext.prefix1" in mock_lint.failed[0][2]
+    assert "ext.prefix3" in mock_lint.failed[0][2]
+    assert "ext.prefix22" in mock_lint.failed[0][2]
 
     # ext.argsN where N >= 2 should be valid
     mock_lint.passed, mock_lint.failed = [], []
@@ -1061,35 +1065,6 @@ def test_validate_ext_keys():
         ],
     )
     assert len(mock_lint.failed) == 0
-
-    # ext.prefix2 should be valid, but not other numbers
-    mock_lint.passed, mock_lint.failed = [], []
-    check_script_section(
-        mock_lint,
-        [
-            """
-    def prefix2 = task.ext.prefix2 ?: ''
-    """
-        ],
-    )
-    assert len(mock_lint.failed) == 0
-
-    # ext.prefix1 or ext.prefix3+ should be invalid
-    mock_lint.passed, mock_lint.failed = [], []
-    check_script_section(
-        mock_lint,
-        [
-            """
-    def prefix1 = task.ext.prefix1 ?: ''
-    def prefix3 = task.ext.prefix3 ?: ''
-    def prefix22 = task.ext.prefix22 ?: ''
-    """
-        ],
-    )
-    assert len(mock_lint.failed) == 1
-    assert "ext.prefix1" in mock_lint.failed[0][2]
-    assert "ext.prefix3" in mock_lint.failed[0][2]
-    assert "ext.prefix22" in mock_lint.failed[0][2]
 
     # Check false positive matches, e.g. text.tokenize()
     mock_lint.passed, mock_lint.failed = [], []


### PR DESCRIPTION
In the [April maintainers meeting](https://nf-co.re/blog/2026/maintainers-minutes-2026-04-27) we agreed to allow task.ext.prefix2 as an option for modules that really need it, as an analogy to `ext.args`, `ext.args2` etc.
This PR actually allows any number of numbered prefix values, in the same way as we do for `args` (using the same code).

## PR checklist

- [X] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
