### PR TITLE
feat(install/update): add --skip-deps for single-target operations

### DIFF
--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -993,11 +993,17 @@ def command_modules_list_local(ctx, keywords, json, directory):  # pylint: disab
     help="Force reinstallation of module if it already exists",
 )
 @click.option("-s", "--sha", type=str, metavar="<commit sha>", help="Install module at commit SHA")
-def command_modules_install(ctx, tool, directory, prompt, force, sha):
+@click.option(
+    "--only",
+    is_flag=True,
+    default=False,
+    help="Restrict the install to the named component; do not recurse into included modules/subworkflows.",
+)
+def command_modules_install(ctx, tool, directory, prompt, force, sha, only):
     """
     Install DSL2 modules within a pipeline.
     """
-    modules_install(ctx, tool, directory, prompt, force, sha)
+    modules_install(ctx, tool, directory, prompt, force, sha, only)
 
 
 # nf-core modules update
@@ -1065,6 +1071,12 @@ def command_modules_install(ctx, tool, directory, prompt, force, sha):
     default=False,
     help="Automatically update all linked modules and subworkflows without asking for confirmation",
 )
+@click.option(
+    "--only",
+    is_flag=True,
+    default=False,
+    help="Restrict the update to the named module; do not touch transitively linked components. Mutually exclusive with --update-deps.",
+)
 def command_modules_update(
     ctx,
     tool,
@@ -1077,11 +1089,14 @@ def command_modules_update(
     save_diff,
     update_deps,
     limit_output,
+    only,
 ):
     """
     Update DSL2 modules within a pipeline.
     """
-    modules_update(ctx, tool, directory, force, prompt, sha, install_all, preview, save_diff, update_deps, limit_output)
+    modules_update(
+        ctx, tool, directory, force, prompt, sha, install_all, preview, save_diff, update_deps, limit_output, only
+    )
 
 
 # nf-core modules patch
@@ -1725,11 +1740,17 @@ def command_subworkflows_info(ctx, subworkflow, directory):
     metavar="<commit sha>",
     help="Install subworkflow at commit SHA",
 )
-def command_subworkflows_install(ctx, subworkflow, directory, prompt, force, sha):
+@click.option(
+    "--only",
+    is_flag=True,
+    default=False,
+    help="Restrict the install to the named subworkflow; do not recurse into included modules/subworkflows.",
+)
+def command_subworkflows_install(ctx, subworkflow, directory, prompt, force, sha, only):
     """
     Install DSL2 subworkflow within a pipeline.
     """
-    subworkflows_install(ctx, subworkflow, directory, prompt, force, sha)
+    subworkflows_install(ctx, subworkflow, directory, prompt, force, sha, only)
 
 
 # nf-core subworkflows patch
@@ -1882,6 +1903,12 @@ def command_subworkflows_remove(ctx, directory, subworkflow, force):
     default=False,
     help="Automatically update all linked modules and subworkflows without asking for confirmation",
 )
+@click.option(
+    "--only",
+    is_flag=True,
+    default=False,
+    help="Restrict the update to the named subworkflow; do not touch transitively linked components. Mutually exclusive with --update-deps.",
+)
 def command_subworkflows_update(
     ctx,
     subworkflow,
@@ -1894,12 +1921,24 @@ def command_subworkflows_update(
     save_diff,
     update_deps,
     limit_output,
+    only,
 ):
     """
     Update DSL2 subworkflow within a pipeline.
     """
     subworkflows_update(
-        ctx, subworkflow, directory, force, prompt, sha, install_all, preview, save_diff, update_deps, limit_output
+        ctx,
+        subworkflow,
+        directory,
+        force,
+        prompt,
+        sha,
+        install_all,
+        preview,
+        save_diff,
+        update_deps,
+        limit_output,
+        only,
     )
 
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -993,17 +993,11 @@ def command_modules_list_local(ctx, keywords, json, directory):  # pylint: disab
     help="Force reinstallation of module if it already exists",
 )
 @click.option("-s", "--sha", type=str, metavar="<commit sha>", help="Install module at commit SHA")
-@click.option(
-    "--only",
-    is_flag=True,
-    default=False,
-    help="Restrict the install to the named component; do not recurse into included modules/subworkflows.",
-)
-def command_modules_install(ctx, tool, directory, prompt, force, sha, only):
+def command_modules_install(ctx, tool, directory, prompt, force, sha):
     """
     Install DSL2 modules within a pipeline.
     """
-    modules_install(ctx, tool, directory, prompt, force, sha, only)
+    modules_install(ctx, tool, directory, prompt, force, sha)
 
 
 # nf-core modules update
@@ -1075,7 +1069,7 @@ def command_modules_install(ctx, tool, directory, prompt, force, sha, only):
     "--only",
     is_flag=True,
     default=False,
