### PR TITLE
fix CI: commit updated configs after modules update step

### DIFF
--- a/.github/actions/create-lint-wf/action.yml
+++ b/.github/actions/create-lint-wf/action.yml
@@ -67,19 +67,19 @@ runs:
     # Remove TODO statements
     - name: remove TODO
       shell: bash
-      run: find nf-core-testpipeline -type f -exec sed -i 's#TODO nf-core:##g' {} \;
+      run: find nf-core-testpipeline -not -path '*/.git/*' -type f -exec sed -i 's#TODO nf-core:##g' {} \;
       working-directory: create-lint-wf
 
     # Uncomment includeConfig statement
     - name: uncomment include config
       shell: bash
-      run: find nf-core-testpipeline -type f -exec sed -i 's/\/\/ includeConfig/includeConfig/' {} \;
+      run: find nf-core-testpipeline -not -path '*/.git/*' -type f -exec sed -i 's/\/\/ includeConfig/includeConfig/' {} \;
       working-directory: create-lint-wf
 
     # Replace zenodo.XXXXXX to pass readme linting
     - name: replace zenodo.XXXXXX
       shell: bash
-      run: find nf-core-testpipeline -type f -exec sed -i 's/zenodo.XXXXXX/zenodo.123456/g' {} \;
+      run: find nf-core-testpipeline -not -path '*/.git/*' -type f -exec sed -i 's/zenodo.XXXXXX/zenodo.123456/g' {} \;
       working-directory: create-lint-wf
 
     # Run nf-core pipelines linting

--- a/.github/actions/create-lint-wf/action.yml
+++ b/.github/actions/create-lint-wf/action.yml
@@ -53,6 +53,15 @@ runs:
       run: uv run nf-core --log-file log.txt modules update --dir nf-core-testpipeline --all --no-preview
       working-directory: create-lint-wf
 
+    # Commit regenerated container configs so lint sees them as up to date
+    - name: commit updated container configs
+      shell: bash
+      run: |
+        cd nf-core-testpipeline
+        git add conf/containers_*.config
+        git diff --cached --quiet || git commit -m "Update container configs after modules update"
+      working-directory: create-lint-wf
+
     # Remove TODO statements
     - name: remove TODO
       shell: bash

--- a/.github/actions/create-lint-wf/action.yml
+++ b/.github/actions/create-lint-wf/action.yml
@@ -58,6 +58,8 @@ runs:
       shell: bash
       run: |
         cd nf-core-testpipeline
+        git config user.email "nf-core-bot@nf-co.re"
+        git config user.name "nf-core-bot"
         git add conf/containers_*.config
         git diff --cached --quiet || git commit -m "Update container configs after modules update"
       working-directory: create-lint-wf

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -203,7 +203,7 @@ class Pipeline:
         self.files: list[Path] = []
         self.git_sha: str | None = None
         self.minNextflowVersion: str | None = None
-        self.wf_path = Path(wf_path)
+        self.wf_path = Path(wf_path).resolve()
         self.pipeline_name: str | None = None
         self.pipeline_prefix: str | None = None
         self.schema_obj: PipelineSchema | None = None


### PR DESCRIPTION
MultiQC has been updated upstream, but not yet in the template. therefore https://github.com/nf-core/tools/actions/runs/26166291868/job/76971356193?pr=4287 fails because it runs `modules update`, which updates the configs, meaning the linting step will fail.