### PR TITLE
Add `--help-json` flag for machine-readable CLI help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### General
 
-- Add a global `--help-json` flag to every CLI command, printing machine-readable help/usage as JSON with a recursive index of subcommands (for LLMs and tooling) ([#XXXX](https://github.com/nf-core/tools/pull/XXXX))
+- Add a global `--help-json` flag to every CLI command, printing machine-readable help/usage as JSON with a recursive index of subcommands (for LLMs and tooling) ([#4310](https://github.com/nf-core/tools/pull/4310))
 - Update pre-commit hook pre-commit/mirrors-mypy to v2 ([#4270](https://github.com/nf-core/tools/pull/4270))
 - container configs: use correct key for conda configs ([#4269](https://github.com/nf-core/tools/pull/4269))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### General
 
+- Add a global `--help-json` flag to every CLI command, printing machine-readable help/usage as JSON with a recursive index of subcommands (for LLMs and tooling) ([#XXXX](https://github.com/nf-core/tools/pull/XXXX))
 - Update pre-commit hook pre-commit/mirrors-mypy to v2 ([#4270](https://github.com/nf-core/tools/pull/4270))
 - container configs: use correct key for conda configs ([#4269](https://github.com/nf-core/tools/pull/4269))
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -15,6 +15,7 @@ import rich_click.rich_click as rc
 from trogon import tui
 
 from nf_core import __version__
+from nf_core.cli_schema import JSONGroup
 from nf_core.commands_modules import (
     modules_bump_versions,
     modules_create,
@@ -73,6 +74,11 @@ setup_nfcore_dir()
 rc.MAX_WIDTH = 100
 rc.USE_RICH_MARKUP = True
 rc.COMMANDS_BEFORE_OPTIONS = True
+# Tip shown on every --help screen, pointing tools/agents at the machine-readable schema
+rc.FOOTER_TEXT = (
+    "[dim]Tip:[/] add [bold]--help-json[/] to any command for machine-readable help "
+    "(usage, options and a recursive index of subcommands) as JSON."
+)
 
 
 # Set up rich stderr console
@@ -131,7 +137,7 @@ def run_nf_core():
 
 
 @tui(command="interface", help="Launch the nf-core interface")
-@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+@click.group(cls=JSONGroup, context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(__version__)
 @click.option(
     "-v",

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -76,8 +76,8 @@ rc.USE_RICH_MARKUP = True
 rc.COMMANDS_BEFORE_OPTIONS = True
 # Tip shown on every --help screen, pointing tools/agents at the machine-readable schema
 rc.FOOTER_TEXT = (
-    "[dim]Tip:[/] add [bold]--help-json[/] to any command for machine-readable help "
-    "(usage, options and a recursive index of subcommands) as JSON."
+    "[dim]Tip: add --help-json to any command for machine-readable help "
+    "(usage, options and a recursive index of subcommands) as JSON.[/]"
 )
 
 

--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -75,10 +75,7 @@ rc.MAX_WIDTH = 100
 rc.USE_RICH_MARKUP = True
 rc.COMMANDS_BEFORE_OPTIONS = True
 # Tip shown on every --help screen, pointing tools/agents at the machine-readable schema
-rc.FOOTER_TEXT = (
-    "[dim]Tip: add --help-json to any command for machine-readable help "
-    "(usage, options and a recursive index of subcommands) as JSON.[/]"
-)
+rc.FOOTER_TEXT = "[dim]Tip: add --help-json to any command for machine-readable help as JSON.[/]"
 
 
 # Set up rich stderr console

--- a/nf_core/cli_schema.py
+++ b/nf_core/cli_schema.py
@@ -1,0 +1,150 @@
+"""Machine-readable ``--help-json`` help/usage schema for the nf-core CLI.
+
+Adds a global ``--help-json`` flag (via :class:`JSONGroup` / :class:`JSONCommand`)
+that prints the *current* command's full help and usage as JSON, together with
+a recursive index of all subcommand names. This lets tools and LLMs discover
+the CLI one level at a time without parsing rendered ``--help`` text or pulling
+the entire command tree into context at once.
+
+A distinct ``--help-json`` name is used (rather than ``--json``) because several
+commands already define their own ``--json`` data-output flag.
+
+Usage::
+
+    nf-core --help-json                  # root: options + recursive name index
+    nf-core modules --help-json          # modules group and its subcommand names
+    nf-core pipelines schema validate --help-json   # full detail for a single command
+"""
+
+import json
+
+import rich_click as click
+from rich.errors import MarkupError
+from rich.text import Text
+
+
+def _strip_markup(text):
+    """Render Rich console markup (``[dim]``, ``\\[default: …]``, …) to plain text."""
+    if not text:
+        return text
+    try:
+        return Text.from_markup(text).plain.strip()
+    except MarkupError:
+        return text.strip()
+
+
+def _param_to_dict(param, ctx):
+    """Convert a Click Option/Argument into a compact, JSON-friendly dict."""
+    info = param.to_info_dict()
+    type_info = info.get("type") or {}
+    fields = {
+        "name": info.get("name"),
+        "kind": info.get("param_type_name"),  # "option" or "argument"
+        "opts": info.get("opts"),
+        "type": type_info.get("param_type"),
+        "choices": type_info.get("choices"),
+        "required": info.get("required") or None,
+        "is_flag": info.get("is_flag") or None,
+        "multiple": info.get("multiple") or None,
+        "help": _strip_markup(info.get("help")),
+    }
+    # Drop empty/false/None values to keep the output lean
+    result = {key: value for key, value in fields.items() if value not in (None, False, [], "")}
+    # Keep a real default (including 0 or "") for non-flag params; a flag's False default is implied
+    default = info.get("default")
+    if default is not None and not info.get("is_flag"):
+        result["default"] = default
+    return result
+
+
+def _subcommand_name_tree(group, ctx):
+    """Recursively map subcommand names to nested children (names only, no help text).
+
+    Leaf commands map to an empty dict; groups map to a dict of their children.
+    """
+    tree = {}
+    for name in group.list_commands(ctx):
+        sub = group.get_command(ctx, name)
+        if sub is None:
+            continue
+        if isinstance(sub, click.Group):
+            sub_ctx = click.Context(sub, info_name=name, parent=ctx)
+            tree[name] = _subcommand_name_tree(sub, sub_ctx)
+        else:
+            tree[name] = {}
+    return tree
+
+
+def _emit_json(ctx, param, value):
+    """Eager callback for the ``--help-json`` flag: print the schema and exit."""
+    if not value or ctx.resilient_parsing:
+        return
+    click.echo(json.dumps(command_schema(ctx.command, ctx), indent=2, default=str))
+    ctx.exit()
+
+
+# A single shared --help-json option, injected into every command and group below.
+JSON_OPTION = click.Option(
+    ["--help-json"],
+    is_flag=True,
+    is_eager=True,
+    expose_value=False,
+    callback=_emit_json,
+    help="Print this command's help/usage as JSON, with a recursive index of subcommand names.",
+)
+
+# Universal meta-options excluded from each command's reported parameters.
+_META_PARAMS = {"help", JSON_OPTION.name}
+
+
+def command_schema(cmd, ctx):
+    """Build the JSON schema for a single command level.
+
+    Includes the command's own help, usage and full parameter detail. For groups,
+    a ``subcommands`` key holds a recursive name-only index of all descendants.
+    """
+    schema = {
+        "name": cmd.name,
+        "path": ctx.command_path,
+        "help": _strip_markup(cmd.help),
+        "usage": " ".join([ctx.command_path, *cmd.collect_usage_pieces(ctx)]),
+        "params": [_param_to_dict(param, ctx) for param in cmd.get_params(ctx) if param.name not in _META_PARAMS],
+    }
+    aliases = getattr(cmd, "aliases", None)
+    if aliases:
+        schema["aliases"] = list(aliases)
+    if isinstance(cmd, click.Group):
+        schema["subcommands"] = _subcommand_name_tree(cmd, ctx)
+    return schema
+
+
+def _with_json_option(get_params):
+    """Wrap ``get_params`` so the shared ``--help-json`` option appears before ``--help``."""
+
+    def patched(self, ctx):
+        params = get_params(self, ctx)
+        # Place --help-json just before the trailing --help, without mutating the list
+        # returned by Click (which may be the command's own persistent params list).
+        return [*params[:-1], JSON_OPTION, *params[-1:]]
+
+    return patched
+
+
+class JSONCommand(click.RichCommand):
+    """A leaf command that exposes the ``--help-json`` schema flag."""
+
+    get_params = _with_json_option(click.RichCommand.get_params)
+
+
+class JSONGroup(click.RichGroup):
+    """A group that exposes ``--help-json`` and propagates these classes to children.
+
+    ``group_class = type`` tells Click that subgroups use this same class, and
+    ``command_class`` sets the class for leaf subcommands, so a single ``cls=``
+    on the root group is enough to add ``--help-json`` everywhere.
+    """
+
+    command_class = JSONCommand
+    group_class = type
+
+    get_params = _with_json_option(click.RichGroup.get_params)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ Most tests check the cli arguments are passed along and that some action is
 taken.
 """
 
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -67,6 +68,29 @@ class TestCli(unittest.TestCase):
         result = self.invoke_cli(["--help"])
         assert result.exit_code == 0
         assert "Show the version and exit." in result.output
+
+    def test_cli_help_json(self):
+        """Test the main launch function with --help-json returns the CLI schema as JSON"""
+        result = self.invoke_cli(["--help-json"])
+        assert result.exit_code == 0
+
+        schema = json.loads(result.output)
+
+        # Top-level command metadata
+        assert schema["name"] == "nf-core-cli"
+        assert schema["path"] == "nf-core-cli"
+        assert schema["usage"].startswith("nf-core-cli")
+
+        # The --verbose option should be reported, but the meta-options should be hidden
+        param_opts = [opt for param in schema["params"] for opt in param["opts"]]
+        assert "--verbose" in param_opts
+        assert "--help" not in param_opts
+        assert "--help-json" not in param_opts
+
+        # Subcommands are indexed recursively by name, with groups nesting their children
+        assert "subcommands" in schema
+        assert "pipelines" in schema["subcommands"]
+        assert "lint" in schema["subcommands"]["pipelines"]
 
     def test_cli_bad_subcommand(self):
         """Test the main launch function with an unrecognised argument"""


### PR DESCRIPTION
## Summary

Adds a global `--help-json` flag to every nf-core CLI command and group. It prints the current command's full help, usage and parameter detail as JSON, plus a recursive index of subcommand names, so LLMs and tooling can discover the entire CLI one level at a time. (Hat-tip to @awgymer for the idea!)

### How it works

- A small `nf_core/cli_schema.py` introspects the Click/`rich-click` command tree (`get_params` then `Param.to_info_dict()`, `list_commands`/`get_command`, `collect_usage_pieces`), with no `--help` text parsing.
- The flag is injected once via a `JSONGroup`/`JSONCommand` class pair on the root group. Because `rich-click`'s `group_class` is already `type`, a single `cls=` on the root propagates `--help-json` to all commands automatically, with no per-command boilerplate.
- A footer tip is added to every `--help` screen (via `rich_click`'s `FOOTER_TEXT`) so agents landing on the human help are pointed at the JSON flag.

### Design notes

- I originally wanted `--help --json` but the latter collided, so `--help-json` it is
- Progressive disclosure by design. The flag is contextual: it dumps the current command and a names-only index of descendants. Real usage stays cheap, with the root call around 540 tokens, a group around 140 to 310, and a leaf around 140. Agents drill down via subcommands rather than pulling everything at once.
- Eager flag, so `nf-core <any command> --help-json` works even when required arguments are missing (like `--help`).

## Examples

### Regular `--help` now advertises the flag (footer)

The tip is appended to every help screen:

<img width="1604" height="470" alt="CleanShot 2026-05-29 at 10 32 27@2x" src="https://github.com/user-attachments/assets/f7ab94f1-7763-4088-952b-08b20b568b9e" />


<details>
<summary><code>nf-core --help-json</code>: root top-level options plus recursive name index of the whole CLI</summary>

```json
{
  "name": "nf-core-cli",
  "path": "nf-core",
  "help": "nf-core/tools provides a set of helper tools for use with nf-core Nextflow pipelines.\n\nIt is designed for both end-users running pipelines and also developers creating new pipelines.",
  "usage": "nf-core [OPTIONS] COMMAND [ARGS]...",
  "params": [
    { "name": "version", "kind": "option", "opts": ["--version"], "type": "Bool", "is_flag": true, "help": "Show the version and exit." },
    { "name": "verbose", "kind": "option", "opts": ["-v", "--verbose"], "type": "Bool", "is_flag": true, "help": "Print verbose output to the console." },
    { "name": "hide_progress", "kind": "option", "opts": ["--hide-progress"], "type": "Bool", "is_flag": true, "help": "Don't show progress bars." },
    { "name": "log_file", "kind": "option", "opts": ["-l", "--log-file"], "type": "String", "help": "Save a verbose log to a file." }
  ],
  "subcommands": {
    "interface": {},
    "modules": {
      "bump-versions": {}, "create": {}, "info": {}, "install": {}, "lint": {},
      "list": { "local": {}, "remote": {} },
      "patch": {}, "remove": {}, "test": {}, "update": {}
    },
    "pipelines": {
      "bump-version": {}, "create": {}, "create-logo": {}, "create-params-file": {},
      "download": {}, "launch": {}, "lint": {}, "list": {}, "rocrate": {},
      "schema": { "build": {}, "docs": {}, "lint": {}, "validate": {} },
      "sync": {}
    },
    "subworkflows": {
      "create": {}, "info": {}, "install": {}, "lint": {},
      "list": { "local": {}, "remote": {} },
      "patch": {}, "remove": {}, "test": {}, "update": {}
    },
    "test-datasets": { "list": {}, "list-branches": {}, "search": {} }
  }
}
```

</details>

<details>
<summary><code>nf-core modules --help-json</code>: a group, its own options, aliases, and immediate subcommand index</summary>

```json
{
  "name": "modules",
  "path": "nf-core modules",
  "help": "Commands to manage Nextflow DSL2 modules (tool wrappers).",
  "usage": "nf-core modules [OPTIONS] COMMAND [ARGS]...",
  "params": [
    { "name": "git_remote", "kind": "option", "opts": ["-g", "--git-remote"], "type": "String", "help": "Remote git repo to fetch files from", "default": "https://github.com/nf-core/modules.git" },
    { "name": "branch", "kind": "option", "opts": ["-b", "--branch"], "type": "String", "help": "Branch of git repository hosting modules." },
    { "name": "no_pull", "kind": "option", "opts": ["-N", "--no-pull"], "type": "Bool", "is_flag": true, "help": "Do not pull in latest changes to local clone of modules repository." }
  ],
  "aliases": ["m", "module"],
  "subcommands": {
    "bump-versions": {}, "create": {}, "info": {}, "install": {}, "lint": {},
    "list": { "local": {}, "remote": {} },
    "patch": {}, "remove": {}, "test": {}, "update": {}
  }
}
```

</details>

<details>
<summary><code>nf-core pipelines schema validate --help-json</code>: a leaf command, full options plus positional arguments</summary>

```json
{
  "name": "validate",
  "path": "nf-core pipelines schema validate",
  "help": "Validate a set of parameters against a pipeline schema.",
  "usage": "nf-core pipelines schema validate [OPTIONS] <pipeline name> <JSON params file>",
  "params": [
    { "name": "directory", "kind": "option", "opts": ["-d", "--dir"], "type": "Path", "help": "Pipeline directory. [default: current working directory]", "default": "." },
    { "name": "pipeline", "kind": "argument", "opts": ["pipeline"], "type": "String" },
    { "name": "params", "kind": "argument", "opts": ["params"], "type": "Path", "required": true }
  ]
}
```

</details>

## Notes

- All 21 existing `tests/test_cli.py` tests pass.
- I noticed a pre-existing `UserWarning: The parameter -b is used more than once` (a duplicate `-b` short flag around `modules`/`bump-version`) surfaced while introspecting the tree. This is unrelated to this PR, but worth a follow-up fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
