### PR TITLE
switch changelog bot trigger only on comments

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,14 +2,11 @@ name: Update CHANGELOG.md
 on:
   issue_comment:
     types: [created] # Add "@nf-core-bot changelog" as a PR comment to trigger this workflow.
-  pull_request_target:
-    types: [opened]
-    branches:
-      - dev
 
 jobs:
   update_changelog:
     runs-on: ubuntu-latest
+    if: contains(github.event.comment.body, '@nf-core-bot changelog')
 
     steps:
       - name: branch-deploy
@@ -31,11 +28,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.NF_CORE_BOT_AUTH_TOKEN }}
         run: |
-          if [[ "${{ github.event_name }}" == "issue_comment" ]]; then
-            PR_NUMBER="${{ github.event.issue.number }}"
-          elif [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
-            PR_NUMBER="${{ github.event.pull_request.number }}"
-          fi
+          PR_NUMBER="${{ github.event.issue.number }}"
           gh pr checkout $PR_NUMBER
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -86,5 +79,5 @@ jobs:
           git config user.name "nf-core-bot"
           git add ${GITHUB_WORKSPACE}/CHANGELOG.md
           git status
-          git commit -m "[automated] Update CHANGELOG.md"
+          git commit -m "[automated] Update CHANGELOG.md [skip ci]"
           git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@
 ### General
 
 - fix failing api doc generation script ([#4239](https://github.com/nf-core/tools/pull/4239))
+- ## [Codecov](https://app.codecov.io/gh/nf-core/tools/pull/4241?dropdown=coverage&src=pr&el=h1&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=nf-core) Report
+  :white_check_mark: All modified and coverable lines are covered by tests.
+  :white_check_mark: Project coverage is 17.00%. Comparing base ([`33d9944`](https://app.codecov.io/gh/nf-core/tools/commit/33d9944622d081645def84318b04e73ebaaebfdc?dropdown=coverage&el=desc&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=nf-core)) to head ([`e57bb1f`](https://app.codecov.io/gh/nf-core/tools/commit/e57bb1f376e09ee1fce186396e745d849c0f3629?dropdown=coverage&el=desc&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=nf-core)).
+  :warning: Report is 5 commits behind head on dev.
+  > :exclamation: There is a different number of reports uploaded between BASE (33d9944) and HEAD (e57bb1f). Click for more details.
+  >
+  > <details><summary>HEAD has 74 uploads less than BASE</summary>
+  >
+  > | Flag        | BASE (33d9944) | HEAD (e57bb1f) |
+  > | ----------- | -------------- | -------------- |
+  > | python-3.10 | 88             | 14             |
+  >
+  > </details>
+
+[:umbrella: View full report in Codecov by Sentry](https://app.codecov.io/gh/nf-core/tools/pull/4241?dropdown=coverage&src=pr&el=continue&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=nf-core).  
+:loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/?utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=nf-core).
+
+<details><summary> :rocket: New features to boost your workflow: </summary>
+
+- :snowflake: [Test Analytics](https://docs.codecov.com/docs/test-analytics): Detect flaky tests, report on failures, and find test suite problems.
+</details> ([#4241](https://github.com/nf-core/tools/pull/4241))
 
 ### Linting
 

--- a/uv.lock
+++ b/uv.lock
@@ -863,14 +863,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.48"
+version = "3.1.49"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/c3/e4a9656f3cdb280f5dc65a68cc6fc46e79f897d27c1a36bbb4f0f47aaac5/gitpython-3.1.48.tar.gz", hash = "sha256:b7c49ff4a49946fce38ac84116efa311b15e7dad06dc3787fc9e206bf9ef75e1", size = 217288, upload-time = "2026-04-28T05:35:45.328Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/63/210aaa302d6a0a78daa67c5c15bbac2cad361722841278b0209b6da20855/gitpython-3.1.49.tar.gz", hash = "sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1", size = 219367, upload-time = "2026-04-29T00:31:20.478Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/50/bb9703c364c00e7be67ccda03536f3d684766ce109d184c9d1f072d866ca/gitpython-3.1.48-py3-none-any.whl", hash = "sha256:737698b05889cca0f9aba7054d796620df2092c68926ee1470e5c7f5ac886680", size = 209800, upload-time = "2026-04-28T05:35:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6f/b842bfa6f21d6f87c57f9abf7194225e55279d96d869775e19e9f7236fc5/gitpython-3.1.49-py3-none-any.whl", hash = "sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c", size = 212190, upload-time = "2026-04-29T00:31:18.412Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The switch to github/branch-deploy means that it the changelog action only can run after CI has finished and an approving review has been given. 
This PR changes the trigger for this action from opened PR to approving review, hopefully making this action work like before again.