### PR TITLE
Update nf-core/tools docs link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ Note: The `--config` flag is important in this repository to ensure prek uses th
 ## API Documentation
 
 We aim to write function docstrings according to the [Google Python style-guide](https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings). These are used to automatically generate package documentation on the nf-core website using Sphinx.
-You can find this documentation here: [https://nf-co.re/tools/docs/](https://nf-co.re/tools/docs/)
+You can find this documentation here: [nf-core tools Python API docs](https://nf-co.re/docs/nf-core-tools/api_reference/latest/).
 
 If you would like to test the documentation, you can install Sphinx locally by following Sphinx's [installation instruction](https://www.sphinx-doc.org/en/master/usage/installation.html).
 Once done, you can run `make clean` and then `make html` in the `docs/api` directory of `nf-core tools`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 A python package with helper tools for the nf-core community.
 
 The nf-core tools package is written in Python and can be imported and used within other packages.
-For documentation of the internal Python functions, please refer to the [Tools Python API docs](https://nf-co.re/tools/docs/).
+For documentation of the internal Python functions, please refer to the [nf-core tools Python API docs](https://nf-co.re/docs/nf-core-tools/api_reference/latest/).
 
 ## Installation
 

--- a/nf_core/commands_pipelines.py
+++ b/nf_core/commands_pipelines.py
@@ -120,7 +120,7 @@ def pipelines_lint(
 
     Runs a large number of automated tests to ensure that the supplied pipeline
     meets the nf-core guidelines. Documentation of all lint tests can be found
-    on the nf-core website: [link=https://nf-co.re/tools/docs/]https://nf-co.re/tools/docs/[/]
+    on the nf-core website: [link=https://nf-co.re/docs/nf-core-tools/api_reference/latest/]https://nf-co.re/docs/nf-core-tools/api_reference/latest/[/]
 
     You can ignore tests using a file called [blue].nf-core.yml[/] [i](if you have a good reason!)[/].
     See the documentation for details.

--- a/nf_core/pipelines/lint/__init__.py
+++ b/nf_core/pipelines/lint/__init__.py
@@ -328,7 +328,9 @@ class PipelineLint(nf_core.utils.Pipeline):
             if "dev" in __version__:
                 tools_version = "dev"
             for eid, msg in test_results:
-                yield Markdown(f"[{eid}](https://nf-co.re/tools/docs/{tools_version}/pipeline_lint_tests/{eid}): {msg}")
+                yield Markdown(
+                    f"[{eid}](https://nf-co.re/docs/nf-core-tools/api_reference/{tools_version}/pipeline_lint_tests/{eid}): {msg}"
+                )
 
         # Table of passed tests
         if len(self.passed) > 0 and show_passed:
@@ -429,7 +431,7 @@ class PipelineLint(nf_core.utils.Pipeline):
             test_failures = "### :x: Test failures:\n\n{}\n\n".format(
                 "\n".join(
                     [
-                        f"* [{eid}](https://nf-co.re/tools/docs/{tools_version}/pipeline_lint_tests/{eid}) - "
+                        f"* [{eid}](https://nf-co.re/docs/nf-core-tools/api_reference/{tools_version}/pipeline_lint_tests/{eid}) - "
                         f"{strip_ansi_codes(msg, '`')}"
                         for eid, msg in self.failed
                     ]
@@ -443,7 +445,7 @@ class PipelineLint(nf_core.utils.Pipeline):
             test_ignored = "### :grey_question: Tests ignored:\n\n{}\n\n".format(
                 "\n".join(
                     [
-                        f"* [{eid}](https://nf-co.re/tools/docs/{tools_version}/pipeline_lint_tests/{eid}) - "
+                        f"* [{eid}](https://nf-co.re/docs/nf-core-tools/api_reference/{tools_version}/pipeline_lint_tests/{eid}) - "
                         f"{strip_ansi_codes(msg, '`')}"
                         for eid, msg in self.ignored
                     ]
@@ -457,7 +459,7 @@ class PipelineLint(nf_core.utils.Pipeline):
             test_fixed = "### :grey_question: Tests fixed:\n\n{}\n\n".format(
                 "\n".join(
                     [
-                        f"* [{eid}](https://nf-co.re/tools/docs/{tools_version}/pipeline_lint_tests/{eid}) - "
+                        f"* [{eid}](https://nf-co.re/docs/nf-core-tools/api_reference/{tools_version}/pipeline_lint_tests/{eid}) - "
                         f"{strip_ansi_codes(msg, '`')}"
                         for eid, msg in self.fixed
                     ]
@@ -471,7 +473,7 @@ class PipelineLint(nf_core.utils.Pipeline):
             test_warnings = "### :heavy_exclamation_mark: Test warnings:\n\n{}\n\n".format(
                 "\n".join(
                     [
-                        f"* [{eid}](https://nf-co.re/tools/docs/{tools_version}/pipeline_lint_tests/{eid}) - "
+                        f"* [{eid}](https://nf-co.re/docs/nf-core-tools/api_reference/{tools_version}/pipeline_lint_tests/{eid}) - "
                         f"{strip_ansi_codes(msg, '`')}"
                         for eid, msg in self.warned
                     ]
@@ -486,7 +488,7 @@ class PipelineLint(nf_core.utils.Pipeline):
                 "\n".join(
                     [
                         (
-                            f"* [{eid}](https://nf-co.re/tools/docs/{tools_version}/pipeline_lint_tests/{eid})"
+                            f"* [{eid}](https://nf-co.re/docs/nf-core-tools/api_reference/{tools_version}/pipeline_lint_tests/{eid})"
                             f" - {strip_ansi_codes(msg, '`')}"
                         )
                         for eid, msg in self.passed

--- a/nf_core/pipelines/lint_utils.py
+++ b/nf_core/pipelines/lint_utils.py
@@ -49,7 +49,7 @@ def print_results_plain_text(results_list, directory=None, component_type=None):
                     # Pipeline results: (eid, msg)
                     eid, msg = r
                     console.print(
-                        f"\n[{color}]{eid}[/{color}] https://nf-co.re/tools/docs/{tools_version}/pipeline_lint_tests/{eid}"
+                        f"\n[{color}]{eid}[/{color}] https://nf-co.re/docs/nf-core-tools/api_reference/{tools_version}/pipeline_lint_tests/{eid}"
                     )
                     print_lines(msg, strip_ansi=True)
                 else:


### PR DESCRIPTION
Closes #3489
I am interested in contributing to this environment, and I took a `good-first-issue` to go through your PR process once before looking into other issues.

# Description
Updates all references to the nf-core tools docs away from the old URL structure. There are two different cases in the code base.

In the different markdown files, the previous URL led to a redirect that was visible to the user.
```diff
- https://nf-co.re/tools/docs/
+ https://nf-co.re/docs/nf-core-tools/api_reference/latest/
```

For the different URLs generated by the `nf-core pipelines lint` command, they were able to resolve using the old format, but when navigating to the same page using any links, they would resolve to the new format.
```diff
- https://nf-co.re/tools/docs/{VERSION}/pipeline_lint_tests/{ID}
+ https://nf-co.re/docs/nf-core-tools/api_reference/{VERSION}/pipeline_lint_tests/{ID}
```