### PR TITLE
fix: relax stub .gz linting regex to accept echo without arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,4 @@ If you use `nf-core tools` in your work, please cite the `nf-core` publication a
 > Philip Ewels, Alexander Peltzer, Sven Fillinger, Harshil Patel, Johannes Alneberg, Andreas Wilm, Maxime Ulysse Garcia, Paolo Di Tommaso & Sven Nahnsen.
 >
 > _Nat Biotechnol._ 2020 Feb 13. doi: [10.1038/s41587-020-0439-x](https://dx.doi.org/10.1038/s41587-020-0439-x).
+

--- a/nf_core/modules/lint/module_tests.py
+++ b/nf_core/modules/lint/module_tests.py
@@ -329,8 +329,8 @@ def _check_stub_gzip_syntax(module: NFCoreComponent):
             if not line or line.startswith(("//", "#")):
                 continue
 
-            # The ONLY valid pattern is: echo "" | gzip > file.gz
-            valid_pattern = r'echo\s+""\s*\|\s*gzip\s*>\s*.*\.gz$'
+            # Valid patterns: echo "" | gzip >, echo '' | gzip >, or echo | gzip >
+            valid_pattern = r'''echo(?:\s+(?:""|''))?\s*\|\s*gzip\s*>\s*.*\.gz$'''
 
             if not re.search(valid_pattern, line):
                 invalid_gz_patterns.append(line.strip())


### PR DESCRIPTION
## Summary

Fixes #4231 by relaxing the stub .gz linting regex to make the echo argument optional.

## Changes

- Updated the stub .gz linting regex to accept `echo`, `echo ''`, and `echo ""` as valid arguments before piping to gzip.
- Previously only `echo ""` was accepted; `echo | gzip >` now also passes lint.

## Tests

Verified that existing valid patterns continue to pass and that invalid syntax (touch, non-empty echo strings) is still correctly flagged.

## Risk

Low. The change only broadens an existing regex match — it does not affect any other lint rule or module behavior.