### PR TITLE
switch to json format for nextflow inspect

### DIFF
--- a/nf_core/modules/modules_json.py
+++ b/nf_core/modules/modules_json.py
@@ -81,8 +81,9 @@ class ModulesJson:
             UserWarning: If the creation fails
         """
         pipeline_config = nf_core.utils.fetch_wf_config(self.directory)
-        pipeline_name = pipeline_config.get("manifest.name", "")
-        pipeline_url = pipeline_config.get("manifest.homePage", "")
+        manifest = pipeline_config.get("manifest", {})
+        pipeline_name = manifest.get("name", "")
+        pipeline_url = manifest.get("homePage", "")
         new_modules_json = ModulesJsonType(name=pipeline_name, homePage=pipeline_url, repos={})
 
         if not self.modules_dir.exists():

--- a/nf_core/pipelines/bump_version.py
+++ b/nf_core/pipelines/bump_version.py
@@ -26,8 +26,8 @@ def bump_pipeline_version(pipeline_obj: Pipeline, new_version: str) -> None:
         new_version (str): The new version tag for the pipeline. Semantic versioning only.
     """
 
-    # Collect the old and new version numbers
-    current_version = pipeline_obj.nf_config.get("manifest.version", "").strip(" '\"")
+    manifest = pipeline_obj.nf_config.get("manifest", {})
+    current_version = manifest.get("version", "") or ""
     if new_version.startswith("v"):
         log.warning("Stripping leading 'v' from new version number")
         new_version = new_version[1:]
@@ -99,7 +99,7 @@ def bump_pipeline_version(pipeline_obj: Pipeline, new_version: str) -> None:
         yaml_key=["report_comment"],
     )
     # nf-test snap files
