### PR TITLE
feat(modules/lint): warn on unpinned pip deps in environment.yml

### DIFF
--- a/nf_core/modules/lint/environment_yml.py
+++ b/nf_core/modules/lint/environment_yml.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import ruamel.yaml
 from jsonschema import exceptions, validators
+from packaging.requirements import InvalidRequirement, Requirement
 
 from nf_core.components.lint import ComponentLint, LintExceptionError
 from nf_core.components.nfcore_component import NFCoreComponent
@@ -34,6 +35,11 @@ def environment_yml(module_lint_object: ComponentLint, module: NFCoreComponent, 
     * ``environment_yml_sorted``: The dependencies listed in ``environment.yml``
       must be sorted alphabetically. If they are not, they will be sorted
       automatically.
+
+    * ``environment_yml_pip_pinned``: If a ``pip:`` block is present, every entry
+      must be pinned with ``==`` (e.g. ``pkg==1.2.3``) or installed from a pinned
+      URL/VCS reference (``pkg @ url``). Range specifiers like ``>=`` and ``~=``
+      are not treated as pinned.
     """
     env_yml = None
     has_schema_header = False
@@ -229,3 +235,67 @@ def environment_yml(module_lint_object: ComponentLint, module: NFCoreComponent, 
                         module.environment_yml,
                     )
                 )
+
+            # Check that any pip dependencies are pinned to a version
+            if "dependencies" in env_yml:
+                has_pip_block, unpinned_pip = _find_unpinned_pip_deps(env_yml["dependencies"])
+                if has_pip_block:
+                    if unpinned_pip:
+                        module.warned.append(
+                            (
+                                "environment_yml",
+                                "environment_yml_pip_pinned",
+                                (
+                                    f"Module's `environment.yml` has unpinned pip "
+                                    f"dependencies: {', '.join(unpinned_pip)}. Pin each "
+                                    f"entry with `==` (e.g. `pkg==1.2.3`) or a URL/VCS "
+                                    f"reference."
+                                ),
+                                module.environment_yml,
+                            )
+                        )
+                    else:
+                        module.passed.append(
+                            (
+                                "environment_yml",
+                                "environment_yml_pip_pinned",
+                                "All pip dependencies in the module's `environment.yml` are pinned",
+                                module.environment_yml,
+                            )
+                        )
+
+
+def _find_unpinned_pip_deps(dependencies):
+    """Return ``(has_pip_block, unpinned)`` for the dependencies list of an environment.yml.
+
+    A pip entry counts as pinned when it has a single ``==`` (or ``===``)
+    specifier, or installs from a URL/VCS reference. Range operators
+    (``>=``, ``~=``, ``<``, ...) and compound specifiers are flagged as
+    unpinned. Entries that fail to parse as PEP 508 (e.g. ``-r
+    requirements.txt``) are skipped, leaving stricter checks to the
+    conda/pip schema.
+    """
+    has_pip_block = False
+    unpinned = []
+    for term in dependencies:
+        if not isinstance(term, dict):
+            continue
+        pip_entries = term.get("pip")
+        if not isinstance(pip_entries, list):
+            continue
+        has_pip_block = True
+        for entry in pip_entries:
+            entry = str(entry).strip()
+            if not entry:
+                continue
+            try:
+                req = Requirement(entry)
+            except InvalidRequirement:
+                continue
+            if req.url:
+                continue
+            specs = list(req.specifier)
+            if len(specs) == 1 and specs[0].operator in ("==", "==="):
+                continue
+            unpinned.append(entry)
+    return has_pip_block, unpinned

--- a/tests/modules/lint/test_environment_yml.py
+++ b/tests/modules/lint/test_environment_yml.py
@@ -183,6 +183,106 @@ def test_environment_yml_invalid_files(tmp_path, invalid_content, filename):
         environment_yml(lint, module)
 
 
+@pytest.mark.parametrize(
+    "input_content,expected_status,expected_unpinned",
+    [
+        # All pip deps pinned with == → passes
+        (
+            """
+            dependencies:
+                - python=3.12
+                - pip:
+                    - foo==1.2.3
+                    - bar==4.5.6
+            """,
+            "passed",
+            [],
+        ),
+        # Range specifiers (~=, >=, compound) are NOT considered pinned
+        (
+            """
+            dependencies:
+                - pip:
+                    - foo==1.2.3
+                    - bar~=2.0
+                    - baz>=1.0,<2.0
+            """,
+            "warned",
+            ["bar~=2.0", "baz>=1.0,<2.0"],
+        ),
+        # URL / VCS form is treated as pinned
+        (
+            """
+            dependencies:
+                - pip:
+                    - foo @ git+https://github.com/x/foo@v1.2.3
+            """,
+            "passed",
+            [],
+        ),
+        # All unpinned → warned, all entries reported
+        (
+            """
+            dependencies:
+                - pip:
+                    - foo
+                    - bar
+            """,
+            "warned",
+            ["foo", "bar"],
+        ),
+        # Mix → warned, only unpinned entries reported
+        (
+            """
+            dependencies:
+                - python=3.12
+                - pip:
+                    - foo==1.2.3
+                    - bar
+            """,
+            "warned",
+            ["bar"],
+        ),
+        # Empty pip block → passes (no entries to flag)
+        (
+            """
+            dependencies:
+                - python=3.12
+                - pip: []
+            """,
+            "passed",
+            [],
+        ),
+    ],
+)
+def test_environment_yml_pip_pinned(tmp_path, input_content, expected_status, expected_unpinned):
+    """Test the pip-pinned check on environment.yml with a pip block."""
+    test_file, module, lint = setup_test_environment(tmp_path, input_content)
+
+    environment_yml(lint, module)
+
+    bucket = getattr(module, expected_status)
+    pip_pinned = [entry for entry in bucket if entry[1] == "environment_yml_pip_pinned"]
+    assert len(pip_pinned) == 1, f"Expected one pip_pinned {expected_status} entry, got {bucket}"
+    for unpinned in expected_unpinned:
+        assert unpinned in pip_pinned[0][2]
+
+
+def test_environment_yml_pip_pinned_skipped_when_no_pip_block(tmp_path):
+    """Without a pip: block, the pip-pinned check should not appear at all."""
+    content = """
+    dependencies:
+        - python=3.12
+        - bioconda::samtools=1.21
+    """
+    test_file, module, lint = setup_test_environment(tmp_path, content)
+
+    environment_yml(lint, module)
+
+    all_checks = module.passed + module.failed + module.warned
+    assert not any(entry[1] == "environment_yml_pip_pinned" for entry in all_checks)
+
+
 def test_environment_yml_missing_dependencies(tmp_path):
     """Test handling of environment.yml without dependencies section"""
     content = "channels:\n  - conda-forge\n"


### PR DESCRIPTION
Hi, I'm a software engineer learning bioinformatics through contributions to open-source tooling. Issue #4131 mentions a lint for pinned pip dependencies in module `environment.yml`, so I took a shot at it. The issue was otherwise rather short, so if this isn't what was meant I'm happy to change direction.

Closes #4131. Adds `environment_yml_pip_pinned` to the module env-yml linter: when a `pip:` block is present, every entry must be pinned with `==` (e.g. `pkg==1.2.3`) or use a URL/VCS reference (`pkg @ url`). Plain `- pkg`, range specifiers (`>=`, `<`, compound), and compatible-release (`~=`) all flag.

## Implementation notes

Detection uses `packaging.requirements.Requirement` (already a project dependency), which handles extras, environment markers, and URL form. An entry counts as unpinned when `req.specifier` is empty and `req.url` is absent. Pip's requirements.txt allows things outside PEP 508 (`-r requirements.txt`, local paths, bare URLs); these are skipped, since "is this pinned?" isn't well-defined for them.

## Severity and strictness

I went with `module.warned` rather than `module.failed`, since "you should pin your dependencies" is an opinion-grade rule and flipping the lint from green to red felt aggressive for a drive-by. Happy to flip to `module.failed` if you'd rather have it enforced. As context, I surveyed nf-core/modules: 33 of 1734 modules have a `pip:` block (70 entries total) and **all 70 are pinned with `==`**, so the blast radius for either severity is currently zero.

For "pinned" the lint accepts only `==` (and `===`) plus URL/VCS form. `~=` (PEP 440 compatible-release, e.g. `~=1.4.2` ⇒ `>=1.4.2, ==1.4.*`) is **not** treated as pinned: it caps the upper end automatically but still lets pip pick the highest matching patch at install time, so it's a range, not a pin. That's a defensible call but a judgment call; happy to admit `~=` if you'd consider compatible-release pinning enough.

## Tests

Unit tests in `tests/modules/lint/test_environment_yml.py` cover: all-pinned with `==`, range/compound specifiers (flagged), URL/VCS form (accepted), all-unpinned, mixed pinned+unpinned (only unpinned entries appear in the message), empty pip block, and a no-pip-block module (the check should not appear at all). Full `tests/modules/lint` suite is green: 125 passed, 3 skipped, 0 failed (baseline on `dev`: 118 passed).

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] If you've fixed a bug or added code that should be tested, add tests!

(`CHANGELOG.md` left to nf-core-bot per CONTRIBUTING; no separate `docs/` page touched, the lint check has a docstring that the existing autodoc picks up.)

