### PR TITLE
Fix duplicate `-b` short flag in `pipelines sync`

### DIFF
--- a/nf_core/__main__.py
+++ b/nf_core/__main__.py
@@ -630,7 +630,7 @@ def rocrate(
 @click.option("-g", "--github-repository", type=str, help="GitHub PR: target repository.")
 @click.option("-u", "--username", type=str, help="GitHub PR: auth username.")
 @click.option("-t", "--template-yaml", help="Pass a YAML file to customize the template")
-@click.option("-b", "--blog-post", type=str, help="Link to the blog post")
+@click.option("--blog-post", type=str, help="Link to the blog post")
 @click.option("-n", "--no-prompts", is_flag=True, default=False, help="Run without prompting for user input")
 def command_pipelines_sync(
     ctx,


### PR DESCRIPTION
## Summary

Fixes a pre-existing `UserWarning: The parameter -b is used more than once` emitted on startup.

`nf-core pipelines sync` assigned the `-b` short flag to two different options:

- `-b`, `--from-branch`
- `-b`, `--blog-post`

This made `-b` ambiguous and triggered the warning whenever the CLI was loaded.

## Fix

Drop `-b` from `--blog-post` (now long-form only), keeping `-b` for `--from-branch`. This matches the `-b`/branch convention used elsewhere in the CLI (for example `test-datasets ... --branch`).


🤖 Generated with [Claude Code](https://claude.com/claude-code)