-    help="Restrict the update to the named module; do not touch transitively linked components. Mutually exclusive with --update-deps.",
+    help="Single-target update: don't cascade to linked components. Conflicts with --update-deps and --all.",
 )
 def command_modules_update(
     ctx,
@@ -1744,7 +1738,7 @@ def command_subworkflows_info(ctx, subworkflow, directory):
     "--only",
     is_flag=True,
     default=False,
-    help="Restrict the install to the named subworkflow; do not recurse into included modules/subworkflows.",
+    help="With --force, refresh only the named subworkflow; leave transitive deps' files and SHAs pinned.",
 )
 def command_subworkflows_install(ctx, subworkflow, directory, prompt, force, sha, only):
     """
@@ -1907,7 +1901,7 @@ def command_subworkflows_remove(ctx, directory, subworkflow, force):
     "--only",
     is_flag=True,
     default=False,
-    help="Restrict the update to the named subworkflow; do not touch transitively linked components. Mutually exclusive with --update-deps.",
+    help="Single-target update: don't cascade to linked components. Conflicts with --update-deps and --all.",
 )
 def command_subworkflows_update(
     ctx,

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -1066,10 +1066,10 @@ def command_modules_install(ctx, tool, directory, prompt, force, sha):
     help="Automatically update all linked modules and subworkflows without asking for confirmation",
 )
 @click.option(
-    "--only",
+    "--skip-deps",
     is_flag=True,
     default=False,
-    help="Single-target update: don't cascade to linked components. Conflicts with --update-deps and --all.",
+    help="Skip the cascade to linked components. Conflicts with --update-deps and --all.",
 )
 def command_modules_update(
     ctx,
@@ -1083,13 +1083,13 @@ def command_modules_update(
     save_diff,
     update_deps,
     limit_output,
-    only,
+    skip_deps,
 ):
     """
     Update DSL2 modules within a pipeline.
     """
     modules_update(
-        ctx, tool, directory, force, prompt, sha, install_all, preview, save_diff, update_deps, limit_output, only
+        ctx, tool, directory, force, prompt, sha, install_all, preview, save_diff, update_deps, limit_output, skip_deps
     )
 
 
@@ -1735,16 +1735,16 @@ def command_subworkflows_info(ctx, subworkflow, directory):
     help="Install subworkflow at commit SHA",
 )
 @click.option(
-    "--only",
+    "--skip-deps",
     is_flag=True,
     default=False,
     help="With --force, refresh only the named subworkflow; leave transitive deps' files and SHAs pinned.",
 )
-def command_subworkflows_install(ctx, subworkflow, directory, prompt, force, sha, only):
+def command_subworkflows_install(ctx, subworkflow, directory, prompt, force, sha, skip_deps):
     """
     Install DSL2 subworkflow within a pipeline.
     """
-    subworkflows_install(ctx, subworkflow, directory, prompt, force, sha, only)
+    subworkflows_install(ctx, subworkflow, directory, prompt, force, sha, skip_deps)
 
 
 # nf-core subworkflows patch
@@ -1898,10 +1898,10 @@ def command_subworkflows_remove(ctx, directory, subworkflow, force):
     help="Automatically update all linked modules and subworkflows without asking for confirmation",
 )
 @click.option(
-    "--only",
+    "--skip-deps",
     is_flag=True,
     default=False,
-    help="Single-target update: don't cascade to linked components. Conflicts with --update-deps and --all.",
+    help="Skip the cascade to linked components. Conflicts with --update-deps and --all.",
 )
 def command_subworkflows_update(
     ctx,
@@ -1915,7 +1915,7 @@ def command_subworkflows_update(
     save_diff,
     update_deps,
     limit_output,
-    only,
+    skip_deps,
 ):
     """
     Update DSL2 subworkflow within a pipeline.
@@ -1932,7 +1932,7 @@ def command_subworkflows_update(
         save_diff,
         update_deps,
         limit_output,
-        only,
+        skip_deps,
     )
 
 

--- a/nf_core/commands_modules.py
+++ b/nf_core/commands_modules.py
@@ -49,7 +49,7 @@ def modules_list_local(ctx, keywords, json, directory):  # pylint: disable=redef
         sys.exit(1)
 
 
-def modules_install(ctx, tool, directory, prompt, force, sha):
+def modules_install(ctx, tool, directory, prompt, force, sha, only=False):
     """
     Install DSL2 modules within a pipeline.
 
@@ -66,6 +66,7 @@ def modules_install(ctx, tool, directory, prompt, force, sha):
             ctx.obj["modules_repo_url"],
             ctx.obj["modules_repo_branch"],
             ctx.obj["modules_repo_no_pull"],
+            only=only,
         )
         exit_status = module_install.install(tool)
         if not exit_status:
@@ -87,6 +88,7 @@ def modules_update(
     save_diff,
     update_deps,
     limit_output,
+    only,
 ):
     """
     Update DSL2 modules within a pipeline.
@@ -109,6 +111,7 @@ def modules_update(
             ctx.obj["modules_repo_branch"],
             ctx.obj["modules_repo_no_pull"],
             limit_output,
+            only,
         )
         exit_status = module_install.update(tool)
         if not exit_status and install_all:

--- a/nf_core/commands_modules.py
+++ b/nf_core/commands_modules.py
@@ -49,7 +49,7 @@ def modules_list_local(ctx, keywords, json, directory):  # pylint: disable=redef
         sys.exit(1)
 
 
-def modules_install(ctx, tool, directory, prompt, force, sha, only=False):
+def modules_install(ctx, tool, directory, prompt, force, sha):
     """
     Install DSL2 modules within a pipeline.
 
@@ -66,7 +66,6 @@ def modules_install(ctx, tool, directory, prompt, force, sha, only=False):
             ctx.obj["modules_repo_url"],
             ctx.obj["modules_repo_branch"],
             ctx.obj["modules_repo_no_pull"],
-            only=only,
         )
         exit_status = module_install.install(tool)
         if not exit_status:

--- a/nf_core/commands_modules.py
+++ b/nf_core/commands_modules.py
@@ -87,7 +87,7 @@ def modules_update(
     save_diff,
     update_deps,
     limit_output,
-    only,
+    skip_deps,
 ):
     """
     Update DSL2 modules within a pipeline.
@@ -110,7 +110,7 @@ def modules_update(
             ctx.obj["modules_repo_branch"],
             ctx.obj["modules_repo_no_pull"],
             limit_output,
-            only,
+            skip_deps,
         )
         exit_status = module_install.update(tool)
         if not exit_status and install_all:

--- a/nf_core/commands_subworkflows.py
+++ b/nf_core/commands_subworkflows.py
@@ -177,7 +177,7 @@ def subworkflows_info(ctx, subworkflow, directory):
         sys.exit(1)
 
 
