### PR TITLE
handle prek not being exposed to $PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@
 
 ### General
 
+- ## [Codecov](https://app.codecov.io/gh/nf-core/tools/pull/4238?dropdown=coverage&src=pr&el=h1&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=nf-core) Report
+  :x: Patch coverage is `85.71429%` with `1 line` in your changes missing coverage. Please review.
+  :white_check_mark: Project coverage is 20.06%. Comparing base ([`33d9944`](https://app.codecov.io/gh/nf-core/tools/commit/33d9944622d081645def84318b04e73ebaaebfdc?dropdown=coverage&el=desc&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=nf-core)) to head ([`b27bd38`](https://app.codecov.io/gh/nf-core/tools/commit/b27bd38c182a21ec6dd15f176e3c5ad8c42ada33?dropdown=coverage&el=desc&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=nf-core)).
+
+| [Files with missing lines](https://app.codecov.io/gh/nf-core/tools/pull/4238?dropdown=coverage&src=pr&el=tree&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=nf-core)                                                                                     | Patch % | Lines                                                                                                                                                                                        |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [nf_core/pipelines/lint_utils.py](https://app.codecov.io/gh/nf-core/tools/pull/4238?src=pr&el=tree&filepath=nf_core%2Fpipelines%2Flint_utils.py&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=nf-core#diff-bmZfY29yZS9waXBlbGluZXMvbGludF91dGlscy5weQ==) | 85.71%  | [1 Missing :warning: ](https://app.codecov.io/gh/nf-core/tools/pull/4238?src=pr&el=tree&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=nf-core) |
+
+> :exclamation: There is a different number of reports uploaded between BASE (33d9944) and HEAD (b27bd38). Click for more details.
+>
+> <details><summary>HEAD has 41 uploads less than BASE</summary>
+>
+> | Flag        | BASE (33d9944) | HEAD (b27bd38) |
+> | ----------- | -------------- | -------------- |
+> | python-3.10 | 54             | 13             |
+>
+> </details>
+
+[:umbrella: View full report in Codecov by Sentry](https://app.codecov.io/gh/nf-core/tools/pull/4238?dropdown=coverage&src=pr&el=continue&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=nf-core).  
+:loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/?utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=nf-core).
+
+<details><summary> :rocket: New features to boost your workflow: </summary>
+
+- :snowflake: [Test Analytics](https://docs.codecov.com/docs/test-analytics): Detect flaky tests, report on failures, and find test suite problems.
+</details> ([#4238](https://github.com/nf-core/tools/pull/4238))
+
 ### Linting
 
 ### Modules

--- a/nf_core/pipelines/lint_utils.py
+++ b/nf_core/pipelines/lint_utils.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import subprocess
+import sys
 from pathlib import Path
 
 import rich
@@ -151,7 +152,13 @@ def run_prettier_on_file(file: Path | str | list[str]) -> None:
     is_git = check_git_repo()
 
     nf_core_pre_commit_config = Path(nf_core.__file__).parent / ".pre-commit-prettier-config.yaml"
-    args = ["prek", "run", "--config", str(nf_core_pre_commit_config), "prettier"]
+    # Resolve prek relative to the current interpreter so it works in isolated
+    # environments (uv tool, pipx, conda) where only the main entry point is on
+    # PATH. Fall back to the bare name for system-wide pip installs where the
+    # scripts directory differs from the interpreter location.
+    prek_bin = Path(sys.executable).parent / "prek"
+    prek = str(prek_bin) if prek_bin.exists() else "prek"
+    args = [prek, "run", "--config", str(nf_core_pre_commit_config), "prettier"]
     if isinstance(file, list):
         args.extend(["--files", *file])
     else:

--- a/nf_core/pipelines/lint_utils.py
+++ b/nf_core/pipelines/lint_utils.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import git
 import rich
 import yaml
 from rich.console import Console
@@ -133,9 +134,9 @@ def print_fixes(lint_obj, plain_text=False):
 def check_git_repo() -> bool:
     """Check if the current directory is a git repository."""
     try:
-        subprocess.check_output(["git", "rev-parse", "--is-inside-work-tree"])
+        git.Repo(search_parent_directories=True)
         return True
-    except subprocess.CalledProcessError:
+    except git.InvalidGitRepositoryError:
         return False
 
 

--- a/tests/test_lint_utils.py
+++ b/tests/test_lint_utils.py
@@ -1,5 +1,3 @@
-import shutil
-
 import git
 import pytest
 
@@ -8,8 +6,6 @@ import nf_core.pipelines.lint_utils
 JSON_WITH_SYNTAX_ERROR = "{'a':1, 1}"
 JSON_MALFORMED = "{'a':1}"
 JSON_FORMATTED = '{ "a": 1 }\n'
-
-WHICH_PREK = shutil.which("prek")
 
 
 @pytest.fixture()
@@ -63,3 +59,10 @@ def test_run_prettier_on_syntax_error_file(syntax_error_json, caplog):
     nf_core.pipelines.lint_utils.run_prettier_on_file(syntax_error_json)
     expected_critical_log = "SyntaxError: Unexpected token (1:10)"
     assert expected_critical_log in caplog.text
+
+
+def test_run_prettier_prek_not_in_path(formatted_json, monkeypatch, tmp_path):
+    """prek must be found via sys.executable when not on PATH (e.g. uv tool install)."""
+    monkeypatch.setenv("PATH", str(tmp_path))
+    nf_core.pipelines.lint_utils.run_prettier_on_file(formatted_json)
+    assert formatted_json.read_text() == JSON_FORMATTED


### PR DESCRIPTION
Fixes prek not found error, after `uv tools install`, e.g. in https://github.com/nf-core/funcscan/actions/runs/25051953862/job/73381798336?pr=527#step:8:272