### PR TITLE
perf(components): regenerate container configs once per top-level install/update

### DIFF
--- a/nf_core/components/install.py
+++ b/nf_core/components/install.py
@@ -169,10 +169,8 @@ class ComponentInstall(ComponentCommand):
             # Install included modules and subworkflows
             self.install_included_components(component_dir)
 
-        # Regenerate container configuration files for the pipeline once per
-        # top-level install. Recursive installs of dependent modules pass
-        # silent=True and would otherwise re-run `nextflow inspect` for every
-        # transitive dependency.
+        # Regenerate container configs once per top-level invocation
+        # (recursive installs pass silent=True).
         if not silent:
             if self.component_type == "modules":
                 try_generate_container_configs(self.directory, component_dir, component)

--- a/nf_core/components/install.py
+++ b/nf_core/components/install.py
@@ -169,9 +169,15 @@ class ComponentInstall(ComponentCommand):
             # Install included modules and subworkflows
             self.install_included_components(component_dir)
 
-        # Regenerate container configuration files for the pipeline when modules are installed
-        if self.component_type == "modules":
-            try_generate_container_configs(self.directory, component_dir, component)
+        # Regenerate container configuration files for the pipeline once per
+        # top-level install. Recursive installs of dependent modules pass
+        # silent=True and would otherwise re-run `nextflow inspect` for every
+        # transitive dependency.
+        if not silent:
+            if self.component_type == "modules":
+                try_generate_container_configs(self.directory, component_dir, component)
+            else:
+                try_generate_container_configs(self.directory)
 
         if not silent:
             modules_json.load()

--- a/nf_core/components/update.py
+++ b/nf_core/components/update.py
@@ -353,9 +353,8 @@ class ComponentUpdate(ComponentCommand):
             self.modules_json.load()
             self.modules_json.dump(run_prettier=True)
 
-        # Regenerate container configuration files for the pipeline once per
-        # top-level update. The previous in-loop call ran `nextflow inspect`
-        # for every transitive linked component, which dominated wall time.
+        # Regenerate container configs once per top-level invocation
+        # (recursive updates pass silent=True; skip in --save-diff dry runs).
         if not silent and updated and not self.save_diff_fn:
             try_generate_container_configs(self.directory)
 

--- a/nf_core/components/update.py
+++ b/nf_core/components/update.py
@@ -309,9 +309,6 @@ class ComponentUpdate(ComponentCommand):
                 self.modules_json.update(self.component_type, modules_repo, component, version, installed_by=None)
                 updated.append(component)
 
-                # Regenerate container configuration files for the pipeline when modules are updated
-                if self.component_type == "modules":
-                    try_generate_container_configs(self.directory)
                 recursive_update = True
                 modules_to_update, subworkflows_to_update = self.get_components_to_update(component)
                 if not silent and len(modules_to_update + subworkflows_to_update) > 0 and not self.update_all:
@@ -355,6 +352,12 @@ class ComponentUpdate(ComponentCommand):
             log.info("Updates complete :sparkles:")
             self.modules_json.load()
             self.modules_json.dump(run_prettier=True)
+
+        # Regenerate container configuration files for the pipeline once per
+        # top-level update. The previous in-loop call ran `nextflow inspect`
+        # for every transitive linked component, which dominated wall time.
+        if not silent and updated and not self.save_diff_fn:
+            try_generate_container_configs(self.directory)
 
         return exit_value
 

--- a/tests/modules/test_install.py
+++ b/tests/modules/test_install.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -43,6 +44,12 @@ class TestModulesCreate(TestModules):
         """Test installing a module - TrimGalore! already there"""
         self.mods_install.install("trimgalore")
         assert self.mods_install.install("trimgalore") is True
+
+    @mock.patch("nf_core.components.install.try_generate_container_configs")
+    def test_modules_install_regenerates_container_configs_once(self, mock_gen):
+        """Container config regen runs exactly once for a top-level module install."""
+        assert self.mods_install.install("trimgalore") is not False
+        assert mock_gen.call_count == 1
 
     def test_modules_install_from_gitlab(self):
         """Test installing a module from GitLab"""

--- a/tests/subworkflows/test_install.py
+++ b/tests/subworkflows/test_install.py
@@ -194,15 +194,9 @@ class TestSubworkflowsInstall(TestSubworkflows):
 
     @mock.patch("nf_core.components.install.try_generate_container_configs")
     def test_subworkflows_install_regenerates_container_configs_once(self, mock_gen):