-def subworkflows_install(ctx, subworkflow, directory, prompt, force, sha):
+def subworkflows_install(ctx, subworkflow, directory, prompt, force, sha, only=False):
     """
     Install DSL2 subworkflow within a pipeline.
 
@@ -194,6 +194,7 @@ def subworkflows_install(ctx, subworkflow, directory, prompt, force, sha):
             ctx.obj["modules_repo_url"],
             ctx.obj["modules_repo_branch"],
             ctx.obj["modules_repo_no_pull"],
+            only=only,
         )
         exit_status = subworkflow_install.install(subworkflow)
         if not exit_status:
@@ -234,6 +235,7 @@ def subworkflows_update(
     save_diff,
     update_deps,
     limit_output,
+    only,
 ):
     """
     Update DSL2 subworkflow within a pipeline.
@@ -256,6 +258,7 @@ def subworkflows_update(
             ctx.obj["modules_repo_branch"],
             ctx.obj["modules_repo_no_pull"],
             limit_output,
+            only,
         )
         exit_status = subworkflow_install.update(subworkflow)
         if not exit_status and install_all:

--- a/nf_core/commands_subworkflows.py
+++ b/nf_core/commands_subworkflows.py
@@ -177,7 +177,7 @@ def subworkflows_info(ctx, subworkflow, directory):
         sys.exit(1)
 
 
-def subworkflows_install(ctx, subworkflow, directory, prompt, force, sha, only=False):
+def subworkflows_install(ctx, subworkflow, directory, prompt, force, sha, skip_deps=False):
     """
     Install DSL2 subworkflow within a pipeline.
 
@@ -194,7 +194,7 @@ def subworkflows_install(ctx, subworkflow, directory, prompt, force, sha, only=F
             ctx.obj["modules_repo_url"],
             ctx.obj["modules_repo_branch"],
             ctx.obj["modules_repo_no_pull"],
-            only=only,
+            skip_deps=skip_deps,
         )
         exit_status = subworkflow_install.install(subworkflow)
         if not exit_status:
@@ -235,7 +235,7 @@ def subworkflows_update(
     save_diff,
     update_deps,
     limit_output,
-    only,
+    skip_deps,
 ):
     """
     Update DSL2 subworkflow within a pipeline.
@@ -258,7 +258,7 @@ def subworkflows_update(
             ctx.obj["modules_repo_branch"],
             ctx.obj["modules_repo_no_pull"],
             limit_output,
-            only,
+            skip_deps,
         )
         exit_status = subworkflow_install.update(subworkflow)
         if not exit_status and install_all:

--- a/nf_core/components/install.py
+++ b/nf_core/components/install.py
@@ -37,6 +37,7 @@ class ComponentInstall(ComponentCommand):
         branch: str | None = None,
         no_pull: bool = False,
         installed_by: list[str] | None = None,
+        only: bool = False,
     ):
         super().__init__(component_type, pipeline_dir, remote_url, branch, no_pull)
         self.current_remote = ModulesRepo(remote_url, branch)
@@ -45,6 +46,7 @@ class ComponentInstall(ComponentCommand):
         self.prompt = prompt
         self.sha = sha
         self.current_sha = sha
+        self.only = only
         if installed_by is not None:
             self.installed_by = installed_by
         else:
@@ -165,7 +167,7 @@ class ComponentInstall(ComponentCommand):
             self.component_type, self.modules_repo, component, version, self.installed_by, install_track
         )
 
-        if self.component_type == "subworkflows":
+        if self.component_type == "subworkflows" and not self.only:
             # Install included modules and subworkflows
             self.install_included_components(component_dir)
 

--- a/nf_core/components/install.py
+++ b/nf_core/components/install.py
@@ -37,7 +37,7 @@ class ComponentInstall(ComponentCommand):
         branch: str | None = None,
         no_pull: bool = False,
         installed_by: list[str] | None = None,
-        only: bool = False,
+        skip_deps: bool = False,
     ):
         super().__init__(component_type, pipeline_dir, remote_url, branch, no_pull)
         self.current_remote = ModulesRepo(remote_url, branch)
@@ -46,7 +46,7 @@ class ComponentInstall(ComponentCommand):
         self.prompt = prompt
         self.sha = sha
         self.current_sha = sha
-        self.only = only
+        self.skip_deps = skip_deps
         if installed_by is not None:
             self.installed_by = installed_by
         else:
@@ -168,10 +168,10 @@ class ComponentInstall(ComponentCommand):
         )
 
         if self.component_type == "subworkflows":
-            # Under --only, don't propagate --force to transitive deps so
+            # Under --skip-deps, don't propagate --force to transitive deps so
             # already-installed ones keep their pinned SHAs and just have
             # installed_by tracking refreshed.
-            if self.only:
+            if self.skip_deps:
                 original_force = self.force
                 self.force = False
                 try:

--- a/nf_core/components/install.py
+++ b/nf_core/components/install.py
@@ -167,9 +167,19 @@ class ComponentInstall(ComponentCommand):
             self.component_type, self.modules_repo, component, version, self.installed_by, install_track
         )
 
-        if self.component_type == "subworkflows" and not self.only:
-            # Install included modules and subworkflows
-            self.install_included_components(component_dir)
+        if self.component_type == "subworkflows":
+            # Under --only, don't propagate --force to transitive deps so
+            # already-installed ones keep their pinned SHAs and just have
+            # installed_by tracking refreshed.
+            if self.only:
+                original_force = self.force
+                self.force = False
+                try:
+                    self.install_included_components(component_dir)
+                finally:
+                    self.force = original_force
+            else:
+                self.install_included_components(component_dir)
 
         # Regenerate container configuration files for the pipeline when modules are installed
         if self.component_type == "modules":

--- a/nf_core/components/update.py
+++ b/nf_core/components/update.py
@@ -38,7 +38,7 @@ class ComponentUpdate(ComponentCommand):
         branch=None,
         no_pull=False,
         limit_output=False,
-        only=False,
+        skip_deps=False,
     ):
         super().__init__(component_type, pipeline_dir, remote_url, branch, no_pull)
         self.current_remote = ModulesRepo(remote_url, branch)
