### PR TITLE
feat: module lint for module name granularity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Modules
 
 - `modules info`: handle one element channels correctly ([#4268](https://github.com/nf-core/tools/pull/4268))
+- feat: module lint for module name granularity ([#4325](https://github.com/nf-core/tools/pull/4325))
 
 ### Subworkflows
 

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -29,6 +29,10 @@ def main_nf(
 
     The following checks are performed:
 
+    * ``main_nf_module_granularity``: The module must represent a single command
+      as ``<tool>`` or single subcommand with distinct functionality as
+      ``<tool/subtool>``.
+
     * ``main_nf_exists``: The ``main.nf`` file must exist.
 
     * ``deprecated_dsl2``: The file must not contain deprecated DSL2 identifiers
@@ -63,6 +67,9 @@ def main_nf(
     inputs: list[str] = []
     emits: list[str] = []
     topics: list[str] = []
+
+    # Check the module name granularity
+    check_nf_module_name_modularity(module, module.component_name)
 
     # Check if we have a patch file affecting the 'main.nf' file
     # otherwise read the lines directly from the module
@@ -270,6 +277,23 @@ def main_nf(
             )
 
     return inputs, emits
+
+
+def check_nf_module_name_modularity(self, component_name):
+    """
+    Lint the module granularity
+    Checks whether the module name has at most two levels of granularity.
+    """
+    if component_name.count("/") > 1:
+        self.failed.append(
+            ("main_nf", "main_nf_module_granularity", "Module not named as `<tool>` or `<tool/subtool>`", self.main_nf)
+        )
+    elif component_name.count("/") == 1:
+        self.passed.append(
+            ("main_nf", "main_nf_module_granularity", "Module properly named as `<tool/subtool>`", self.main_nf)
+        )
+    else:
+        self.passed.append(("main_nf", "main_nf_module_granularity", "Module properly named as `<tool>`", self.main_nf))
 
 
 def check_script_section(self, lines):

--- a/tests/modules/lint/test_main_nf.py
+++ b/tests/modules/lint/test_main_nf.py
@@ -8,6 +8,7 @@ from nf_core.components.nfcore_component import NFCoreComponent
 from nf_core.modules.lint.main_nf import (
     _parse_output_topics,
     check_container_link_line,
+    check_nf_module_name_modularity,
     check_process_labels,
     check_process_section,
     check_script_section,
@@ -16,6 +17,27 @@ from nf_core.modules.lint.main_nf import (
 from ...test_modules import TestModules
 from ...utils import GITLAB_NFTEST_BRANCH, GITLAB_URL
 from .test_lint_utils import MockModuleLint
+
+
+@pytest.mark.parametrize(
+    "content,passed,warned,failed",
+    [
+        # Valid module <tool> name
+        ("tar", 1, 0, 0),
+        # Valid module <tool/subtool> name
+        ("tabix/tabix", 1, 0, 0),
+        # Invalid module <tool/subtool/subtool> name
+        ("aws/s3/ls", 0, 0, 1),
+    ],
+)
+def test_module_name_granularity(content, passed, warned, failed):
+    """Test module name granularity"""
+    mock_lint = MockModuleLint()
+    check_nf_module_name_modularity(mock_lint, content)
+
+    assert len(mock_lint.passed) == passed
+    assert len(mock_lint.warned) == warned
+    assert len(mock_lint.failed) == failed
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #4235

This linting relies on an inspection of the `NFCoreComponent.component_name`, using the same logic as `ComponentCreate._collect_name_prompt`, which is invoked when modules are created using `nf-core modules create`.

The `component_name` origin itself is not tested since it is derived from the directory structure by `ModulesJSON.get_component_names_from_repo`.