-        """Container config regeneration runs once for a top-level subworkflow install,
-        not once per transitive module dependency. ``bam_sort_stats_samtools`` pulls
-        in five samtools modules plus the ``bam_stats_samtools`` sub-subworkflow, so
-        the previous per-component behaviour would have called this many times."""
+        """Container config regen runs once for a top-level subworkflow install with module deps."""
         assert self.subworkflow_install.install("bam_sort_stats_samtools") is not False
-        assert mock_gen.call_count == 1, (
-            f"Expected try_generate_container_configs to run once per top-level "
-            f"install, got {mock_gen.call_count} calls"
-        )
+        assert mock_gen.call_count == 1
 
     def test_subworkflows_install_alternate_remote(self):
         """Test installing a module from a different remote with the same organization path"""

--- a/tests/subworkflows/test_install.py
+++ b/tests/subworkflows/test_install.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -190,6 +191,18 @@ class TestSubworkflowsInstall(TestSubworkflows):
                 "bam_stats_samtools"
             ]["installed_by"]
         ) == sorted(["subworkflows", "bam_sort_stats_samtools"])
+
+    @mock.patch("nf_core.components.install.try_generate_container_configs")
+    def test_subworkflows_install_regenerates_container_configs_once(self, mock_gen):
+        """Container config regeneration runs once for a top-level subworkflow install,
+        not once per transitive module dependency. ``bam_sort_stats_samtools`` pulls
+        in five samtools modules plus the ``bam_stats_samtools`` sub-subworkflow, so
+        the previous per-component behaviour would have called this many times."""
+        assert self.subworkflow_install.install("bam_sort_stats_samtools") is not False
+        assert mock_gen.call_count == 1, (
+            f"Expected try_generate_container_configs to run once per top-level "
+            f"install, got {mock_gen.call_count} calls"
+        )
 
     def test_subworkflows_install_alternate_remote(self):
         """Test installing a module from a different remote with the same organization path"""

--- a/tests/subworkflows/test_update.py
+++ b/tests/subworkflows/test_update.py
@@ -34,17 +34,22 @@ class TestSubworkflowsUpdate(TestSubworkflows):
 
     @mock.patch("nf_core.components.update.try_generate_container_configs")
     def test_subworkflow_update_regenerates_container_configs_once(self, mock_gen):
-        """Container config regeneration runs once for a top-level update, not once
-        per linked component. Updating ``fastq_align_bowtie2`` from an old SHA with
-        ``--update-deps`` cascades to several samtools modules; before this fix that
-        triggered ``nextflow inspect`` per dependency."""
+        """Container config regen runs once for a top-level update, not per linked component."""
         assert self.subworkflow_install_old.install("fastq_align_bowtie2")
         mock_gen.reset_mock()
         update_obj = SubworkflowUpdate(self.pipeline_dir, show_diff=False, update_deps=True)
         assert update_obj.update("fastq_align_bowtie2") is True
-        assert mock_gen.call_count == 1, (
-            f"Expected try_generate_container_configs to run once per top-level update, got {mock_gen.call_count} calls"
-        )
+        assert mock_gen.call_count == 1
+
+    @mock.patch("nf_core.components.update.try_generate_container_configs")
+    def test_subworkflow_update_save_diff_skips_container_configs(self, mock_gen):
+        """``--save-diff`` is a dry run; container configs must not be regenerated."""
+        assert self.subworkflow_install_old.install("fastq_align_bowtie2")
+        mock_gen.reset_mock()
+        patch_path = Path(self.pipeline_dir, "fastq_align_bowtie2.patch")
+        update_obj = SubworkflowUpdate(self.pipeline_dir, save_diff_fn=patch_path, update_deps=True)
+        assert update_obj.update("fastq_align_bowtie2") is True
+        assert mock_gen.call_count == 0
 
     def test_install_at_hash_and_update(self):
         """Installs an old version of a subworkflow in the pipeline and updates it"""

--- a/tests/subworkflows/test_update.py
+++ b/tests/subworkflows/test_update.py
@@ -32,6 +32,21 @@ class TestSubworkflowsUpdate(TestSubworkflows):
         assert update_obj.update("bam_stats_samtools") is True
         assert cmp_component(tmpdir, sw_path) is True
 