@@ -51,7 +51,7 @@ class ComponentUpdate(ComponentCommand):
         self.save_diff_fn = save_diff_fn
         self.limit_output = limit_output
         self.update_deps = update_deps
-        self.only = only
+        self.skip_deps = skip_deps
         self.component = None
         self.update_config = None
         self.modules_json = ModulesJson(self.directory)
@@ -70,11 +70,11 @@ class ComponentUpdate(ComponentCommand):
         if self.update_all and self.component:
             raise UserWarning(f"Either a {self.component_type[:-1]} or the '--all' flag can be specified, not both.")
 
-        if self.only and self.update_deps:
-            raise UserWarning("`--only` and `--update-deps` are mutually exclusive: pick single-target or cascade.")
+        if self.skip_deps and self.update_deps:
+            raise UserWarning("`--skip-deps` and `--update-deps` are mutually exclusive.")
 
-        if self.only and self.update_all:
-            raise UserWarning("`--only` and `--all` are mutually exclusive.")
+        if self.skip_deps and self.update_all:
+            raise UserWarning("`--skip-deps` and `--all` are mutually exclusive.")
 
         if self.repo_type == "modules":
             raise UserWarning(
@@ -322,7 +322,7 @@ class ComponentUpdate(ComponentCommand):
                     try_generate_container_configs(self.directory)
                 recursive_update = True
                 modules_to_update, subworkflows_to_update = self.get_components_to_update(component)
-                if self.only:
+                if self.skip_deps:
                     # Caller asked for single-target update; skip linked components entirely.
                     recursive_update = False
                 elif not silent and len(modules_to_update + subworkflows_to_update) > 0 and not self.update_all:

--- a/nf_core/components/update.py
+++ b/nf_core/components/update.py
@@ -38,6 +38,7 @@ class ComponentUpdate(ComponentCommand):
         branch=None,
         no_pull=False,
         limit_output=False,
+        only=False,
     ):
         super().__init__(component_type, pipeline_dir, remote_url, branch, no_pull)
         self.current_remote = ModulesRepo(remote_url, branch)
@@ -50,6 +51,7 @@ class ComponentUpdate(ComponentCommand):
         self.save_diff_fn = save_diff_fn
         self.limit_output = limit_output
         self.update_deps = update_deps
+        self.only = only
         self.component = None
         self.update_config = None
         self.modules_json = ModulesJson(self.directory)
@@ -67,6 +69,9 @@ class ComponentUpdate(ComponentCommand):
 
         if self.update_all and self.component:
             raise UserWarning(f"Either a {self.component_type[:-1]} or the '--all' flag can be specified, not both.")
+
+        if self.only and self.update_deps:
+            raise UserWarning("`--only` and `--update-deps` are mutually exclusive: pick single-target or cascade.")
 
         if self.repo_type == "modules":
             raise UserWarning(
@@ -314,7 +319,10 @@ class ComponentUpdate(ComponentCommand):
                     try_generate_container_configs(self.directory)
                 recursive_update = True
                 modules_to_update, subworkflows_to_update = self.get_components_to_update(component)
-                if not silent and len(modules_to_update + subworkflows_to_update) > 0 and not self.update_all:
+                if self.only:
+                    # Caller asked for single-target update; skip linked components entirely.
+                    recursive_update = False
+                elif not silent and len(modules_to_update + subworkflows_to_update) > 0 and not self.update_all:
                     log.warning(
                         f"All modules and subworkflows linked to the updated {self.component_type[:-1]} will be {'asked for update' if self.show_diff else 'automatically updated'}.\n"
                         "It is advised to keep all your modules and subworkflows up to date.\n"

--- a/nf_core/components/update.py
+++ b/nf_core/components/update.py
@@ -73,6 +73,9 @@ class ComponentUpdate(ComponentCommand):
         if self.only and self.update_deps:
             raise UserWarning("`--only` and `--update-deps` are mutually exclusive: pick single-target or cascade.")
 
+        if self.only and self.update_all:
+            raise UserWarning("`--only` and `--all` are mutually exclusive.")
+
         if self.repo_type == "modules":
             raise UserWarning(
                 f"{self.component_type.title()} can not be updated in clones of the nf-core/modules repository."

--- a/nf_core/components/update.py
+++ b/nf_core/components/update.py
@@ -266,7 +266,9 @@ class ComponentUpdate(ComponentCommand):
                             updated.append(component)
                     recursive_update = True
                     modules_to_update, subworkflows_to_update = self.get_components_to_update(component)
-                    if not silent and len(modules_to_update + subworkflows_to_update) > 0:
+                    if self.skip_deps:
+                        recursive_update = False
+                    elif not silent and len(modules_to_update + subworkflows_to_update) > 0:
                         log.warning(
                             f"All modules and subworkflows linked to the updated {self.component_type[:-1]} will be added to the same diff file.\n"
                             "It is advised to keep all your modules and subworkflows up to date.\n"

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -12,6 +12,7 @@ class ModuleInstall(ComponentInstall):
         branch=None,
         no_pull=False,
         installed_by=None,
+        only=False,
     ):
         super().__init__(
             pipeline_dir,
@@ -23,4 +24,5 @@ class ModuleInstall(ComponentInstall):
             branch=branch,
             no_pull=no_pull,
             installed_by=installed_by,
+            only=only,
         )

--- a/nf_core/modules/install.py
+++ b/nf_core/modules/install.py
@@ -12,7 +12,6 @@ class ModuleInstall(ComponentInstall):
         branch=None,
         no_pull=False,
         installed_by=None,
-        only=False,
     ):
         super().__init__(
             pipeline_dir,
@@ -24,5 +23,4 @@ class ModuleInstall(ComponentInstall):
             branch=branch,
             no_pull=no_pull,
             installed_by=installed_by,
-            only=only,
         )

--- a/nf_core/modules/update.py
+++ b/nf_core/modules/update.py
@@ -16,7 +16,7 @@ class ModuleUpdate(ComponentUpdate):
         branch=None,
         no_pull=False,
         limit_output=False,
-        only=False,
+        skip_deps=False,
     ):
         super().__init__(
             pipeline_dir,
@@ -32,5 +32,5 @@ class ModuleUpdate(ComponentUpdate):
             branch,
             no_pull,
             limit_output,
-            only,
+            skip_deps,
         )

--- a/nf_core/modules/update.py
+++ b/nf_core/modules/update.py
@@ -16,6 +16,7 @@ class ModuleUpdate(ComponentUpdate):
         branch=None,
         no_pull=False,
         limit_output=False,
+        only=False,
     ):
         super().__init__(
             pipeline_dir,
@@ -31,4 +32,5 @@ class ModuleUpdate(ComponentUpdate):
             branch,
             no_pull,
             limit_output,
+            only,
         )

