### PR TITLE
fix: correct always-true lint condition and template doc typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - add `process_low_memory` resource label to `base.config` ([#4264](https://github.com/nf-core/tools/pull/4264))
 - fix dead link ([#4307](https://github.com/nf-core/tools/pull/4307))
 - remove date placeholder from changelog title ([#4333](https://github.com/nf-core/tools/pull/4333))
+- correct always-true `nf-core pipelines lint` condition in the linting workflow and fix doc typos (broken `#lint-tests` anchor, duplicate word, stray code-span space) ([#XXXX](https://github.com/nf-core/tools/pull/XXXX))
 
 #### Version updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - add `process_low_memory` resource label to `base.config` ([#4264](https://github.com/nf-core/tools/pull/4264))
 - fix dead link ([#4307](https://github.com/nf-core/tools/pull/4307))
 - remove date placeholder from changelog title ([#4333](https://github.com/nf-core/tools/pull/4333))
-- correct always-true `nf-core pipelines lint` condition in the linting workflow and fix doc typos (broken `#lint-tests` anchor, duplicate word, stray code-span space) ([#XXXX](https://github.com/nf-core/tools/pull/XXXX))
+- correct always-true `nf-core pipelines lint` condition in the linting workflow and fix doc typos (broken `#lint-tests` anchor, duplicate word, stray code-span space) ([#4324](https://github.com/nf-core/tools/pull/4324))
 
 #### Version updates
 

--- a/nf_core/pipeline-template/.github/workflows/linting.yml
+++ b/nf_core/pipeline-template/.github/workflows/linting.yml
@@ -46,7 +46,7 @@ jobs:
         run: uv tool install nf-core==${{ steps.read_yml.outputs['nf_core_version'] }}
 
       - name: Run nf-core pipelines lint
-        if: ${{ github.base_ref != 'master' || github.base_ref != 'main' }}
+        if: ${{ github.base_ref != 'master' && github.base_ref != 'main' }}
         env:
           GITHUB_COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/nf_core/pipeline-template/docs/CONTRIBUTING.md
+++ b/nf_core/pipeline-template/docs/CONTRIBUTING.md
@@ -144,7 +144,7 @@ Please also refer to the [pipeline-specific contribution guidelines](#pipeline-s
 - [ ] Perform local tests to validate that the new code works as expected.
   - [ ] If applicable, add a new test in the `tests` directory.
 - [ ] Update `usage.md`, `output.md`, and `citation.md` as appropriate.
-- [ ] [Lint](lint) the code with nf-core/tools.
+- [ ] [Lint](#lint-tests) the code with nf-core/tools.
 - [ ] Update any diagrams or pipeline images as necessary.
       {%- if multiqc %}
 - [ ] Update MultiQC config `assets/multiqc_config.yml` so relevant suffixes, file name cleanup, and module plots are in the appropriate order.
@@ -184,7 +184,7 @@ Specify these with generic `withLabel:` selectors, so they can be shared across 
 nf-core provides a set of standard labels that you should follow where possible, as seen in the [nf-core pipeline template](https://github.com/nf-core/tools/blob/main/nf_core/pipeline-template/conf/base.config).
 These labels define resource defaults for single-core processes, modules that require a GPU, and different levels of multi-core configurations with increasing memory requirements.
 
-Values assigned within these labels can be dynamically passed to a tool using the the `${task.cpus}` and `${task.memory}` Nextflow variables in the `script:` block of a module (see an example in the [modules repository](https://github.com/nf-core/modules/blob/bd1b6a40f55933d94b8c9ca94ec8c1ea0eaf4b82/modules/nf-core/samtools/bam2fq/main.nf#L30)).
+Values assigned within these labels can be dynamically passed to a tool using the `${task.cpus}` and `${task.memory}` Nextflow variables in the `script:` block of a module (see an example in the [modules repository](https://github.com/nf-core/modules/blob/bd1b6a40f55933d94b8c9ca94ec8c1ea0eaf4b82/modules/nf-core/samtools/bam2fq/main.nf#L30)).
 
 #### Nextflow version bumping
 

--- a/nf_core/pipeline-template/docs/usage.md
+++ b/nf_core/pipeline-template/docs/usage.md
@@ -165,7 +165,7 @@ If `-profile` is not specified, the pipeline will run locally and expect all sof
 - `apptainer`
   - A generic configuration profile to be used with [Apptainer](https://apptainer.org/)
 - `wave`
-  - A generic configuration profile to enable [Wave](https://seqera.io/wave/) containers. Use together with one of the above (requires Nextflow ` 24.03.0-edge` or later).
+  - A generic configuration profile to enable [Wave](https://seqera.io/wave/) containers. Use together with one of the above (requires Nextflow `24.03.0-edge` or later).
 - `conda`
   - A generic configuration profile to be used with [Conda](https://conda.io/docs/). Please only use Conda as a last resort i.e. when it's not possible to run the pipeline with Docker, Singularity, Podman, Shifter, Charliecloud, or Apptainer.
 


### PR DESCRIPTION
## Description

Small template fixes discovered while syncing a fastquourm to the 4.0.2 template. https://github.com/nf-core/fastquorum/pull/150

- **`.github/workflows/linting.yml`** — the non-release lint step guarded on `if: ${{ github.base_ref != 'master' || github.base_ref != 'main' }}`, which is **always true** (a value cannot equal both `master` and `main`, so at least one `!=` always holds). As a result the non-release `nf-core pipelines lint` step also ran on release PRs to `main`/`master`, alongside the `--release` step. Changed to `&&` so it runs only when the base is neither.
- **`docs/CONTRIBUTING.md`** — fixed the broken `[Lint](lint)` checklist link to `[Lint](#lint-tests)` (the correct anchor, already used by the matching item earlier in the same file); removed a duplicate "the the".
- **`docs/usage.md`** — removed a stray leading space inside the Wave Nextflow-version code span (`` ` 24.03.0-edge` `` → `` `24.03.0-edge` ``).

No lint-rule logic or template structure changed; these are a CI-condition correctness fix and doc typo fixes.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] Documentation in `docs` is updated