+    @mock.patch("nf_core.components.update.try_generate_container_configs")
+    def test_subworkflow_update_regenerates_container_configs_once(self, mock_gen):
+        """Container config regeneration runs once for a top-level update, not once
+        per linked component. Updating ``fastq_align_bowtie2`` from an old SHA with
+        ``--update-deps`` cascades to several samtools modules; before this fix that
+        triggered ``nextflow inspect`` per dependency."""
+        assert self.subworkflow_install_old.install("fastq_align_bowtie2")
+        mock_gen.reset_mock()
+        update_obj = SubworkflowUpdate(self.pipeline_dir, show_diff=False, update_deps=True)
+        assert update_obj.update("fastq_align_bowtie2") is True
+        assert mock_gen.call_count == 1, (
+            f"Expected try_generate_container_configs to run once per top-level "
+            f"update, got {mock_gen.call_count} calls"
+        )
+
     def test_install_at_hash_and_update(self):
         """Installs an old version of a subworkflow in the pipeline and updates it"""
         assert self.subworkflow_install_old.install("fastq_align_bowtie2")

--- a/tests/subworkflows/test_update.py
+++ b/tests/subworkflows/test_update.py
@@ -43,8 +43,7 @@ class TestSubworkflowsUpdate(TestSubworkflows):
         update_obj = SubworkflowUpdate(self.pipeline_dir, show_diff=False, update_deps=True)
         assert update_obj.update("fastq_align_bowtie2") is True
         assert mock_gen.call_count == 1, (
-            f"Expected try_generate_container_configs to run once per top-level "
-            f"update, got {mock_gen.call_count} calls"
+            f"Expected try_generate_container_configs to run once per top-level update, got {mock_gen.call_count} calls"
         )
 
     def test_install_at_hash_and_update(self):


### PR DESCRIPTION
## Improvement

`nf-core modules/subworkflows install` and `update` were re-running `nextflow inspect` (via `try_generate_container_configs`) once for every transitive module dependency rather than once per command. Each call is JVM startup plus pipeline parse (~17 s).

Move the call out of the recursive path:
- `nf_core/components/install.py`: gate on `not silent`. Recursive installs pass `silent=True`. Also runs at the end of top-level subworkflow installs, which previously skipped regeneration entirely because of the `component_type == "modules"` guard.
- `nf_core/components/update.py`: hoist out of the per-component loop to after it. Skip when `--save-diff` is set (no changes applied to the working tree).

### Behaviour notes (worth flagging in review)

- **Top-level `subworkflows install`/`update` now regenerates container configs.** Previously skipped entirely because of `component_type == "modules"`. Aligns with the original intent of #3955.
- `--save-diff` updates explicitly do not regenerate (dry run).
- `nf-core modules install`/`update`: behaviour unchanged.

## Measured impact

nf-core/rnaseq `pr-1680`, warm cache:

| Command | Before | After |
|---|---:|---:|
| `subworkflows install --force bam_dedup_umi` | 5m 27s | **39s** |
| `subworkflows update --update-deps --no-preview bam_dedup_umi` | 4m 4s | **44s** |
| Repeating `Could not find meta.yml` warning lines | 36 | **2** |

## Tests

- `tests/subworkflows/test_install.py::test_subworkflows_install_regenerates_container_configs_once` — subworkflow with multiple module deps, regen exactly once.
- `tests/subworkflows/test_update.py::test_subworkflow_update_regenerates_container_configs_once` — `--update-deps` cascade, regen exactly once.
- `tests/subworkflows/test_update.py::test_subworkflow_update_save_diff_skips_container_configs` — `--save-diff` dry run, regen zero times.
- `tests/modules/test_install.py::test_modules_install_regenerates_container_configs_once` — top-level module install regression, regen exactly once.

## Validation requested

- [ ] CI passes (existing install/update tests).
- [ ] Behaviour check confirmed: `nf-core subworkflows install <X>` now regenerates container configs at the top level (previously skipped).
- [ ] Behaviour check confirmed: `nf-core modules install <X>` still regenerates exactly once (unchanged).
- [ ] Behaviour check confirmed: `nf-core ... update --save-diff <X>` does not regenerate.