--- a/nf_core/subworkflows/install.py
+++ b/nf_core/subworkflows/install.py
@@ -12,7 +12,7 @@ class SubworkflowInstall(ComponentInstall):
         branch=None,
         no_pull=False,
         installed_by=None,
-        only=False,
+        skip_deps=False,
     ):
         super().__init__(
             pipeline_dir,
@@ -24,5 +24,5 @@ class SubworkflowInstall(ComponentInstall):
             branch=branch,
             no_pull=no_pull,
             installed_by=installed_by,
-            only=only,
+            skip_deps=skip_deps,
         )

--- a/nf_core/subworkflows/install.py
+++ b/nf_core/subworkflows/install.py
@@ -12,6 +12,7 @@ class SubworkflowInstall(ComponentInstall):
         branch=None,
         no_pull=False,
         installed_by=None,
+        only=False,
     ):
         super().__init__(
             pipeline_dir,
@@ -23,4 +24,5 @@ class SubworkflowInstall(ComponentInstall):
             branch=branch,
             no_pull=no_pull,
             installed_by=installed_by,
+            only=only,
         )

--- a/nf_core/subworkflows/update.py
+++ b/nf_core/subworkflows/update.py
@@ -16,6 +16,7 @@ class SubworkflowUpdate(ComponentUpdate):
         branch=None,
         no_pull=False,
         limit_output=False,
+        only=False,
     ):
         super().__init__(
             pipeline_dir,
@@ -31,4 +32,5 @@ class SubworkflowUpdate(ComponentUpdate):
             branch,
             no_pull,
             limit_output,
+            only,
         )

--- a/nf_core/subworkflows/update.py
+++ b/nf_core/subworkflows/update.py
@@ -16,7 +16,7 @@ class SubworkflowUpdate(ComponentUpdate):
         branch=None,
         no_pull=False,
         limit_output=False,
-        only=False,
+        skip_deps=False,
     ):
         super().__init__(
             pipeline_dir,
@@ -32,5 +32,5 @@ class SubworkflowUpdate(ComponentUpdate):
             branch,
             no_pull,
             limit_output,
-            only,
+            skip_deps,
         )

--- a/tests/modules/test_update.py
+++ b/tests/modules/test_update.py
@@ -48,11 +48,11 @@ class TestModulesInstall(TestModules):
         "nf_core.components.update.ComponentUpdate.get_components_to_update",
         return_value=([], [{"name": "fake_sw", "git_remote": "x"}]),
     )
-    def test_module_update_only_does_not_cascade(self, mock_get_linked, mock_cascade):
-        """`module update --only` skips cascade even when linked subworkflows exist."""
+    def test_module_update_skip_deps_does_not_cascade(self, mock_get_linked, mock_cascade):
+        """`module update --skip-deps` skips cascade even when linked subworkflows exist."""
         assert self.mods_install_old.install("trimgalore")
         update_obj = ModuleUpdate(
-            self.pipeline_dir, show_diff=False, only=True, remote_url=GITLAB_URL, branch=OLD_TRIMGALORE_BRANCH
+            self.pipeline_dir, show_diff=False, skip_deps=True, remote_url=GITLAB_URL, branch=OLD_TRIMGALORE_BRANCH
         )
         assert update_obj.update("trimgalore") is True
         assert not mock_cascade.called

--- a/tests/modules/test_update.py
+++ b/tests/modules/test_update.py
@@ -43,6 +43,20 @@ class TestModulesInstall(TestModules):
         assert update_obj.update("trimgalore") is True
         assert cmp_component(trimgalore_tmpdir, trimgalore_path) is True
 
+    @mock.patch("nf_core.components.update.ComponentUpdate.update_linked_components")
+    @mock.patch(
+        "nf_core.components.update.ComponentUpdate.get_components_to_update",
+        return_value=([], [{"name": "fake_sw", "git_remote": "x"}]),
+    )
+    def test_module_update_only_does_not_cascade(self, mock_get_linked, mock_cascade):
+        """`module update --only` skips cascade even when linked subworkflows exist."""
+        assert self.mods_install_old.install("trimgalore")
+        update_obj = ModuleUpdate(
+            self.pipeline_dir, show_diff=False, only=True, remote_url=GITLAB_URL, branch=OLD_TRIMGALORE_BRANCH
+        )
+        assert update_obj.update("trimgalore") is True
+        assert not mock_cascade.called
+
     def test_install_at_hash_and_update(self):
         """Installs an old version of a module in the pipeline and updates it"""
         assert self.mods_install_old.install("trimgalore")