-    pipeline_name = pipeline_obj.nf_config.get("manifest.name", "").strip(" '\"")
+    pipeline_name = manifest.get("name", "")
     snap_files = [f.relative_to(pipeline_obj.wf_path) for f in Path(pipeline_obj.wf_path).glob("tests/pipeline/*.snap")]
     for snap_file in snap_files:
         update_file_version(
@@ -169,8 +169,8 @@ def bump_nextflow_version(pipeline_obj: Pipeline, new_version: str) -> None:
         new_version (str): The new version tag for the required Nextflow version.
     """
 
-    # Collect the old and new version numbers - strip leading non-numeric characters (>=)
-    current_version = pipeline_obj.nf_config.get("manifest.nextflowVersion", "").strip(" '\"")
+    manifest = pipeline_obj.nf_config.get("manifest", {})
+    current_version = manifest.get("nextflowVersion", "") or ""
     current_version = re.sub(r"^[^0-9\.]*", "", current_version)
     new_version = re.sub(r"^[^0-9\.]*", "", new_version)
     if not current_version:

--- a/nf_core/pipelines/download/container_fetcher.py
+++ b/nf_core/pipelines/download/container_fetcher.py
@@ -292,8 +292,11 @@ class ContainerFetcher(ABC):
 
         config_registries = set()
         for registry_key in registry_keys:
-            if registry_key in nf_config:
-                config_registries.add(nf_config[registry_key])
+            parts = registry_key.split(".", 1)
+            if len(parts) == 2 and parts[0] in nf_config and isinstance(nf_config[parts[0]], dict):
+                val = nf_config[parts[0]].get(parts[1])
+                if val:
+                    config_registries.add(val)
 
         return config_registries
 

--- a/nf_core/pipelines/lint/files_exist.py
+++ b/nf_core/pipelines/lint/files_exist.py
@@ -120,11 +120,12 @@ def files_exist(self) -> dict[str, list[str]]:
     # NB: Should all be files, not directories
     # List of lists. Passes if any of the files in the sublist are found.
     #: test autodoc
-    try:
-        _, short_name = self.nf_config["manifest.name"].strip("\"'").split("/")
-    except ValueError:
+    pipeline_name = self.nf_config.get("manifest", {}).get("name", "")
+    if "/" in pipeline_name:
+        _, short_name = pipeline_name.split("/")
+    else:
         log.warning("Expected manifest.name to be in the format '<repo>/<pipeline>'. Will assume it is '<pipeline>'.")
-        short_name = self.nf_config["manifest.name"].strip("\"'").split("/")
+        short_name = pipeline_name
 
     files_fail = [
         [Path(".gitattributes")],

--- a/nf_core/pipelines/lint/files_unchanged.py
+++ b/nf_core/pipelines/lint/files_unchanged.py
@@ -114,12 +114,11 @@ def files_unchanged(self) -> dict[str, list[str] | bool]:
     tmp_dir.mkdir(parents=True)
 
     # Create a template.yaml file for the pipeline creation
-    names = ""
-    if manifest_config.get("author"):
-        names = manifest_config.get("author", "")
     contributors = manifest_config.get("contributors", [])
     if contributors:
-        names = ", ".join([c.get("name", "") for c in contributors if c.get("name")])
+        names = ", ".join(c.get("name", "") for c in contributors if c.get("name"))
+    else:
+        names = manifest_config.get("author", "")
     template_yaml = {
         "name": short_name,
         "description": manifest_config.get("description", ""),

--- a/nf_core/pipelines/lint/files_unchanged.py
+++ b/nf_core/pipelines/lint/files_unchanged.py
@@ -1,6 +1,5 @@
 import filecmp
 import logging
-import re
 import shutil
 import tempfile
 from pathlib import Path
@@ -66,21 +65,18 @@ def files_unchanged(self) -> dict[str, list[str] | bool]:
     could_fix: bool = False
 
     # Check that we have the minimum required config
-    required_pipeline_config = {
-        "manifest.name",
-        "manifest.description",
-        "manifest.contributors",
-    }
-    missing_pipeline_config = required_pipeline_config.difference(self.nf_config)
+    manifest_config = self.nf_config.get("manifest", {})
+    missing_pipeline_config = {k for k in ("name", "description", "contributors") if not manifest_config.get(k)}
     if missing_pipeline_config:
-        return {"ignored": [f"Required pipeline config not found - {missing_pipeline_config}"]}
+        missing_keys = {f"manifest.{k}" for k in missing_pipeline_config}
+        return {"ignored": [f"Required pipeline config not found - {missing_keys}"]}
     try:
-        prefix, short_name = self.nf_config["manifest.name"].strip("\"'").split("/")
+        prefix, short_name = manifest_config.get("name", "").split("/")
     except ValueError:
         log.warning(
             "Expected manifest.name to be in the format '<repo>/<pipeline>'. Will assume it is <pipeline> and default to repo 'nf-core'"
         )
-        short_name = self.nf_config["manifest.name"].strip("\"'")
+        short_name = manifest_config.get("name", "")
         prefix = "nf-core"
 
     # NB: Should all be files, not directories
@@ -118,14 +114,15 @@ def files_unchanged(self) -> dict[str, list[str] | bool]:
     tmp_dir.mkdir(parents=True)
 
     # Create a template.yaml file for the pipeline creation
-    if "manifest.author" in self.nf_config:
-        names = self.nf_config["manifest.author"].strip("\"'")
-    if "manifest.contributors" in self.nf_config:
-        contributors = self.nf_config["manifest.contributors"]
-        names = ", ".join(re.findall(r"name:'([^']+)'", contributors))
+    names = ""
+    if manifest_config.get("author"):
+        names = manifest_config.get("author", "")
+    contributors = manifest_config.get("contributors", [])
+    if contributors:
+        names = ", ".join([c.get("name", "") for c in contributors if c.get("name")])
     template_yaml = {
         "name": short_name,
-        "description": self.nf_config["manifest.description"].strip("\"'"),
+        "description": manifest_config.get("description", ""),
         "author": names,
         "org": prefix,
     }

--- a/nf_core/pipelines/lint/multiqc_config.py
+++ b/nf_core/pipelines/lint/multiqc_config.py
@@ -98,7 +98,7 @@ def multiqc_config(self) -> dict[str, list[str]]:
 
         if "report_comment" not in ignore_configs:
             # Check that the minimum plugins exist and are coming first in the summary
-            version = self.nf_config.get("manifest.version", "").strip(" '\"")
+            version = self.nf_config.get("manifest", {}).get("version", "") or ""
 
             # Get the org from .nf-core.yml config, defaulting to "nf-core"
             _, nf_core_yaml_config = load_tools_config(self.wf_path)

--- a/nf_core/pipelines/lint/nextflow_config.py
+++ b/nf_core/pipelines/lint/nextflow_config.py
@@ -1,4 +1,3 @@
-import ast
 import logging
 import re
 from pathlib import Path
@@ -170,7 +169,7 @@ def nextflow_config(self) -> dict[str, list[str]]:
     ]
 
     # Lint for plugins
-    config_plugins = ast.literal_eval(self.nf_config.get("plugins", "[]"))
+    config_plugins = self.nf_config.get("plugins", [])
     found_plugins = []
     for plugin in config_plugins:
         if "@" not in plugin:
@@ -203,39 +202,34 @@ def nextflow_config(self) -> dict[str, list[str]]:
     # Remove field that should be ignored according to the linting config
     ignore_configs = self.lint_config.get("nextflow_config", []) if self.lint_config is not None else []
 
-    for cfs in config_fail:
-        for cf in cfs:
-            if cf in ignore_configs:
-                ignored.append(f"Config variable ignored: {self._wrap_quotes(cf)}")
-                break
-            if cf in self.nf_config:
-                passed.append(f"Config variable found: {self._wrap_quotes(cf)}")
-                break
-        else:
-            failed.append(f"Config variable not found: {self._wrap_quotes(cfs)}")
-    for cfs in config_warn:
-        for cf in cfs:
-            if cf in ignore_configs:
-                ignored.append(f"Config variable ignored: {self._wrap_quotes(cf)}")
-                break
-            if cf in self.nf_config:
-                passed.append(f"Config variable found: {self._wrap_quotes(cf)}")
-                break
-        else:
-            warned.append(f"Config variable not found: {self._wrap_quotes(cfs)}")
+    def _config_has_key(key: str) -> bool:
+        section, name = key.split(".", 1)
+        return self.nf_config.get(section, {}).get(name) is not None
+
+    for configs, not_found in [(config_fail, failed), (config_warn, warned)]:
+        for cfs in configs:
+            for cf in cfs:
+                if cf in ignore_configs:
+                    ignored.append(f"Config variable ignored: {self._wrap_quotes(cf)}")
+                    break
+                if _config_has_key(cf):
+                    passed.append(f"Config variable found: {self._wrap_quotes(cf)}")
+                    break
+            else:
+                not_found.append(f"Config variable not found: {self._wrap_quotes(cfs)}")
     for cf in config_fail_ifdefined:
         if cf in ignore_configs:
             ignored.append(f"Config variable ignored: {self._wrap_quotes(cf)}")
-            break
-        if cf not in self.nf_config:
+            continue
+        if not _config_has_key(cf):
             passed.append(f"Config variable (correctly) not found: {self._wrap_quotes(cf)}")
         else:
             failed.append(f"Config variable (incorrectly) found: {self._wrap_quotes(cf)}")
 
     # Check and warn if the process configuration is done with deprecated syntax
-
+    process_config = self.nf_config.get("process", {})
     process_with_deprecated_syntax = list(
-        {match.group(1) for ck in self.nf_config if (match := re.match(r"^(process\.\$.*?)\.+.*$", ck)) is not None}
+        {f"process.{ck}" for ck in (process_config if isinstance(process_config, dict) else {}) if re.match(r"^\$", ck)}
     )
     for pd in process_with_deprecated_syntax:
         warned.append(f"Process configuration is done with deprecated_syntax: {pd}")
@@ -244,90 +238,75 @@ def nextflow_config(self) -> dict[str, list[str]]:
     for k in ["timeline.enabled", "report.enabled", "trace.enabled", "dag.enabled"]:
         if k in ignore_configs:
             continue
-        if self.nf_config.get(k) == "true":
-            passed.append(f"Config ``{k}`` had correct value: ``{self.nf_config.get(k)}``")
+        section, name = k.split(".")
+        val = self.nf_config.get(section, {}).get(name)
+        if val is True:
+            passed.append(f"Config ``{k}`` had correct value: ``{val}``")
         else:
-            failed.append(f"Config ``{k}`` did not have correct value: ``{self.nf_config.get(k)}``")
+            failed.append(f"Config ``{k}`` did not have correct value: ``{val}``")
 
     _, nf_core_yaml_config = load_tools_config(self.wf_path)
     org_name = "nf-core"
     if nf_core_yaml_config and getattr(nf_core_yaml_config, "template", None):
         org_name = getattr(nf_core_yaml_config.template, "org", org_name) or org_name
 
-    if "manifest.name" not in ignore_configs:
-        # Check that the pipeline name starts with nf-core
-        try:
-            manifest_name = self.nf_config.get("manifest.name", "").strip("'\"")
-            if not manifest_name.startswith(f"{org_name}/"):
-                raise AssertionError
-        except (AssertionError, IndexError):
-            failed.append(f"Config ``manifest.name`` did not begin with ``{org_name}/``:\n    {manifest_name}")
+    manifest = self.nf_config.get("manifest", {})
+    for key, expected_prefix in [
+        ("name", f"{org_name}/"),
+        ("homePage", f"https://github.com/{org_name}/"),
+    ]:
+        value = manifest.get(key, "")
+        if value in ignore_configs:
+            continue
+        if value.startswith(expected_prefix):
+            passed.append(f"Config ``{value}`` began with ``{expected_prefix}``")
         else:
-            passed.append(f"Config ``manifest.name`` began with ``{org_name}/``")
+            failed.append(f"Config ``{value}`` did not begin with ``{expected_prefix}``")
 
-    if "manifest.homePage" not in ignore_configs:
-        # Check that the homePage is set to the GitHub URL
-        try:
-            manifest_homepage = self.nf_config.get("manifest.homePage", "").strip("'\"")
-            if not manifest_homepage.startswith(f"https://github.com/{org_name}/"):
-                raise AssertionError
-        except (AssertionError, IndexError):
-            failed.append(
-                f"Config variable ``manifest.homePage`` did not begin with https://github.com/{org_name}/:\n    {manifest_homepage}"
-            )
-
-        else:
-            passed.append(f"Config variable ``manifest.homePage`` began with https://github.com/{org_name}/")
-
-    # Check that the DAG filename ends in ``.svg``
-    if "dag.file" in self.nf_config:
+    dag_file = self.nf_config.get("dag", {}).get("file", "")
+    if dag_file:
         default_dag_format = ".html"
-        if self.nf_config["dag.file"].strip("'\"").endswith(default_dag_format):
+        if dag_file.endswith(default_dag_format):
             passed.append(f"Config ``dag.file`` ended with ``{default_dag_format}``")
         else:
             failed.append(f"Config ``dag.file`` did not end with ``{default_dag_format}``")
 
     # Check that the minimum nextflowVersion is set properly
-    if "manifest.nextflowVersion" in self.nf_config:
-        if self.nf_config.get("manifest.nextflowVersion", "").strip("\"'").lstrip("!").startswith(">="):
+    nextflow_version = self.nf_config.get("manifest", {}).get("nextflowVersion", "")
+    if nextflow_version:
+        if nextflow_version.lstrip("!").startswith(">="):
             passed.append("Config variable ``manifest.nextflowVersion`` started with >= or !>=")
         else:
             failed.append(
-                "Config ``manifest.nextflowVersion`` did not start with ``>=`` or ``!>=`` : "
-                f"``{self.nf_config.get('manifest.nextflowVersion', '')}``".strip("\"'")
+                f"Config ``manifest.nextflowVersion`` did not start with ``>=`` or ``!>=`` : ``{nextflow_version}``"
             )
 
     # Check that the pipeline version contains ``dev``
-    if not self.release_mode and "manifest.version" in self.nf_config:
-        if self.nf_config["manifest.version"].strip(" '\"").endswith("dev"):
-            passed.append(f"Config ``manifest.version`` ends in ``dev``: ``{self.nf_config['manifest.version']}``")
+    manifest_version = self.nf_config.get("manifest", {}).get("version", "")
+    if not self.release_mode and manifest_version:
+        if manifest_version.endswith("dev"):
+            passed.append(f"Config ``manifest.version`` ends in ``dev``: ``{manifest_version}``")
         else:
-            warned.append(
-                f"Config ``manifest.version`` should end in ``dev``: ``{self.nf_config['manifest.version']}``"
-            )
-    elif "manifest.version" in self.nf_config:
-        if "dev" in self.nf_config["manifest.version"]:
+            warned.append(f"Config ``manifest.version`` should end in ``dev``: ``{manifest_version}``")
+    elif manifest_version:
+        if "dev" in manifest_version:
             failed.append(
-                "Config ``manifest.version`` should not contain ``dev`` for a release: "
-                f"``{self.nf_config['manifest.version']}``"
+                f"Config ``manifest.version`` should not contain ``dev`` for a release: ``{manifest_version}``"
             )
         else:
-            passed.append(
-                "Config ``manifest.version`` does not contain ``dev`` for release: "
-                f"``{self.nf_config['manifest.version']}``"
-            )
+            passed.append(f"Config ``manifest.version`` does not contain ``dev`` for release: ``{manifest_version}``")
 
     if "custom_config" not in ignore_configs:
         # Check if custom profile params are set correctly
-        if self.nf_config.get("params.custom_config_version", "").strip("'") == "master":
+        if self.nf_config.get("params", {}).get("custom_config_version", "") == "master":
             passed.append("Config `params.custom_config_version` is set to `master`")
         else:
             failed.append("Config `params.custom_config_version` is not set to `master`")
 
         custom_config_base = "https://raw.githubusercontent.com/nf-core/configs/{}".format(
-            self.nf_config.get("params.custom_config_version", "").strip("'")
+            self.nf_config.get("params", {}).get("custom_config_version", "")
         )
-        if self.nf_config.get("params.custom_config_base", "").strip("'") == custom_config_base:
+        if self.nf_config.get("params", {}).get("custom_config_base", "") == custom_config_base:
             passed.append(f"Config `params.custom_config_base` is set to `{custom_config_base}`")
         else:
             failed.append(f"Config `params.custom_config_base` is not set to `{custom_config_base}`")
@@ -411,18 +390,19 @@ def nextflow_config(self) -> dict[str, list[str]]:
     schema.get_schema_types()  # Get types from schema
     for param_name in schema.schema_defaults:
         param = "params." + param_name
+        param_value = self.nf_config.get("params", {}).get(param_name)
         if param in ignore_defaults:
             ignored.append(f"Config default ignored: {param}")
-        elif param in self.nf_config:
+        elif param_value is not None:
             config_default: str | float | int | None = None
             schema_default: str | float | int | None = None
             if schema.schema_types[param_name] == "boolean":
                 schema_default = str(schema.schema_defaults[param_name]).lower()
-                config_default = str(self.nf_config[param]).lower()
+                config_default = str(param_value).lower()
             elif schema.schema_types[param_name] == "number":
                 try:
                     schema_default = float(schema.schema_defaults[param_name])
-                    config_default = float(self.nf_config[param])
+                    config_default = float(param_value)
                 except ValueError:
                     failed.append(
                         f"Config default value incorrect: `{param}` is set as type `number` in nextflow_schema.json, but is not a number in `nextflow.config`."
@@ -430,19 +410,19 @@ def nextflow_config(self) -> dict[str, list[str]]:
             elif schema.schema_types[param_name] == "integer":
                 try:
                     schema_default = int(schema.schema_defaults[param_name])
-                    config_default = int(self.nf_config[param])
+                    config_default = int(param_value)
                 except ValueError:
                     failed.append(
                         f"Config default value incorrect: `{param}` is set as type `integer` in nextflow_schema.json, but is not an integer in `nextflow.config`."
                     )
             else:
                 schema_default = str(schema.schema_defaults[param_name])
-                config_default = str(self.nf_config[param])
+                config_default = str(param_value)
             if config_default is not None and config_default == schema_default:
                 passed.append(f"Config default value correct: {param}= {schema_default}")
             else:
                 failed.append(
-                    f"Config default value incorrect: `{param}` is set as {self._wrap_quotes(schema_default)} in `nextflow_schema.json` but is {self._wrap_quotes(self.nf_config[param])} in `nextflow.config`."
+                    f"Config default value incorrect: `{param}` is set as {self._wrap_quotes(schema_default)} in `nextflow_schema.json` but is {self._wrap_quotes(param_value)} in `nextflow.config`."
                 )
         else:
             schema_default = str(schema.schema_defaults[param_name])

--- a/nf_core/pipelines/lint/nextflow_config.py
+++ b/nf_core/pipelines/lint/nextflow_config.py
@@ -204,7 +204,7 @@ def nextflow_config(self) -> dict[str, list[str]]:
 
     def _config_has_key(key: str) -> bool:
         section, name = key.split(".", 1)
-        return self.nf_config.get(section, {}).get(name) is not None
+        return name in self.nf_config.get(section, {})
 
     for configs, not_found in [(config_fail, failed), (config_warn, warned)]:
         for cfs in configs:

--- a/nf_core/pipelines/lint/nextflow_config.py
+++ b/nf_core/pipelines/lint/nextflow_config.py
@@ -255,13 +255,14 @@ def nextflow_config(self) -> dict[str, list[str]]:
         ("name", f"{org_name}/"),
         ("homePage", f"https://github.com/{org_name}/"),
     ]:
-        value = manifest.get(key, "")
-        if value in ignore_configs:
+        config_key = f"manifest.{key}"
+        if config_key in ignore_configs:
             continue
+        value = manifest.get(key, "")
         if value.startswith(expected_prefix):
-            passed.append(f"Config ``{value}`` began with ``{expected_prefix}``")
+            passed.append(f"Config ``{config_key}`` began with ``{expected_prefix}``")
         else:
-            failed.append(f"Config ``{value}`` did not begin with ``{expected_prefix}``")
+            failed.append(f"Config ``{config_key}`` did not begin with ``{expected_prefix}``")
 
     dag_file = self.nf_config.get("dag", {}).get("file", "")
     if dag_file:
@@ -272,7 +273,7 @@ def nextflow_config(self) -> dict[str, list[str]]:
             failed.append(f"Config ``dag.file`` did not end with ``{default_dag_format}``")
 
     # Check that the minimum nextflowVersion is set properly
-    nextflow_version = self.nf_config.get("manifest", {}).get("nextflowVersion", "")
+    nextflow_version = manifest.get("nextflowVersion", "")
     if nextflow_version:
         if nextflow_version.lstrip("!").startswith(">="):
             passed.append("Config variable ``manifest.nextflowVersion`` started with >= or !>=")

--- a/nf_core/pipelines/lint/plugin_includes.py
+++ b/nf_core/pipelines/lint/plugin_includes.py
@@ -1,4 +1,3 @@
-import ast
 import logging
 import re
 from pathlib import Path
@@ -12,7 +11,7 @@ def plugin_includes(self) -> dict[str, list[str]]:
     When nf-schema is used in an nf-core pipeline, the include statements of the plugin
     functions have to use nf-schema instead of nf-validation and vice versa
     """
-    config_plugins = [plugin.split("@")[0] for plugin in ast.literal_eval(self.nf_config.get("plugins", "[]"))]
+    config_plugins = [plugin.split("@")[0] for plugin in self.nf_config.get("plugins", [])]
     validation_plugin = "nf-validation" if "nf-validation" in config_plugins else "nf-schema"
 
     passed: list[str] = []

--- a/nf_core/pipelines/lint/version_consistency.py
+++ b/nf_core/pipelines/lint/version_consistency.py
@@ -32,10 +32,10 @@ def version_consistency(self):
     # Get the version definitions
     # Get version from nextflow.config
     versions = {}
-    versions["manifest.version"] = self.nf_config.get("manifest", {}).get("version", "") or ""
+    versions["manifest.version"] = self.nf_config.get("manifest", {}).get("version") or ""
 
     # Get version from the docker tag
-    process_container = self.nf_config.get("process", {}).get("container", "") or ""
+    process_container = self.nf_config.get("process", {}).get("container") or ""
     if process_container and ":" not in process_container:
         failed.append(f"Docker slug seems not to have a version tag: {process_container}")
 

--- a/nf_core/pipelines/lint/version_consistency.py
+++ b/nf_core/pipelines/lint/version_consistency.py
@@ -32,15 +32,16 @@ def version_consistency(self):
     # Get the version definitions
     # Get version from nextflow.config
     versions = {}
-    versions["manifest.version"] = self.nf_config.get("manifest.version", "").strip(" '\"")
+    versions["manifest.version"] = self.nf_config.get("manifest", {}).get("version", "") or ""
 
     # Get version from the docker tag
-    if self.nf_config.get("process.container", "") and ":" not in self.nf_config.get("process.container", ""):
-        failed.append(f"Docker slug seems not to have a version tag: {self.nf_config.get('process.container', '')}")
+    process_container = self.nf_config.get("process", {}).get("container", "") or ""
+    if process_container and ":" not in process_container:
+        failed.append(f"Docker slug seems not to have a version tag: {process_container}")
 
     # Get config container tag (if set; one container per workflow)
-    if self.nf_config.get("process.container", ""):
-        versions["process.container"] = self.nf_config.get("process.container", "").strip(" '\"").split(":")[-1]
+    if process_container:
+        versions["process.container"] = process_container.split(":")[-1]
 
     # Get version from the $GITHUB_REF env var if this is a release
     if (

--- a/nf_core/pipelines/rocrate.py
+++ b/nf_core/pipelines/rocrate.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 """Code to deal with pipeline RO (Research Object) Crates"""
 
-import json
 import logging
 import os
 import re
@@ -103,7 +102,7 @@ class ROCrate:
         """
 
         # Check that the checkout pipeline version is the same as the requested version
-        if self.version != "" and self.version != self.pipeline_obj.nf_config.get("manifest.version"):
+        if self.version and self.version != self.pipeline_obj.nf_config.get("manifest", {}).get("version"):
             # using git checkout to get the requested version
             log.info(f"Checking out pipeline version {self.version}")
             if self.pipeline_obj.repo is None:
@@ -119,7 +118,7 @@ class ROCrate:
             except GitCommandError:
                 log.error(f"Could not checkout version {self.version}")
                 sys.exit(1)
-        self.version = self.pipeline_obj.nf_config.get("manifest.version", "")
+        self.version = self.pipeline_obj.nf_config.get("manifest", {}).get("version", "")
         self.make_workflow_rocrate()
 
         # Save just the JSON metadata file
@@ -161,13 +160,14 @@ class ROCrate:
 
         # Create the RO Crate object
 
+        manifest = self.pipeline_obj.nf_config.get("manifest", {})
         self.crate = custom_make_crate(
             self.pipeline_dir,
             self.pipeline_dir / "main.nf",
-            self.pipeline_obj.nf_config.get("manifest.homePage", ""),
-            self.pipeline_obj.nf_config.get("manifest.name", ""),
-            self.pipeline_obj.nf_config.get("manifest.version", ""),
-            self.pipeline_obj.nf_config.get("manifest.nextflowVersion", ""),
+            manifest.get("homePage", ""),
+            manifest.get("name", ""),
+            manifest.get("version", ""),
+            manifest.get("nextflowVersion", ""),
             diagram=diagram,
         )
 
@@ -268,10 +268,11 @@ class ROCrate:
         """
         Add workflow authors to the crate
         """
+        manifest = self.pipeline_obj.nf_config.get("manifest", {})
         contributors = []
-        if "manifest.contributors" in self.pipeline_obj.nf_config:
+        if manifest.get("contributors"):
             contributors = self.parse_manifest_contributors()
-        if not contributors and "manifest.author" in self.pipeline_obj.nf_config:
+        if not contributors and manifest.get("author"):
             if self.pipeline_obj.repo:
                 contributors = self.parse_manifest_authors()
             else:
@@ -346,7 +347,7 @@ class ROCrate:
 
     def parse_manifest_authors(self) -> list:
         # parse manifest.author"
-        authors = [a.strip() for a in self.pipeline_obj.nf_config["manifest.author"].split(",")]
+        authors = [a.strip() for a in self.pipeline_obj.nf_config.get("manifest", {}).get("author", "").split(",")]
         # remove duplicates
         authors = list(set(authors))
         log.debug(f"Authors: {authors}")
@@ -398,26 +399,14 @@ class ROCrate:
     # and return as a list of dictionaries
     def parse_manifest_contributors(self) -> list:
         field_names = ["name", "affiliation", "github", "contribution", "orcid", "email"]
-        # Grab the contributor list and convert to JSON
-        # TODO: can be removed once we switch to `nextflow config -o json`
-        contributors_str = self.pipeline_obj.nf_config["manifest.contributors"]
-        log.debug(f"manifest.contributors: {contributors_str}")
-        # JSON uses double quotes, not single quotes
-        contributors_str = contributors_str.replace("'", '"')
-        for key in field_names:
-            # All dictionary keys need to be quoted
-            contributors_str = contributors_str.replace(f"{key}:", f'"{key}":')
-        # Use curly brackets for dictionaries
-        contributors_str = contributors_str.replace("], [", "}, {").replace("[[", "[{").replace("]]", "}]")
-        log.debug(f"manifest.contributors (normalised): {contributors_str}")
-        try:
-            contributors = json.loads(contributors_str)
-        except json.JSONDecodeError as exc:
+        # Grab the contributor list directly from the nested config (already a list[dict])
+        contributors = self.pipeline_obj.nf_config.get("manifest", {}).get("contributors", [])
+        log.debug(f"manifest.contributors: {contributors}")
+        if not isinstance(contributors, list):
             log.error(
                 "Could not parse `manifest.contributors` from nextflow.config. "
                 "Expected a list of maps, for example: [[name: 'First Last', github: 'user']]. "
-                f"Normalised string passed to JSON parser was: {contributors_str!r}. "
-                f"JSON decoding error: {exc}"
+                f"Got: {contributors!r}"
             )
             return []
 

--- a/nf_core/pipelines/schema.py
+++ b/nf_core/pipelines/schema.py
@@ -93,16 +93,17 @@ class PipelineSchema:
         # Previous versions of nf-schema used "defs", but it's advised to use "$defs"
         if plugin == "nf-schema":
             self.defs_notation = "$defs"
+            validation = conf.get("validation", {})
+            help_config = validation.get("help", {})
             ignored_params = [
-                conf.get("validation.help.shortParameter", "help"),
-                conf.get("validation.help.fullParameter", "helpFull"),
-                conf.get("validation.help.showHiddenParameter", "showHidden"),
+                help_config.get("shortParameter", "help"),
+                help_config.get("fullParameter", "helpFull"),
+                help_config.get("showHiddenParameter", "showHidden"),
                 "trace_report_suffix",  # report suffix should be ignored by default as it is a Java Date object
             ]  # Help parameter should be ignored by default
-            ignored_params_config_str = conf.get("validation.defaultIgnoreParams", "")
-            ignored_params_config = [
-                item.strip().strip("'") for item in ignored_params_config_str[1:-1].split(",")
-            ]  # Extract list elements and remove whitespace
+            ignored_params_config = validation.get("defaultIgnoreParams", [])
+            if not isinstance(ignored_params_config, list):
+                ignored_params_config = []
 
             if len(ignored_params_config) > 0:
                 log.debug(f"Ignoring parameters from config: {ignored_params_config}")
@@ -761,16 +762,15 @@ class PipelineSchema:
         log.debug("Collecting pipeline parameter defaults\n")
         config = nf_core.utils.fetch_wf_config(Path(self.schema_filename).parent)
         skipped_params = []
-        # Pull out just the params. values
-        for ckey, cval in config.items():
-            if ckey.startswith("params."):
-                # skip anything that's not a flat variable
-                if "." in ckey[7:]:
-                    skipped_params.append(ckey)
-                    continue
-                self.pipeline_params[ckey[7:]] = cval
-            if ckey.startswith("manifest."):
-                self.pipeline_manifest[ckey[9:]] = cval
+        # Pull out just the params values (top-level flat keys only)
+        for pkey, pval in config.get("params", {}).items():
+            if isinstance(pval, dict):
+                skipped_params.append(f"params.{pkey}")
+                continue
+            self.pipeline_params[pkey] = pval
+        # Pull out manifest values
+        for mkey, mval in config.get("manifest", {}).items():
+            self.pipeline_manifest[mkey] = mval
         # Log skipped params
         if len(skipped_params) > 0:
             log.debug(

--- a/nf_core/pipelines/schema.py
+++ b/nf_core/pipelines/schema.py
@@ -384,13 +384,13 @@ class PipelineSchema:
                 return
 
         # if default is null, we're good
-        if config_default == "null":
+        if config_default is None or config_default == "null":
             return
 
         # Check variable types in nextflow.config
-        if schema_param["type"] == "string" and str(config_default) in ["false", "true", "''"]:
+        if schema_param["type"] == "string" and str(config_default).lower() in ["false", "true", "''"]:
             self.invalid_nextflow_config_default_parameters[param] = f"String should not be set to `{config_default}`"
-        if schema_param["type"] == "boolean" and str(config_default) not in ["false", "true"]:
+        if schema_param["type"] == "boolean" and str(config_default).lower() not in ["false", "true"]:
             self.invalid_nextflow_config_default_parameters[param] = (
                 f"Booleans should only be true or false, not `{config_default}`"
             )

--- a/nf_core/pipelines/schema.py
+++ b/nf_core/pipelines/schema.py
@@ -927,7 +927,7 @@ class PipelineSchema:
         if p_val is None:
             return {"type": "string"}
         if isinstance(p_val, bool):
-            return {"type": "boolean", "default": p_val} if p_val else {"type": "boolean"}
+            return {"type": "boolean", "default": p_val} if p_val else {"type": "boolean"}  # no default for False
         if isinstance(p_val, int):
             return {"type": "integer", "default": p_val}
         if isinstance(p_val, float):

--- a/nf_core/pipelines/schema.py
+++ b/nf_core/pipelines/schema.py
@@ -924,32 +924,30 @@ class PipelineSchema:
         """
         Build a pipeline schema dictionary for an param interactively
         """
+        if p_val is None:
+            return {"type": "string"}
+        if isinstance(p_val, bool):
+            return {"type": "boolean", "default": p_val} if p_val else {"type": "boolean"}
+        if isinstance(p_val, int):
+            return {"type": "integer", "default": p_val}
+        if isinstance(p_val, float):
+            return {"type": "number", "default": p_val}
+
+        # TODO: remove string branch once old text-format config caches are no longer supported
         p_val = p_val.strip("\"'")
-        # p_val is always a string as it is parsed from nextflow config this way
+        if not p_val or p_val == "null":
+            return {"type": "string"}
+        if p_val in ("true", "True"):
+            return {"type": "boolean", "default": True}
+        if p_val in ("false", "False"):
+            return {"type": "boolean"}
         try:
-            p_val = float(p_val)
-            if p_val == int(p_val):
-                p_val = int(p_val)
-                p_type = "integer"
-            else:
-                p_type = "number"
+            num = float(p_val)
+            if num == int(num):
+                return {"type": "integer", "default": int(num)}
+            return {"type": "number", "default": num}
         except ValueError:
-            p_type = "string"
-
-        # Anything can be "null", means that it is not set
-        if p_val == "null":
-            p_val = None
-
-        # Booleans
-        if p_val in ["true", "false", "True", "False"]:
-            p_val = p_val in ["true", "True"]  # Convert to bool
-            p_type = "boolean"
-
-        # Don't return a default for anything false-y except 0
-        if not p_val and not (p_val == 0 and p_val is not False):
-            return {"type": p_type}
-
-        return {"type": p_type, "default": p_val}
+            return {"type": "string", "default": p_val}
 
     def launch_web_builder(self):
         """

--- a/nf_core/pipelines/sync.py
+++ b/nf_core/pipelines/sync.py
@@ -81,10 +81,10 @@ class PipelineSync:
         self.make_pr = make_pr
         self.gh_pr_returned_data: dict = {}
         self.required_config_vars = [
-            "manifest.name",
-            "manifest.description",
-            "manifest.version",
-            "manifest.contributors",
+            "name",
+            "description",
+            "version",
+            "contributors",
         ]
         self.force_pr = force_pr
 
@@ -232,8 +232,8 @@ class PipelineSync:
 
         # Check that we have the required variables
         for rvar in self.required_config_vars:
-            if rvar not in self.wf_config:
-                raise SyncExceptionError(f"Workflow config variable `{rvar}` not found!")
+            if rvar not in self.wf_config.get("manifest", {}):
+                raise SyncExceptionError(f"Workflow config variable `manifest.{rvar}` not found!")
 
     def checkout_template_branch(self):
         """
@@ -320,7 +320,7 @@ class PipelineSync:
                 from_config_file=True,
                 no_git=True,
                 force=True,
-                default_branch=self.wf_config.get("manifest.defaultBranch") or "master",
+                default_branch=self.wf_config.get("manifest", {}).get("defaultBranch") or "master",
             )
             pipeline_create_obj.init_pipeline()
 

--- a/nf_core/pipelines/sync.py
+++ b/nf_core/pipelines/sync.py
@@ -53,7 +53,7 @@ class PipelineSync:
         original_branch (str): Repo branch that was checked out before we started.
         made_changes (bool): Whether making the new template pipeline introduced any changes
         make_pr (bool): Whether to try to automatically make a PR on GitHub.com
-        required_config_vars (list): List of nextflow variables required to make template pipeline
+        required_config_vars (dict): Nextflow config variables required to make template pipeline, keyed by section
         gh_username (str): GitHub username
         gh_repo (str): GitHub repository name
     """
@@ -80,12 +80,9 @@ class PipelineSync:
         self.made_changes = False
         self.make_pr = make_pr
         self.gh_pr_returned_data: dict = {}
-        self.required_config_vars = [
-            "name",
-            "description",
-            "version",
-            "contributors",
-        ]
+        self.required_config_vars: dict[str, list[str]] = {
+            "manifest": ["name", "description", "version", "contributors"],
+        }
         self.force_pr = force_pr
 
         self.gh_username = gh_username
@@ -231,9 +228,10 @@ class PipelineSync:
         self.wf_config = nf_core.utils.fetch_wf_config(Path(self.pipeline_dir))
 
         # Check that we have the required variables
-        for rvar in self.required_config_vars:
-            if rvar not in self.wf_config.get("manifest", {}):
-                raise SyncExceptionError(f"Workflow config variable `manifest.{rvar}` not found!")
+        for section, keys in self.required_config_vars.items():
+            for key in keys:
+                if key not in self.wf_config.get(section, {}):
+                    raise SyncExceptionError(f"Workflow config variable `{section}.{key}` not found!")
 
     def checkout_template_branch(self):
         """

--- a/nf_core/test_datasets/test_datasets_utils.py
+++ b/nf_core/test_datasets/test_datasets_utils.py
@@ -204,7 +204,7 @@ def get_or_prompt_branch(maybe_branch: str) -> tuple[str, list[str]]:
                 branch_prefill = MODULES_BRANCH_NAME
             elif repo_type == "pipeline":
                 wf_config = fetch_wf_config(base_dir)
-                pipeline_name = wf_config.get("manifest.name", "").split("/")[-1]
+                pipeline_name = wf_config.get("manifest", {}).get("name", "").split("/")[-1]
                 if pipeline_name in all_branches:
                     branch_prefill = pipeline_name
 

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -465,7 +465,7 @@ def fetch_wf_config(wf_path: Path, cache_config: bool = True) -> dict:
             for line in fh:
                 line_str = line.decode("utf-8")
                 match = re.match(r"^\s*params\.([a-zA-Z0-9_]+)\s*=(?!=)", line_str)
-                if match and match.group(1) not in params_section:
+                if match:
                     params_section[match.group(1)] = None
 
     except FileNotFoundError as e:

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -449,6 +449,8 @@ def fetch_wf_config(wf_path: Path, cache_config: bool = True) -> dict:
             raw_str = nfconfig_raw.decode("utf-8")
             json_start = raw_str.find("{")
             parsed = json.loads(raw_str[json_start:] if json_start >= 0 else raw_str)
+            if "params" in parsed:
+                parsed["params"] = {k: "null" if v is None else v for k, v in parsed["params"].items()}
             config.update(parsed)
             for k in parsed:
                 log.debug(f"Config section: {k}")

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -440,24 +440,21 @@ def fetch_wf_config(wf_path: Path, cache_config: bool = True) -> dict:
     log.debug("No config cache found")
 
     # Call `nextflow config`
-    result = run_cmd("nextflow", f"config -flat {wf_path}")
+    result = run_cmd("nextflow", f"config -flat -o json {wf_path}")
     if result is not None:
         nfconfig_raw, _ = result
-        nfconfig = nfconfig_raw.decode("utf-8")
-        multiline_key_value_pattern = re.compile(r"(^|\n)([^\n=\s]+?)\s*=\s*((?:(?!\n[^\n=]+?\s*=).)*)", re.DOTALL)
-
-        for config_match in multiline_key_value_pattern.finditer(nfconfig):
-            k = config_match.group(2).strip()
-            v = config_match.group(3).strip().strip("'\"")
-            if k and v == "":
-                config[k] = "null"
-                log.debug(f"Config key: {k}, value: empty string")
-            elif k and v:
-                config[k] = v
-                log.debug(f"Config key: {k}, value: {v}")
-            else:
-                log.debug(f"Couldn't find key=value config pair:\n  {config_match.group(0)}")
-            del config_match
+        try:
+            parsed = json.loads(nfconfig_raw.decode("utf-8"))
+            for k, v in parsed.items():
+                if v is None or v == "":
+                    config[k] = "null"
+                elif isinstance(v, bool):
+                    config[k] = str(v).lower()
+                else:
+                    config[k] = str(v)
+                log.debug(f"Config key: {k}, value: {config[k]}")
+        except json.JSONDecodeError as e:
+            log.warning(f"Unable to parse nextflow config output as JSON: {e}")
 
     # Scrape main.nf for additional parameter declarations
     # Values in this file are likely to be complex, so don't both trying to capture them. Just get the param name.

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -461,11 +461,12 @@ def fetch_wf_config(wf_path: Path, cache_config: bool = True) -> dict:
     main_nf = Path(wf_path, "main.nf")
     try:
         with open(main_nf, "rb") as fh:
+            params_section = config.setdefault("params", {})
             for line in fh:
                 line_str = line.decode("utf-8")
-                match = re.match(r"^\s*(params\.[a-zA-Z0-9_]+)\s*=(?!=)", line_str)
-                if match and match.group(1):
-                    config[match.group(1)] = "null"
+                match = re.match(r"^\s*params\.([a-zA-Z0-9_]+)\s*=(?!=)", line_str)
+                if match and match.group(1) not in params_section:
+                    params_section[match.group(1)] = None
 
     except FileNotFoundError as e:
         log.debug(f"Could not open {main_nf} to look for parameter declarations - {e}")

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -272,10 +272,11 @@ class Pipeline:
         Once loaded, set a few convenience reference class attributes
         """
         self.nf_config = fetch_wf_config(self.wf_path)
+        manifest = self.nf_config.get("manifest", {})
 
-        self.pipeline_prefix, self.pipeline_name = self.nf_config.get("manifest.name", "/").strip("'").split("/")
+        self.pipeline_prefix, self.pipeline_name = manifest.get("name", "/").split("/")
 
-        nextflow_version_match = re.search(r"[0-9\.]+(-edge)?", self.nf_config.get("manifest.nextflowVersion", ""))
+        nextflow_version_match = re.search(r"[0-9\.]+(-edge)?", manifest.get("nextflowVersion", "") or "")
         if nextflow_version_match:
             self.minNextflowVersion = nextflow_version_match.group(0)
             return True
@@ -396,7 +397,7 @@ def fetch_wf_config(wf_path: Path, cache_config: bool = True) -> dict:
 
     log.debug(f"Got '{wf_path}' as path")
     wf_path = Path(wf_path)
-    config = {}
+    config: dict[str, Any] = {}
     cache_fn = None
     cache_basedir = None
     cache_path = None
@@ -441,19 +442,14 @@ def fetch_wf_config(wf_path: Path, cache_config: bool = True) -> dict:
     log.debug("No config cache found")
 
     # Call `nextflow config`
-    result = run_cmd("nextflow", f"config -flat -o json {wf_path}")
+    result = run_cmd("nextflow", f"config -o json {wf_path}")
     if result is not None:
         nfconfig_raw, _ = result
         try:
             parsed = json.loads(nfconfig_raw.decode("utf-8"))
-            for k, v in parsed.items():
-                if v is None or v == "":
-                    config[k] = "null"
-                elif isinstance(v, bool):
-                    config[k] = str(v).lower()
-                else:
-                    config[k] = str(v)
-                log.debug(f"Config key: {k}, value: {config[k]}")
+            config.update(parsed)
+            for k in parsed:
+                log.debug(f"Config section: {k}")
         except json.JSONDecodeError as e:
             log.warning(f"Unable to parse nextflow config output as JSON: {e}")
 
@@ -1488,22 +1484,23 @@ def load_tools_config(directory: str | Path = ".") -> tuple[Path | None, NFCoreY
         template = tools_config.get("template")
         config_template_keys = template.keys() if template is not None else []
         # Get author names from contributors first, then fallback to author
-        if "manifest.contributors" in wf_config:
-            contributors = wf_config["manifest.contributors"]
-            names = re.findall(r"name:'([^']+)'", contributors)
+        manifest = wf_config.get("manifest", {})
+        contributors = manifest.get("contributors", [])
+        if contributors:
+            names = [c.get("name", "") for c in contributors if c.get("name")]
             author_names = ", ".join(names)
-        elif "manifest.author" in wf_config:
-            author_names = wf_config["manifest.author"].strip("'\"")
+        elif manifest.get("author"):
+            author_names = manifest.get("author", "")
         else:
             author_names = None
         if nf_core_yaml_config.template is None:
             # The .nf-core.yml file did not contain template information
             nf_core_yaml_config.template = NFCoreTemplateConfig(
                 org="nf-core",
-                name=wf_config["manifest.name"].strip("'\"").split("/")[-1],
-                description=wf_config["manifest.description"].strip("'\""),
+                name=manifest.get("name", "/").split("/")[-1],
+                description=manifest.get("description", ""),
                 author=author_names,
-                version=wf_config["manifest.version"].strip("'\""),
+                version=manifest.get("version", ""),
                 outdir=str(directory),
                 is_nfcore=True,
             )
@@ -1511,10 +1508,10 @@ def load_tools_config(directory: str | Path = ".") -> tuple[Path | None, NFCoreY
             # The .nf-core.yml file contained the old prefix or skip keys
             nf_core_yaml_config.template = NFCoreTemplateConfig(
                 org=tools_config["template"].get("prefix", tools_config["template"].get("org", "nf-core")),
-                name=tools_config["template"].get("name", wf_config["manifest.name"].strip("'\"").split("/")[-1]),
-                description=tools_config["template"].get("description", wf_config["manifest.description"].strip("'\"")),
+                name=tools_config["template"].get("name", manifest.get("name", "/").split("/")[-1]),
+                description=tools_config["template"].get("description", manifest.get("description", "")),
                 author=tools_config["template"].get("author", author_names),
-                version=tools_config["template"].get("version", wf_config["manifest.version"].strip("'\"")),
+                version=tools_config["template"].get("version", manifest.get("version", "")),
                 outdir=tools_config["template"].get("outdir", str(directory)),
                 skip_features=tools_config["template"].get("skip", tools_config["template"].get("skip_features")),
                 is_nfcore=tools_config["template"].get("prefix", tools_config["template"].get("org")) == "nf-core",

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -276,9 +276,9 @@ class Pipeline:
 
         self.pipeline_prefix, self.pipeline_name = manifest.get("name", "/").split("/")
 
-        nextflow_version_match = re.search(r"[0-9\.]+(-edge)?", manifest.get("nextflowVersion", "") or "")
+        nextflow_version_match = re.search(r"(?P<version>[0-9\.]+(-edge)?)", manifest.get("nextflowVersion", "") or "")
         if nextflow_version_match:
-            self.minNextflowVersion = nextflow_version_match.group(0)
+            self.minNextflowVersion = nextflow_version_match.group("version")
             return True
         return False
 

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -449,8 +449,6 @@ def fetch_wf_config(wf_path: Path, cache_config: bool = True) -> dict:
             raw_str = nfconfig_raw.decode("utf-8")
             json_start = raw_str.find("{")
             parsed = json.loads(raw_str[json_start:] if json_start >= 0 else raw_str)
-            if "params" in parsed:
-                parsed["params"] = {k: "null" if v is None else v for k, v in parsed["params"].items()}
             config.update(parsed)
             for k in parsed:
                 log.debug(f"Config section: {k}")

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 import git
+import git.exc
 import prompt_toolkit.styles
 import questionary
 import requests.auth
@@ -119,7 +120,7 @@ def unquote(s: str) -> str:
     Returns:
         String with outer quotes removed if present, otherwise original string
     """
-    import ruamel.yaml
+    import ruamel.yaml.scalarstring
 
     if isinstance(s, ruamel.yaml.scalarstring.DoubleQuotedScalarString):
         return s
@@ -458,8 +459,9 @@ def fetch_wf_config(wf_path: Path, cache_config: bool = True) -> dict:
 
     # Scrape main.nf for additional parameter declarations
     # Values in this file are likely to be complex, so don't both trying to capture them. Just get the param name.
+
+    main_nf = Path(wf_path, "main.nf")
     try:
-        main_nf = Path(wf_path, "main.nf")
         with open(main_nf, "rb") as fh:
             for line in fh:
                 line_str = line.decode("utf-8")
@@ -645,7 +647,7 @@ class GitHubAPISession(requests_cache.CachedSession):
         """
         log.debug("Initialising GitHub API requests session")
         cache_config = setup_requests_cachedir()
-        super().__init__(**cache_config)
+        super().__init__(**cache_config)  # type: ignore[arg-type]
         self.setup_github_auth()
         self.has_init = True
 
@@ -734,13 +736,13 @@ class GitHubAPISession(requests_cache.CachedSession):
 
         return request
 
-    def get(self, url, **kwargs):
+    def get(self, url, params=None, **kwargs):
         """
         Initialise the session if we haven't already, then call the superclass get method.
         """
         if not self.has_init:
             self.lazy_init()
-        return super().get(url, **kwargs)
+        return super().get(url, params=params, **kwargs)
 
     def request_retry(self, url, post_data=None):
         """
@@ -1124,17 +1126,12 @@ class SingularityCacheFilePathValidator(questionary.Validator):
     Validator for file path specified as --singularity-cache-index argument in nf-core pipelines download
     """
 
-    def validate(self, value):
-        if len(value.text):
-            if Path(value.text).is_file():
-                return True
-            else:
-                raise questionary.ValidationError(
-                    message="Invalid remote cache index file",
-                    cursor_position=len(value.text),
-                )
-        else:
-            return True
+    def validate(self, document) -> None:
+        if len(document.text) and not Path(document.text).is_file():
+            raise questionary.ValidationError(
+                message="Invalid remote cache index file",
+                cursor_position=len(document.text),
+            )
 
 
 def get_repo_releases_branches(pipeline, wfs):

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -446,7 +446,9 @@ def fetch_wf_config(wf_path: Path, cache_config: bool = True) -> dict:
     if result is not None:
         nfconfig_raw, _ = result
         try:
-            parsed = json.loads(nfconfig_raw.decode("utf-8"))
+            raw_str = nfconfig_raw.decode("utf-8")
+            json_start = raw_str.find("{")
+            parsed = json.loads(raw_str[json_start:] if json_start >= 0 else raw_str)
             config.update(parsed)
             for k in parsed:
                 log.debug(f"Config section: {k}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,8 @@ dev = [
     "types-setuptools",
     "typing_extensions>=4.0.0",
     "pytest-asyncio",
+    "pytest-clarity>=1.0.1",
+    "pytest-sugar>=1.1.1",
     "pytest-textual-snapshot==1.1.0",
     "pytest-workflow>=2.0.0",
     "pytest-xdist>=3.7.0",

--- a/tests/pipelines/download/test_download.py
+++ b/tests/pipelines/download/test_download.py
@@ -241,7 +241,7 @@ class DownloadTest(unittest.TestCase):
             # Test the function
             download_obj.wf_use_local_configs("workflow")
             wf_config = nf_core.utils.fetch_wf_config(Path(test_outdir, "workflow"), cache_config=False)
-            assert wf_config["params.custom_config_base"] == f"{test_outdir}/workflow/../configs/"
+            assert wf_config["params"]["custom_config_base"] == f"{test_outdir}/workflow/../configs/"
 
     #
     # Test that `find_container_images` (uses `nextflow inspect`) fetches the correct Docker images

--- a/tests/pipelines/download/test_singularity.py
+++ b/tests/pipelines/download/test_singularity.py
@@ -456,11 +456,11 @@ class SingularityTest(unittest.TestCase):
             container_cache_index=None,
         )
         mock_fetch_wf_config.return_value = {
-            "apptainer.registry": "apptainer-registry.io",
-            "docker.registry": "docker.io",
-            "podman.registry": "podman-registry.io",
-            "singularity.registry": "singularity-registry.io",
-            "someother.registry": "fake-registry.io",
+            "apptainer": {"registry": "apptainer-registry.io"},
+            "docker": {"registry": "docker.io"},
+            "podman": {"registry": "podman-registry.io"},
+            "singularity": {"registry": "singularity-registry.io"},
+            "someother": {"registry": "fake-registry.io"},
         }
         singularity_fetcher.registry_set = singularity_fetcher.gather_registries(tmp_path)
         assert singularity_fetcher.registry_set

--- a/tests/pipelines/lint/test_files_exist.py
+++ b/tests/pipelines/lint/test_files_exist.py
@@ -19,7 +19,7 @@ class TestLintFilesExist(TestLint):
         Path(self.new_pipeline, "CHANGELOG.md").unlink()
 
         assert self.lint_obj._load()
-        self.lint_obj.nf_config["manifest.name"] = "nf-core/testpipeline"
+        self.lint_obj.nf_config["manifest"]["name"] = "nf-core/testpipeline"
 
         results = self.lint_obj.files_exist()
         assert "File not found: `CHANGELOG.md`" in results["failed"]
@@ -61,7 +61,7 @@ class TestLintFilesExist(TestLint):
             f.write(config)
 
         assert self.lint_obj._load()
-        self.lint_obj.nf_config["manifest.schema"] = "nf-core"
+        self.lint_obj.nf_config["manifest"]["schema"] = "nf-core"
         results = self.lint_obj.files_exist()
         assert results["failed"] == []
         assert results["ignored"] == []

--- a/tests/pipelines/lint/test_multiqc_config.py
+++ b/tests/pipelines/lint/test_multiqc_config.py
@@ -104,7 +104,7 @@ class TestLintMultiqcConfig(TestLint):
         lint_obj = nf_core.pipelines.lint.PipelineLint(self.new_pipeline)
         lint_obj._load()
         # bump version
-        lint_obj.nf_config["manifest.version"] = "1.0"
+        lint_obj.nf_config["manifest"]["version"] = "1.0"
         result = lint_obj.multiqc_config()
         # Reset the file
         with open(self.multiqc_config_yml, "w") as fh:

--- a/tests/pipelines/lint/test_nextflow_config.py
+++ b/tests/pipelines/lint/test_nextflow_config.py
@@ -34,7 +34,7 @@ class TestLintNextflowConfig(TestLint):
         lint_obj = nf_core.pipelines.lint.PipelineLint(self.new_pipeline)
         lint_obj.load_pipeline_config()
 
-        lint_obj.nf_config["manifest.name"] = "bad_name"
+        lint_obj.nf_config["manifest"]["name"] = "bad_name"
         result = lint_obj.nextflow_config()
         assert len(result["failed"]) > 0
         assert len(result["warned"]) == 0
@@ -45,7 +45,7 @@ class TestLintNextflowConfig(TestLint):
         lint_obj.load_pipeline_config()
 
         lint_obj.release_mode = True
-        lint_obj.nf_config["manifest.version"] = "dev_is_bad_name"
+        lint_obj.nf_config["manifest"]["version"] = "dev_is_bad_name"
         result = lint_obj.nextflow_config()
         assert len(result["failed"]) > 0
         assert len(result["warned"]) == 0

--- a/tests/pipelines/lint/test_nextflow_config.py
+++ b/tests/pipelines/lint/test_nextflow_config.py
@@ -106,8 +106,12 @@ class TestLintNextflowConfig(TestLint):
         result = lint_obj.nextflow_config()
         assert len(result["failed"]) == 2
         assert (
+            result["failed"][0]
+            == "Config `params.custom_config_base` is not set to `https://raw.githubusercontent.com/nf-core/configs/master`"
+        )
+        assert (
             result["failed"][1]
-            == "Config default value incorrect: `params.custom_config_base` is set as `https://raw.githubusercontent.com/nf-core/configs/master` in `nextflow_schema.json` but is `null` in `nextflow.config`."
+            == "Default value from the Nextflow schema `params.custom_config_base = `https://raw.githubusercontent.com/nf-core/configs/master`` not found in `nextflow.config`."
         )
 
     def test_allow_params_reference_in_main_nf(self):

--- a/tests/pipelines/lint/test_version_consistency.py
+++ b/tests/pipelines/lint/test_version_consistency.py
@@ -35,7 +35,7 @@ class TestLintVersionConsistency(TestLint):
         lint_obj.load_pipeline_config()
         lint_obj.nextflow_config()
         # Set the version for the container
-        lint_obj.nf_config["process.container"] = "nfcore/pipeline:1.0.0"
+        lint_obj.nf_config["process"]["container"] = "nfcore/pipeline:1.0.0"
         result = lint_obj.version_consistency()
         assert result["passed"] == [
             "Version tags are consistent: manifest.version = 1.0.0, process.container = 1.0.0, nfcore_yml.version = 1.0.0",
@@ -73,7 +73,7 @@ class TestLintVersionConsistency(TestLint):
         lint_obj.load_pipeline_config()
         lint_obj.nextflow_config()
 
-        lint_obj.nf_config["process.container"] = "nfcore/pipeline:0.1"
+        lint_obj.nf_config["process"]["container"] = "nfcore/pipeline:0.1"
         result = lint_obj.version_consistency()
         assert len(result["passed"]) == 0
         assert result["failed"] == [

--- a/tests/pipelines/test_bump_version.py
+++ b/tests/pipelines/test_bump_version.py
@@ -24,7 +24,7 @@ class TestBumpVersion(TestPipelines):
 
         # Check nextflow.config
         new_pipeline_obj.load_pipeline_config()
-        assert new_pipeline_obj.nf_config["manifest.version"].strip("'\"") == "1.1.0"
+        assert new_pipeline_obj.nf_config["manifest"]["version"].strip("'\"") == "1.1.0"
 
         # Check multiqc_config.yml
         with open(new_pipeline_obj._fp("assets/multiqc_config.yml")) as fh:
@@ -47,7 +47,7 @@ class TestBumpVersion(TestPipelines):
 
         # Check the pipeline config
         new_pipeline_obj.load_pipeline_config()
-        assert new_pipeline_obj.nf_config["manifest.version"].strip("'\"") == "1.2dev"
+        assert new_pipeline_obj.nf_config["manifest"]["version"].strip("'\"") == "1.2dev"
 
     def test_bump_nextflow_version(self):
         # Bump the version number to a specific version, preferably one
@@ -58,7 +58,7 @@ class TestBumpVersion(TestPipelines):
         new_pipeline_obj._load()
 
         # Check nextflow.config
-        assert new_pipeline_obj.nf_config["manifest.nextflowVersion"].strip("'\"") == f"!>={version}"
+        assert new_pipeline_obj.nf_config["manifest"]["nextflowVersion"].strip("'\"") == f"!>={version}"
 
         # Check .github/workflows/nf-test.yml
         with open(new_pipeline_obj._fp(".github/workflows/nf-test.yml")) as fh:

--- a/tests/pipelines/test_rocrate.py
+++ b/tests/pipelines/test_rocrate.py
@@ -278,7 +278,7 @@ class TestROCrate(TestPipelines):
 
         # Set nf_config directly to avoid running nextflow config -flat on invalid Groovy syntax
         # (unquoted `alice` is valid Groovy but references an undefined variable, causing nextflow to fail)
-        self.rocrate_obj.pipeline_obj.nf_config["manifest.contributors"] = (
+        self.rocrate_obj.pipeline_obj.nf_config["manifest"]["contributors"] = (
             "[[\n    name: 'Alice Example',\n    github: alice\n]]"
         )
 

--- a/tests/pipelines/test_sync.py
+++ b/tests/pipelines/test_sync.py
@@ -148,7 +148,7 @@ class TestModules(TestPipelines):
             psync.inspect_sync_dir()
             psync.get_wf_config()
         # Check that we did actually get some config back
-        assert psync.wf_config["params.validate_params"] == "true"
+        assert psync.wf_config["params"]["validate_params"] == "true"
         # Check that we raised because of the missing fake config var
         assert exc_info.value.args[0] == "Workflow config variable `fakethisdoesnotexist` not found!"
 

--- a/tests/pipelines/test_sync.py
+++ b/tests/pipelines/test_sync.py
@@ -148,7 +148,7 @@ class TestModules(TestPipelines):
             psync.inspect_sync_dir()
             psync.get_wf_config()
         # Check that we did actually get some config back
-        assert psync.wf_config["params"]["validate_params"] == "true"
+        assert psync.wf_config["params"]["validate_params"] is True
         # Check that we raised because of the missing fake config var
         assert exc_info.value.args[0] == "Workflow config variable `fakethisdoesnotexist` not found!"
 

--- a/tests/pipelines/test_sync.py
+++ b/tests/pipelines/test_sync.py
@@ -143,14 +143,14 @@ class TestModules(TestPipelines):
         """Try getting a workflow config, then make it miss a required config option"""
         # Try to sync, check we halt with the right error
         psync = nf_core.pipelines.sync.PipelineSync(self.pipeline_dir)
-        psync.required_config_vars = ["fakethisdoesnotexist"]
+        psync.required_config_vars = {"fakesection": ["fakethisdoesnotexist"]}
         with pytest.raises(nf_core.pipelines.sync.SyncExceptionError) as exc_info:
             psync.inspect_sync_dir()
             psync.get_wf_config()
         # Check that we did actually get some config back
         assert psync.wf_config["params"]["validate_params"] is True
         # Check that we raised because of the missing fake config var
-        assert exc_info.value.args[0] == "Workflow config variable `fakethisdoesnotexist` not found!"
+        assert exc_info.value.args[0] == "Workflow config variable `fakesection.fakethisdoesnotexist` not found!"
 
     def test_checkout_template_branch(self):
         """Try checking out the TEMPLATE branch of the pipeline"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -104,7 +104,7 @@ class TestUtils(TestPipelines):
     def testload_pipeline_config(self):
         """Load the pipeline Nextflow config"""
         self.pipeline_obj.load_pipeline_config()
-        assert self.pipeline_obj.nf_config["dag.enabled"] == "true"
+        assert self.pipeline_obj.nf_config["dag"]["enabled"] == "true"
 
     # TODO nf-core: Assess and strip out if no longer required for DSL2
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -249,10 +249,10 @@ class TestUtils(TestPipelines):
     @mock.patch("nf_core.utils.run_cmd")
     def test_fetch_wf_config(self, mock_run_cmd):
         """Test the fetch_wf_config() regular expression to read config params."""
-        mock_run_cmd.return_value = (b"params.param1 ? 'a=b' : ''\nparams.param2 = foo", b"mock")
-        config = nf_core.utils.fetch_wf_config(".", False)
-        assert len(config.keys()) == 1
-        assert "params.param2" in list(config.keys())
+        mock_run_cmd.return_value = (b'{"params": {"param2": "foo"}}', b"mock")
+        config = nf_core.utils.fetch_wf_config(Path(), False)
+        assert "params" in config
+        assert config["params"].get("param2") == "foo"
 
     @with_temporary_folder
     def test_get_wf_files(self, tmpdir):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -104,7 +104,7 @@ class TestUtils(TestPipelines):
     def testload_pipeline_config(self):
         """Load the pipeline Nextflow config"""
         self.pipeline_obj.load_pipeline_config()
-        assert self.pipeline_obj.nf_config["dag"]["enabled"] == "true"
+        assert self.pipeline_obj.nf_config["dag"]["enabled"] is True
 
     # TODO nf-core: Assess and strip out if no longer required for DSL2
 

--- a/uv.lock
+++ b/uv.lock
@@ -1654,8 +1654,10 @@ dev = [
     { name = "myst-parser", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-clarity" },
     { name = "pytest-cov" },
     { name = "pytest-datafiles" },
+    { name = "pytest-sugar" },
     { name = "pytest-textual-snapshot" },
     { name = "pytest-workflow" },
     { name = "pytest-xdist" },
@@ -1693,8 +1695,10 @@ requires-dist = [
     { name = "pygithub" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
+    { name = "pytest-clarity", marker = "extra == 'dev'", specifier = ">=1.0.1" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "pytest-datafiles", marker = "extra == 'dev'" },
+    { name = "pytest-sugar", marker = "extra == 'dev'", specifier = ">=1.1.1" },
     { name = "pytest-textual-snapshot", marker = "extra == 'dev'", specifier = "==1.1.0" },
     { name = "pytest-workflow", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.7.0" },
@@ -2154,6 +2158,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pprintpp"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/1a/7737e7a0774da3c3824d654993cf57adc915cb04660212f03406334d8c0b/pprintpp-0.4.0.tar.gz", hash = "sha256:ea826108e2c7f49dc6d66c752973c3fc9749142a798d6b254e1e301cfdbc6403", size = 17995, upload-time = "2018-07-01T01:42:34.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/d1/e4ed95fdd3ef13b78630280d9e9e240aeb65cc7c544ec57106149c3942fb/pprintpp-0.4.0-py2.py3-none-any.whl", hash = "sha256:b6b4dcdd0c0c0d75e4d7b2f21a9e933e5b2ce62b26e1a54537f9651ae5a5c01d", size = 16952, upload-time = "2018-07-01T01:42:36.496Z" },
+]
+
+[[package]]
 name = "prek"
 version = "0.3.13"
 source = { registry = "https://pypi.org/simple" }
@@ -2602,6 +2615,17 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-clarity"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pprintpp" },
+    { name = "pytest" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/5c/cafa97944de55738a6a2c5a7cee00d073cb80495032d2b112c4546525eca/pytest-clarity-1.0.1.tar.gz", hash = "sha256:505fe345fad4fe11c6a4187fe683f2c7c52c077caa1e135f3e483fe112db7772", size = 4891, upload-time = "2021-06-11T18:16:18.372Z" }
+
+[[package]]
 name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2625,6 +2649,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fc/8d/081ba12c1ea4eb1b899eb61b4501136c233492280fdb70343edcdfdf26ce/pytest_datafiles-3.0.1.tar.gz", hash = "sha256:05fc3eef2429fe26ae42283cccb1f3831b53b12d4bd8b4734bf42973d4af6e16", size = 222220, upload-time = "2026-01-04T15:08:23.287Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/23/88880d5dc36eac9696ad40823e37c1fdbfa81a67b9cfd0ed445b3ed7ec54/pytest_datafiles-3.0.1-py3-none-any.whl", hash = "sha256:c48f27a8afec03a482a10587ab5f5ab930ced4cbdeb2e3a2cbcc0323a51d22c7", size = 6357, upload-time = "2026-01-04T15:08:25.132Z" },
+]
+
+[[package]]
+name = "pytest-sugar"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "termcolor" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/4e/60fed105549297ba1a700e1ea7b828044842ea27d72c898990510b79b0e2/pytest-sugar-1.1.1.tar.gz", hash = "sha256:73b8b65163ebf10f9f671efab9eed3d56f20d2ca68bda83fa64740a92c08f65d", size = 16533, upload-time = "2025-08-23T12:19:35.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/d5/81d38a91c1fdafb6711f053f5a9b92ff788013b19821257c2c38c1e132df/pytest_sugar-1.1.1-py3-none-any.whl", hash = "sha256:2f8319b907548d5b9d03a171515c1d43d2e38e32bd8182a1781eb20b43344cc8", size = 11440, upload-time = "2025-08-23T12:19:34.894Z" },
 ]
 
 [[package]]
@@ -3332,6 +3369,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
+name = "termcolor"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
With the newer default nextflow version, we can specify json as an output format for `nextflow inspect` making our awkward manual parsing obsolote. This switches the parsed object from the previous flat hierarchy to a more nested one, e.g. `nf_config['manifest.name']` -> `nf_config['manifest']['name']`

Closes #4204 and https://github.com/nf-core/tools/issues/4289