### PR TITLE
feat(template): add process_low_memory resource label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@
 
 ### Linting
 
+- Accept `process_low_memory` as a standard module label.
+
 ### Modules
 
 ### Subworkflows
 
 ### Template
+
+- Add `process_low_memory` resource label to the pipeline-template `base.config`. Mirrors `process_high_memory` so it can be stacked with one of the cpu/time bands (e.g. `process_high` + `process_low_memory` for cpu-bound, memory-light tools).
 
 #### Version updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Linting
 
-- Accept `process_low_memory` as a standard module label.
+- accept `process_low_memory` as a standard module label ([#4264](https://github.com/nf-core/tools/pull/4264))
 
 ### Modules
 
@@ -14,7 +14,7 @@
 
 ### Template
 
-- Add `process_low_memory` resource label to the pipeline-template `base.config`. Mirrors `process_high_memory` so it can be stacked with one of the cpu/time bands (e.g. `process_high` + `process_low_memory` for cpu-bound, memory-light tools).
+- add `process_low_memory` resource label to `base.config` ([#4264](https://github.com/nf-core/tools/pull/4264))
 
 #### Version updates
 

--- a/nf_core/components/create.py
+++ b/nf_core/components/create.py
@@ -249,6 +249,7 @@ class ComponentCreate(ComponentCommand):
             "process_medium",
             "process_high",
             "process_long",
+            "process_low_memory",
             "process_high_memory",
         ]
         if self.process_label is None:

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -621,6 +621,7 @@ def check_process_labels(self, lines):
         "process_medium",
         "process_high",
         "process_long",
+        "process_low_memory",
         "process_high_memory",
     ]
     all_labels = [line.strip() for line in lines if line.lstrip().startswith("label ")]

--- a/nf_core/pipeline-template/conf/base.config
+++ b/nf_core/pipeline-template/conf/base.config
@@ -49,6 +49,9 @@ process {
     withLabel:process_long {
         time   = { 20.h  * task.attempt }
     }
+    withLabel:process_low_memory {
+        memory = { 1.GB * task.attempt }
+    }
     withLabel:process_high_memory {
         memory = { 200.GB * task.attempt }
     }


### PR DESCRIPTION
## Summary

Adds a `process_low_memory` resource label to the pipeline-template `base.config` that overrides only `memory`, mirroring the existing `process_high_memory` modifier.

```groovy
withLabel:process_low_memory {
    memory = { 1.GB * task.attempt }
}
```

## Motivation

There's currently no way to express "cpu-bound but memory-light" via stacked labels. `process_high` pins both cpus *and* memory at 12 / 72 GB; dropping to `process_low` gives up the cpus too. Modern Rust streaming tools (e.g. trim_galore 2.x, with ~100 MB peak_rss on 30M PE) want exactly that shape.

With `process_low_memory` added, a module can stack labels (precedence does what you'd expect - later labels override earlier overrides):

```groovy
process FOO {
    label 'process_high'
    label 'process_low_memory'
    ...
}
```

→ 12 cpus * task.attempt, 1 GB * task.attempt, 16 h * task.attempt.

This is the symmetric counterpart of the existing pattern that `process_high_memory` already enables (low cpus + high memory for memory-hungry single-threaded tools).

Discussed in [#nf-core Slack on 2026-05-05](https://nfcore.slack.com/) - Phil Ewels suggested the label name; James Fellows Yates +1'd more granularity for resource optimisation.

## Changes

- `nf_core/pipeline-template/conf/base.config` - new `withLabel:process_low_memory` block (1 GB * task.attempt).
- `nf_core/modules/lint/main_nf.py` - add to `correct_process_labels` so module lint accepts it.
- `nf_core/components/create.py` - add to the autocomplete list shown by `nf-core modules create`.
- `CHANGELOG.md` - entries under Linting and Template.

## Why 1 GB?

`process_single` is 6 GB, `process_low` is 12 GB. The new label needs to be a meaningful step *down* from `process_single` to be worth having - 1 GB doubles to 2 GB on retry, then 3 GB, before `errorStrategy` kicks in, which is comfortable for tools that genuinely use < 500 MB. Open to bumping to 2 GB or 3 GB if reviewers prefer a more conservative floor.

## Test plan

- [ ] Existing module lint tests still pass.
- [ ] `nf-core modules create` shows the new label in the autocomplete list.
- [ ] A pipeline using `label 'process_high'` + `label 'process_low_memory'` resolves to 12 cpus + 1 GB on the first attempt.

## Out of scope

`process_high_cpu`, `process_low_cpu` - James floated more axes. Worth a follow-up but keeping this PR small.