--- a/tests/subworkflows/test_install.py
+++ b/tests/subworkflows/test_install.py
@@ -18,6 +18,15 @@ from ..utils import (
 
 
 class TestSubworkflowsInstall(TestSubworkflows):
+    def test_subworkflow_install_only_skips_included_components(self):
+        """`--only` installs the named subworkflow but does not pull in transitive modules."""
+        install_obj = SubworkflowInstall(self.pipeline_dir, prompt=False, force=False, only=True)
+        assert install_obj.install("bam_sort_stats_samtools") is not False
+        subworkflow_path = Path(self.pipeline_dir, "subworkflows", "nf-core", "bam_sort_stats_samtools")
+        samtools_index_path = Path(self.pipeline_dir, "modules", "nf-core", "samtools", "index")
+        assert subworkflow_path.exists(), "Named subworkflow should be installed"
+        assert not samtools_index_path.exists(), "Transitive module dep must not be installed under --only"
+
     def test_subworkflows_install_bam_sort_stats_samtools(self):
         """Test installing a subworkflow - bam_sort_stats_samtools"""
         assert self.subworkflow_install.install("bam_sort_stats_samtools") is not False

--- a/tests/subworkflows/test_install.py
+++ b/tests/subworkflows/test_install.py
@@ -34,6 +34,17 @@ class TestSubworkflowsInstall(TestSubworkflows):
         ]["modules"]["nf-core"]["samtools/index"]["git_sha"]
         assert before_sha == after_sha
 
+    def test_subworkflow_install_only_preserves_installed_by_tracking(self):
+        """`install --only` of a parent records the new dependent in shared subcomponents' installed_by."""
+        # Install the sub-subworkflow first so it's already on disk before we --only the parent.
+        assert self.subworkflow_install.install("bam_stats_samtools") is not False
+        only_install = SubworkflowInstall(self.pipeline_dir, prompt=False, force=False, only=True)
+        assert only_install.install("bam_sort_stats_samtools") is not False
+        installed_by = ModulesJson(self.pipeline_dir).get_modules_json()["repos"][
+            "https://github.com/nf-core/modules.git"
+        ]["subworkflows"]["nf-core"]["bam_stats_samtools"]["installed_by"]
+        assert sorted(installed_by) == sorted(["subworkflows", "bam_sort_stats_samtools"])
+
     def test_subworkflows_install_bam_sort_stats_samtools(self):
         """Test installing a subworkflow - bam_sort_stats_samtools"""
         assert self.subworkflow_install.install("bam_sort_stats_samtools") is not False

--- a/tests/subworkflows/test_install.py
+++ b/tests/subworkflows/test_install.py
@@ -18,8 +18,8 @@ from ..utils import (
 
 
 class TestSubworkflowsInstall(TestSubworkflows):
-    def test_subworkflow_install_force_only_does_not_reinstall_deps(self):
-        """`install --force --only` leaves transitive deps' SHAs pinned."""
+    def test_subworkflow_install_force_skip_deps_does_not_reinstall_deps(self):
+        """`install --force --skip-deps` leaves transitive deps' SHAs pinned."""
         assert self.subworkflow_install.install("bam_sort_stats_samtools") is not False
         samtools_index_path = Path(self.pipeline_dir, "modules", "nf-core", "samtools", "index")
         assert samtools_index_path.exists()
@@ -27,19 +27,19 @@ class TestSubworkflowsInstall(TestSubworkflows):
             "https://github.com/nf-core/modules.git"
         ]["modules"]["nf-core"]["samtools/index"]["git_sha"]
 
-        force_only = SubworkflowInstall(self.pipeline_dir, prompt=False, force=True, only=True)
-        assert force_only.install("bam_sort_stats_samtools") is not False
+        force_skip = SubworkflowInstall(self.pipeline_dir, prompt=False, force=True, skip_deps=True)
+        assert force_skip.install("bam_sort_stats_samtools") is not False
         after_sha = ModulesJson(self.pipeline_dir).get_modules_json()["repos"][
             "https://github.com/nf-core/modules.git"
         ]["modules"]["nf-core"]["samtools/index"]["git_sha"]
         assert before_sha == after_sha
 
-    def test_subworkflow_install_only_preserves_installed_by_tracking(self):
-        """`install --only` of a parent records the new dependent in shared subcomponents' installed_by."""
-        # Install the sub-subworkflow first so it's already on disk before we --only the parent.
+    def test_subworkflow_install_skip_deps_preserves_installed_by_tracking(self):
+        """`install --skip-deps` of a parent records the new dependent in shared subcomponents' installed_by."""
+        # Install the sub-subworkflow first so it's already on disk before we --skip-deps the parent.
         assert self.subworkflow_install.install("bam_stats_samtools") is not False
-        only_install = SubworkflowInstall(self.pipeline_dir, prompt=False, force=False, only=True)
-        assert only_install.install("bam_sort_stats_samtools") is not False
+        skip_install = SubworkflowInstall(self.pipeline_dir, prompt=False, force=False, skip_deps=True)
+        assert skip_install.install("bam_sort_stats_samtools") is not False
         installed_by = ModulesJson(self.pipeline_dir).get_modules_json()["repos"][
             "https://github.com/nf-core/modules.git"
         ]["subworkflows"]["nf-core"]["bam_stats_samtools"]["installed_by"]

