### PR TITLE
Fix nf-core pipelines schema docs Markdown line breaks issue with stdout redirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Update pre-commit hook pre-commit/mirrors-mypy to v2 ([#4270](https://github.com/nf-core/tools/pull/4270))
 - container configs: use correct key for conda configs ([#4269](https://github.com/nf-core/tools/pull/4269))
+- generate valid Markdown when piping schema docs to file ([#4319](https://github.com/nf-core/tools/pull/4319))
 
 ### Linting
 

--- a/nf_core/pipelines/schema.py
+++ b/nf_core/pipelines/schema.py
@@ -580,7 +580,10 @@ class PipelineSchema:
 
         if not output_fn:
             console = rich.console.Console()
-            console.print("\n", Syntax(prettified_docs, output_format, word_wrap=True), "\n")
+            if console.is_terminal:
+                console.print("\n", Syntax(prettified_docs, output_format, word_wrap=True), "\n")
+            else:
+                print(prettified_docs, end="")
         else:
             if Path(output_fn).exists() and not force:
                 log.error(f"File '{output_fn}' exists! Please delete first, or use '--force'")

--- a/nf_core/pipelines/schema.py
+++ b/nf_core/pipelines/schema.py
@@ -566,7 +566,7 @@ class PipelineSchema:
         Prints documentation for the schema.
         """
         if columns is None:
-            columns = ["parameter", "description", "type,", "default", "required", "hidden"]
+            columns = ["parameter", "description", "type", "default", "required", "hidden"]
 
         output = self.schema_to_markdown(columns)
         if output_format == "html":

--- a/tests/pipelines/test_schema.py
+++ b/tests/pipelines/test_schema.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from io import StringIO
 from pathlib import Path
 from unittest import mock
 
@@ -129,6 +130,27 @@ class TestSchema(unittest.TestCase):
         for definition in self.schema_obj.schema.get("$defs", {}).values():
             assert definition["title"] in docs
             assert definition["description"] in docs
+
+    def test_schema_docs_markdown_linebreak(self):
+        """Check that Markdown docs linebreak only happens in a terminal"""
+        self.schema_obj.schema_filename = self.template_schema
+        self.schema_obj.load_schema()
+
+        with (
+            mock.patch("rich.console.Console.is_terminal", new_callable=mock.PropertyMock, return_value=False),
+            mock.patch("sys.stdout", new_callable=StringIO) as mock_stdout,
+        ):
+            self.schema_obj.print_documentation()
+            docs = mock_stdout.getvalue()
+
+        with (
+            mock.patch("rich.console.Console.is_terminal", new_callable=mock.PropertyMock, return_value=True),
+            mock.patch("sys.stdout", new_callable=StringIO) as mock_stdout,
+        ):
+            self.schema_obj.print_documentation()
+            docs_tty = mock_stdout.getvalue()
+
+        assert docs_tty.count("\n") > docs.count("\n")
 
     @with_temporary_file
     def test_save_schema(self, tmp_file):

--- a/tests/pipelines/test_schema.py
+++ b/tests/pipelines/test_schema.py
@@ -131,7 +131,8 @@ class TestSchema(unittest.TestCase):
             assert definition["title"] in docs
             assert definition["description"] in docs
 
-    def test_schema_docs_markdown_linebreak(self):
+    @with_temporary_file
+    def test_schema_docs_markdown_linebreak(self, tmp_file):
         """Check that Markdown docs linebreak only happens in a terminal"""
         self.schema_obj.schema_filename = self.template_schema
         self.schema_obj.load_schema()
@@ -150,7 +151,11 @@ class TestSchema(unittest.TestCase):
             self.schema_obj.print_documentation()
             docs_tty = mock_stdout.getvalue()
 
+        self.schema_obj.print_documentation(output_fn=tmp_file.name, force=True)
+        tmp_file.seek(0)
+
         assert docs_tty.count("\n") > docs.count("\n")
+        assert tmp_file.read().decode() == docs
 
     @with_temporary_file
     def test_save_schema(self, tmp_file):


### PR DESCRIPTION
Closes #4291

## Problem
The original bug report complained about a generated Markdown file where superfluous line breaks rendered the tables unreadable. The only way that I was able to recreate the bug was by redirecting the output to a file

:x: wrangled Markdown
```bash
nf-core pipelines schema docs > parameters.md
```

Meanwhile, using the cli options to specify an output file generates a well constructed Markdown file.

:white_check_mark: valid Markdown
```bash
nf-core pipelines schema docs --output parameters.md
````

Whilst there is a clean CLI way to obtain the desired file, redirecting the output of a command should result in a valid output file.

## Fix
I relied on `rich.console.Console.is_terminal` to determine if the output is being redirected, and skipped the rich/Syntax processing when it is. A test has been added to verify the difference in line breaks between the context. The test is also asserting that the file generated by redirecting is the same as with the `--output` flag.