### PR TITLE
feat(update): apply changes directly in non-interactive mode

### DIFF
--- a/nf_core/components/update.py
+++ b/nf_core/components/update.py
@@ -144,23 +144,23 @@ class ComponentUpdate(ComponentCommand):
 
         # Ask if we should show the diffs (unless a filename was already given on the command line)
         if not self.save_diff_fn and self.show_diff is None:
-            self.require_prompts(
-                "Diff display preference not specified.\n"
-                "Please use '--preview', '--save-diff', or neither to skip diff viewing"
-            )
-            diff_type = questionary.select(
-                "Do you want to view diffs of the proposed changes?",
-                choices=[
-                    {"name": "No previews, just update everything", "value": 0},
-                    {"name": "Preview diff in terminal, choose whether to update files", "value": 1},
-                    {"name": "Just write diffs to a patch file", "value": 2},
-                ],
-                default={"name": "No previews, just update everything", "value": 0},
-                style=nf_core.utils.nfcore_question_style,
-            ).unsafe_ask()
+            if self.no_prompts:
+                # Non-interactive: take the prompt's default (apply changes without preview).
+                self.show_diff = False
+            else:
+                diff_type = questionary.select(
+                    "Do you want to view diffs of the proposed changes?",
+                    choices=[
+                        {"name": "No previews, just update everything", "value": 0},
+                        {"name": "Preview diff in terminal, choose whether to update files", "value": 1},
+                        {"name": "Just write diffs to a patch file", "value": 2},
+                    ],
+                    default={"name": "No previews, just update everything", "value": 0},
+                    style=nf_core.utils.nfcore_question_style,
+                ).unsafe_ask()
 
-            self.show_diff = diff_type == 1
-            self.save_diff_fn = diff_type == 2
+                self.show_diff = diff_type == 1
+                self.save_diff_fn = diff_type == 2
 
         if self.save_diff_fn:  # True or a string
             self.setup_diff_file(check_diff_exist)

--- a/tests/subworkflows/test_update.py
+++ b/tests/subworkflows/test_update.py
@@ -32,6 +32,15 @@ class TestSubworkflowsUpdate(TestSubworkflows):
         assert update_obj.update("bam_stats_samtools") is True
         assert cmp_component(tmpdir, sw_path) is True
 
+    @mock.patch("nf_core.components.update.questionary.select")
+    def test_subworkflow_update_skips_diff_prompt_when_non_interactive(self, mock_select):
+        """Non-interactive update applies directly instead of prompting for diff mode."""
+        assert self.subworkflow_install_old.install("fastq_align_bowtie2")
+        update_obj = SubworkflowUpdate(self.pipeline_dir, update_deps=True)
+        update_obj.no_prompts = True
+        assert update_obj.update("fastq_align_bowtie2") is True
+        assert not mock_select.called
+
     def test_install_at_hash_and_update(self):
         """Installs an old version of a subworkflow in the pipeline and updates it"""
         assert self.subworkflow_install_old.install("fastq_align_bowtie2")


### PR DESCRIPTION
## Improvement

In non-TTY contexts (CI, scripted pipelines, shell automation), `nf-core modules/subworkflows update <X>` errors instead of doing anything, because the diff-mode prompt cannot run.

Take the questionary's existing default action when `no_prompts` is set — apply changes without a preview, the same outcome a user gets by pressing Enter at the interactive prompt. Interactive sessions are unchanged.

## Reproduction (before)

Tested against `nf-core 4.0.3` (base commit `b6af91a`) in a non-TTY shell (`ssh remote 'nf-core ...'`), against `nf-core/rnaseq` pr-1680:

```console
$ nf-core subworkflows update --update-deps bam_dedup_umi
ERROR    Diff display preference not specified.
         Please use '--preview', '--save-diff', or neither to skip diff viewing
         and prompts are disabled.
$ echo $?
1
```

Existing workaround: explicitly pass `--no-preview` (`-y`). Discoverable only if you read the source or `--help` carefully — every CI maintainer hits this the first time.

## After this PR

```console
$ nf-core subworkflows update --update-deps bam_dedup_umi
INFO     Updating 'nf-core/bam_dedup_umi'
INFO     Updating 'nf-core/bam_dedup_stats_samtools_umicollapse'
...
INFO     Updates complete :sparkles:
$ echo $?
0
```

Interactive TTY runs are unchanged — the questionary prompt still appears.

## Code

`nf_core/components/update.py:146-163` — split the "no preference set" branch in two: `no_prompts` → apply directly; else → existing questionary prompt.

## Tests

New `tests/subworkflows/test_update.py::test_subworkflow_update_skips_diff_prompt_when_non_interactive`: mocks `questionary.select`, forces `no_prompts=True`, asserts the update succeeds and the prompt is never invoked.

## Validation requested

- [ ] CI passes (existing update tests untouched in behaviour).
- [ ] Interactive sanity check: `nf-core ... update <X>` from a TTY still prompts for diff mode.
- [ ] Interactive sanity check: `--preview` / `--save-diff` still take their existing paths.