--- a/tests/subworkflows/test_install.py
+++ b/tests/subworkflows/test_install.py
@@ -18,14 +18,21 @@ from ..utils import (
 
 
 class TestSubworkflowsInstall(TestSubworkflows):
-    def test_subworkflow_install_only_skips_included_components(self):
-        """`--only` installs the named subworkflow but does not pull in transitive modules."""
-        install_obj = SubworkflowInstall(self.pipeline_dir, prompt=False, force=False, only=True)
-        assert install_obj.install("bam_sort_stats_samtools") is not False
-        subworkflow_path = Path(self.pipeline_dir, "subworkflows", "nf-core", "bam_sort_stats_samtools")
+    def test_subworkflow_install_force_only_does_not_reinstall_deps(self):
+        """`install --force --only` leaves transitive deps' SHAs pinned."""
+        assert self.subworkflow_install.install("bam_sort_stats_samtools") is not False
         samtools_index_path = Path(self.pipeline_dir, "modules", "nf-core", "samtools", "index")
-        assert subworkflow_path.exists(), "Named subworkflow should be installed"
-        assert not samtools_index_path.exists(), "Transitive module dep must not be installed under --only"
+        assert samtools_index_path.exists()
+        before_sha = ModulesJson(self.pipeline_dir).get_modules_json()["repos"][
+            "https://github.com/nf-core/modules.git"
+        ]["modules"]["nf-core"]["samtools/index"]["git_sha"]
+
+        force_only = SubworkflowInstall(self.pipeline_dir, prompt=False, force=True, only=True)
+        assert force_only.install("bam_sort_stats_samtools") is not False
+        after_sha = ModulesJson(self.pipeline_dir).get_modules_json()["repos"][
+            "https://github.com/nf-core/modules.git"
+        ]["modules"]["nf-core"]["samtools/index"]["git_sha"]
+        assert before_sha == after_sha
 
     def test_subworkflows_install_bam_sort_stats_samtools(self):
         """Test installing a subworkflow - bam_sort_stats_samtools"""

--- a/tests/subworkflows/test_update.py
+++ b/tests/subworkflows/test_update.py
@@ -4,6 +4,7 @@ import tempfile
 from pathlib import Path
 from unittest import mock
 
+import pytest
 import questionary
 import yaml
 
@@ -31,6 +32,38 @@ class TestSubworkflowsUpdate(TestSubworkflows):
 
         assert update_obj.update("bam_stats_samtools") is True
         assert cmp_component(tmpdir, sw_path) is True
+
+    def test_subworkflow_update_only_skips_linked_components(self):
+        """`--only` updates the named subworkflow's SHA but leaves transitive deps untouched."""
+        assert self.subworkflow_install_old.install("fastq_align_bowtie2")
+        old_mod_json = ModulesJson(self.pipeline_dir).get_modules_json()
+        old_dep_sha = old_mod_json["repos"][NF_CORE_MODULES_REMOTE]["modules"][NF_CORE_MODULES_NAME][
+            "samtools/flagstat"
+        ]["git_sha"]
+
+        update_obj = SubworkflowUpdate(self.pipeline_dir, show_diff=False, only=True)
+        assert update_obj.update("fastq_align_bowtie2") is True
+
+        mod_json = ModulesJson(self.pipeline_dir).get_modules_json()
+        # The named subworkflow's SHA moved.
+        assert (
+            mod_json["repos"][NF_CORE_MODULES_REMOTE]["subworkflows"][NF_CORE_MODULES_NAME]["fastq_align_bowtie2"][
+                "git_sha"
+            ]
+            != old_mod_json["repos"][NF_CORE_MODULES_REMOTE]["subworkflows"][NF_CORE_MODULES_NAME][
+                "fastq_align_bowtie2"
+            ]["git_sha"]
+        )
+        # A transitively-linked module's SHA did not.
+        assert (
+            mod_json["repos"][NF_CORE_MODULES_REMOTE]["modules"][NF_CORE_MODULES_NAME]["samtools/flagstat"]["git_sha"]
+            == old_dep_sha
+        )
+
+    def test_subworkflow_update_only_with_update_deps_errors(self):
+        """`--only` and `--update-deps` are mutually exclusive."""
+        with pytest.raises(UserWarning, match="mutually exclusive"):
+            SubworkflowUpdate(self.pipeline_dir, only=True, update_deps=True, show_diff=False)._parameter_checks()
 
     def test_install_at_hash_and_update(self):
         """Installs an old version of a subworkflow in the pipeline and updates it"""

--- a/tests/subworkflows/test_update.py
+++ b/tests/subworkflows/test_update.py
@@ -65,6 +65,11 @@ class TestSubworkflowsUpdate(TestSubworkflows):
         with pytest.raises(UserWarning, match="mutually exclusive"):
             SubworkflowUpdate(self.pipeline_dir, only=True, update_deps=True, show_diff=False)._parameter_checks()
 
+    def test_subworkflow_update_only_with_all_errors(self):
+        """`--only` and `--all` are mutually exclusive."""
+        with pytest.raises(UserWarning, match="mutually exclusive"):
+            SubworkflowUpdate(self.pipeline_dir, only=True, update_all=True, show_diff=False)._parameter_checks()
+
     def test_install_at_hash_and_update(self):
         """Installs an old version of a subworkflow in the pipeline and updates it"""
         assert self.subworkflow_install_old.install("fastq_align_bowtie2")

--- a/tests/subworkflows/test_update.py
+++ b/tests/subworkflows/test_update.py
@@ -33,15 +33,15 @@ class TestSubworkflowsUpdate(TestSubworkflows):
         assert update_obj.update("bam_stats_samtools") is True
         assert cmp_component(tmpdir, sw_path) is True
 
-    def test_subworkflow_update_only_skips_linked_components(self):
-        """`--only` updates the named subworkflow's SHA but leaves transitive deps untouched."""
+    def test_subworkflow_update_skip_deps_skips_linked_components(self):
+        """`--skip-deps` updates the named subworkflow's SHA but leaves transitive deps untouched."""
         assert self.subworkflow_install_old.install("fastq_align_bowtie2")
         old_mod_json = ModulesJson(self.pipeline_dir).get_modules_json()
         old_dep_sha = old_mod_json["repos"][NF_CORE_MODULES_REMOTE]["modules"][NF_CORE_MODULES_NAME][
             "samtools/flagstat"
         ]["git_sha"]
 
-        update_obj = SubworkflowUpdate(self.pipeline_dir, show_diff=False, only=True)
+        update_obj = SubworkflowUpdate(self.pipeline_dir, show_diff=False, skip_deps=True)
         assert update_obj.update("fastq_align_bowtie2") is True
 
         mod_json = ModulesJson(self.pipeline_dir).get_modules_json()
@@ -60,15 +60,15 @@ class TestSubworkflowsUpdate(TestSubworkflows):
             == old_dep_sha
         )
 
