### PR TITLE
drop `ext.when` in module template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - accept `process_low_memory` as a standard module label ([#4264](https://github.com/nf-core/tools/pull/4264))
 - improve linting for `modules.json` to add support for only installing subworkflows from a repository and provide more explicit error messages ([#4287](https://github.com/nf-core/tools/pull/4287))
+- Replace `ext.when` linting to disallow use ([#4314](https://github.com/nf-core/tools/pull/4314))
 
 ### Modules
 

--- a/nf_core/module-template/main.nf
+++ b/nf_core/module-template/main.nf
@@ -72,9 +72,6 @@ process {{ component_name_underscore|upper }} {
     {%- endif %}
     tuple val("${task.process}"), val('{{ component }}'), eval("{{ component }} --version"), topic: versions, emit: versions_{{ component }}
 
-    when:
-    task.ext.when == null || task.ext.when
-
     script:
     def args = task.ext.args ?: ''
     {% if has_meta -%}

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -341,22 +341,33 @@ def check_script_section(self, lines):
 
 def check_when_section(self, lines):
     """
-    Lint the when: section
-    Checks whether the line is modified from 'task.ext.when == null || task.ext.when'
+    Lint the when: section.
+
+    The module template no longer allows `task.ext.when` in `when:` blocks.
     """
     if len(lines) == 0:
-        self.failed.append(("main_nf", "when_exist", "when: condition has been removed", self.main_nf))
-        return
-    if len(lines) > 1:
-        self.failed.append(("main_nf", "when_exist", "when: condition has too many lines", self.main_nf))
+        self.passed.append(("main_nf", "when_exist", "No when: condition found", self.main_nf))
         return
     self.passed.append(("main_nf", "when_exist", "when: condition is present", self.main_nf))
 
-    # Check the condition hasn't been changed.
-    if lines[0].strip() != "task.ext.when == null || task.ext.when":
-        self.failed.append(("main_nf", "when_condition", "when: condition has been altered", self.main_nf))
+    if any("task.ext.when" in line for line in lines):
+        self.failed.append(
+            (
+                "main_nf",
+                "when_condition",
+                "task.ext.when is no longer allowed in when: condition",
+                self.main_nf,
+            )
+        )
         return
-    self.passed.append(("main_nf", "when_condition", "when: condition is unchanged", self.main_nf))
+    self.passed.append(
+        (
+            "main_nf",
+            "when_condition",
+            "when: condition does not use task.ext.when",
+            self.main_nf,
+        )
+    )
 
 
 def check_process_section(self, lines, registry, fix_version, progress_bar):

--- a/tests/modules/lint/test_main_nf.py
+++ b/tests/modules/lint/test_main_nf.py
@@ -7,6 +7,7 @@ from nf_core.modules.lint.main_nf import (
     check_container_link_line,
     check_process_labels,
     check_script_section,
+    check_when_section,
 )
 
 from ...test_modules import TestModules
@@ -99,6 +100,26 @@ def test_container_links(content, passed, warned, failed):
     assert len(mock_lint.passed) == passed
     assert len(mock_lint.warned) == warned
     assert len(mock_lint.failed) == failed
+
+
+def test_when_section_rejects_task_ext_when():
+    """Test that task.ext.when in a when: block fails linting"""
+    mock_lint = MockModuleLint()
+
+    check_when_section(mock_lint, ["task.ext.when == null || task.ext.when"])
+
+    assert len(mock_lint.failed) == 1
+    assert "task.ext.when" in mock_lint.failed[0][2]
+
+
+def test_when_section_allows_missing_when_block():
+    """Test that modules without a when: block pass this lint"""
+    mock_lint = MockModuleLint()
+
+    check_when_section(mock_lint, [])
+
+    assert len(mock_lint.failed) == 0
+    assert any("No when: condition found" in message for _, _, message, _ in mock_lint.passed)
 
 
 class TestMainNfLinting(TestModules):


### PR DESCRIPTION
Drop `ext.when` usage in modules

xref: https://nfcore.slack.com/archives/C043UU89KKQ/p1780568879209299

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/main/.github/CONTRIBUTING.md
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
