### PR TITLE
Fix order-dependent bug in ROCrate manifest.contributors parsing

### DIFF
--- a/nf_core/pipelines/rocrate.py
+++ b/nf_core/pipelines/rocrate.py
@@ -408,7 +408,9 @@ class ROCrate:
             # All dictionary keys need to be quoted
             contributors_str = contributors_str.replace(f"{key}:", f'"{key}":')
         # Use curly brackets for dictionaries
-        contributors_str = contributors_str.replace("], [", "}, {").replace("[[", "[{").replace("]]", "}]")
+        contributors_str = (
+            contributors_str.replace("], [", "}, {").replace("]]]", "]}]").replace("[[", "[{").replace("]]", "}]")
+        )
         log.debug(f"manifest.contributors (normalised): {contributors_str}")
         try:
             contributors = json.loads(contributors_str)

--- a/tests/pipelines/test_rocrate.py
+++ b/tests/pipelines/test_rocrate.py
@@ -331,8 +331,8 @@ class TestROCrate(TestPipelines):
                     affiliation: '',
                     email: '',
                     github: '',
-                    contribution: ['contributor'],
-                    orcid: ''
+                    orcid: '',
+                    contribution: ['contributor']
                 ]
             ]
             """


### PR DESCRIPTION
Closes #4289

The issue describes a bug in the bespoke Groovy-to-JSON conversion used during RO-Crate generation. The bug depends on the ordering of elements in `nextflow.config.manifest`. To reproduce it, I extended an existing test case by changing the order of the contributor entries.

While a proper Groovy parser would be a more robust solution, there is already a `TODO` indicating that this conversion logic will be replaced in the near future. As a targeted fix, I added an additional `replace()` operation to handle the triple-square-bracket case before the existing double-bracket replacement is applied.

Based on my understanding of the data entires permitted in the `manifest`, this should address the reported issue without introducing additional complexity. I am not aware of any other edge cases that would justify implementing a more complete parser at this stage.