-    def test_subworkflow_update_only_with_update_deps_errors(self):
-        """`--only` and `--update-deps` are mutually exclusive."""
+    def test_subworkflow_update_skip_deps_with_update_deps_errors(self):
+        """`--skip-deps` and `--update-deps` are mutually exclusive."""
         with pytest.raises(UserWarning, match="mutually exclusive"):
-            SubworkflowUpdate(self.pipeline_dir, only=True, update_deps=True, show_diff=False)._parameter_checks()
+            SubworkflowUpdate(self.pipeline_dir, skip_deps=True, update_deps=True, show_diff=False)._parameter_checks()
 
-    def test_subworkflow_update_only_with_all_errors(self):
-        """`--only` and `--all` are mutually exclusive."""
+    def test_subworkflow_update_skip_deps_with_all_errors(self):
+        """`--skip-deps` and `--all` are mutually exclusive."""
         with pytest.raises(UserWarning, match="mutually exclusive"):
-            SubworkflowUpdate(self.pipeline_dir, only=True, update_all=True, show_diff=False)._parameter_checks()
+            SubworkflowUpdate(self.pipeline_dir, skip_deps=True, update_all=True, show_diff=False)._parameter_checks()
 
     def test_install_at_hash_and_update(self):
         """Installs an old version of a subworkflow in the pipeline and updates it"""

--- a/tests/subworkflows/test_update.py
+++ b/tests/subworkflows/test_update.py
@@ -60,6 +60,29 @@ class TestSubworkflowsUpdate(TestSubworkflows):
             == old_dep_sha
         )
 
+    def test_subworkflow_update_skip_deps_save_diff_only_named_component(self):
+        """`--skip-deps --save-diff` writes a diff for only the named subworkflow, no linked components."""
+        assert self.subworkflow_install_old.install("fastq_align_bowtie2")
+        diff_path = Path(tempfile.mkdtemp()) / "skipdeps.diff"
+        update_obj = SubworkflowUpdate(
+            self.pipeline_dir,
+            show_diff=False,
+            save_diff_fn=diff_path,
+            skip_deps=True,
+        )
+        assert update_obj.update("fastq_align_bowtie2") is True
+
+        diff_text = diff_path.read_text()
+        # The named subworkflow's main.nf should be in the diff
+        assert "subworkflows/nf-core/fastq_align_bowtie2/main.nf" in diff_text
+        # Transitively-linked module files (e.g. samtools/*) must not be in the diff
+        for linked in (
+            "modules/nf-core/samtools/flagstat/main.nf",
+            "modules/nf-core/samtools/index/main.nf",
+            "modules/nf-core/samtools/sort/main.nf",
+        ):
+            assert linked not in diff_text, f"unexpected linked component in --skip-deps diff: {linked}"
+
     def test_subworkflow_update_skip_deps_with_update_deps_errors(self):
         """`--skip-deps` and `--update-deps` are mutually exclusive."""
         with pytest.raises(UserWarning, match="mutually exclusive"):


### PR DESCRIPTION
## Improvement

Today there is no working invocation that updates **only** the named component:

- `install --force <X>` walks the include graph and re-pins every reachable component at the cached-repo HEAD, producing a wide `modules.json` diff for what the user asked to be a focused change.
- `update <X>` (no flags) cascades silently when non-interactive, and prompts per-component interactively. The only way to get a true single-target update is to answer "no" to each prompt by hand.

This makes a focused dep bump impractical to ship as a standalone, reviewable PR — maintainers either hand-edit `modules.json` or accept a sprawling unrelated diff.

Add `--skip-deps` to both `install` and `update` (subworkflows install + modules/subworkflows update). When set:

- **`install --force --skip-deps`** (subworkflows only): the named subworkflow's files are re-fetched, but transitive deps are not force-reinstalled. Already-installed deps keep their pinned SHAs; their `installed_by` tracking is still refreshed via the recursive call.
- **`update --skip-deps`**: `recursive_update` is forced `False`. Mutually exclusive with `--update-deps` and `--all`; raises a clear `UserWarning` if combined.

(Not added to `modules install`: that path has no transitive deps to walk, so the flag would be a no-op.)

## Reproduction

Tested against `nf-core 4.0.3` (base `b6af91a`) on `nf-core/rnaseq` pr-1680:

### Before (`subworkflows install --force bam_dedup_umi`)

```
Files modified: 22
modules.json git_sha lines: 25  (≈ 13 transitive SHA bumps + bam_dedup_umi)
```

### After (`subworkflows install --force --skip-deps bam_dedup_umi`)

```
Files modified: 10  (1 modules.json + 9 container-config side effects)
modules.json git_sha lines: 2  (1 SHA bump: bam_dedup_umi only)
```

`modules.json` diff under `--skip-deps`:

```diff
@@ -408,7 +408,7 @@
                     "bam_dedup_umi": {
                         "branch": "master",
-                        "git_sha": "01e9676391c9749e536bf85fa0c666d36de517f5",
+                        "git_sha": "1298fbd2004c2913d6682ce4a419647d97a8fc3f",
                         "installed_by": ["subworkflows"]
                     },
```

## Tests

- `test_subworkflow_install_force_skip_deps_does_not_reinstall_deps` — `install --force --skip-deps` against an existing pipeline leaves transitive deps' SHAs pinned.
- `test_subworkflow_install_skip_deps_preserves_installed_by_tracking` — installing a parent with `--skip-deps` adds the new parent to the shared sub-component's `installed_by` list (mashehu's scenario).
- `test_subworkflow_update_skip_deps_skips_linked_components` — `update --skip-deps` against an old SHA bumps the named subworkflow's SHA, leaves linked module's SHA pinned.
- `test_subworkflow_update_skip_deps_with_update_deps_errors` / `_with_all_errors` — mutual-exclusion `UserWarning`s.
- `test_module_update_skip_deps_does_not_cascade` — mocks `get_components_to_update` to return a fake linked subworkflow; asserts `update_linked_components` is not invoked under `--skip-deps`.
