### PR TITLE
feat: adding lint rule for module process name

### DIFF
--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -412,11 +412,8 @@ def check_process_section(
     bioconda_packages = []
     allowed_registries = registry
 
-    # Process name should be all capital letters
-    if all(x.upper() for x in self.process_name):
-        self.passed.append(("main_nf", "process_capitals", "Process name is in capital letters", self.main_nf))
-    else:
-        self.failed.append(("main_nf", "process_capitals", "Process name is not in capital letters", self.main_nf))
+    # Check that the process name is correctly formated from the component name
+    check_process_name_format(self, self.process_name, self.component_name)
 
     # Check that process labels are correct
     check_process_labels(self, lines)
@@ -639,6 +636,27 @@ def check_process_section(
         return None
     else:
         return docker_tag == singularity_tag
+
+
+def check_process_name_format(self, process_name, component_name):
+    """
+    Lint the process name
+    Checks that the process name in the module file all is uppercase and derived
+    from the software and tool name separated by an underscore.
+    """
+    # Process name should be all capital letters
+    if process_name.isupper():
+        self.passed.append(("main_nf", "process_capitals", "Process name is in capital letters", self.main_nf))
+    else:
+        self.failed.append(("main_nf", "process_capitals", "Process name is not in capital letters", self.main_nf))
+
+    # Process name should be made from the module name
+    if component_name.upper().replace("-", "").replace("/", "_") == process_name:
+        self.passed.append(("main_nf", "module_process_name", "Process name is derived from module name", self.main_nf))
+    else:
+        self.failed.append(
+            ("main_nf", "module_process_name", "Process name is not derived from module name", self.main_nf)
+        )
 
 
 def check_process_labels(self, lines):

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -641,7 +641,7 @@ def check_process_section(
 def check_process_name_format(self, process_name, component_name):
     """
     Lint the process name
-    Checks that the process name in the module file all is uppercase and derived
+    Checks that the process name in the module file is uppercase and derived
     from the software and tool name separated by an underscore.
     """
     # Process name should be all capital letters
@@ -651,7 +651,7 @@ def check_process_name_format(self, process_name, component_name):
         self.failed.append(("main_nf", "process_capitals", "Process name is not in capital letters", self.main_nf))
 
     # Process name should be made from the module name
-    if component_name.upper().replace("-", "").replace("/", "_") == process_name:
+    if component_name.upper().replace("/", "_") == process_name:
         self.passed.append(("main_nf", "module_process_name", "Process name is derived from module name", self.main_nf))
     else:
         self.failed.append(

--- a/tests/modules/lint/test_main_nf.py
+++ b/tests/modules/lint/test_main_nf.py
@@ -10,6 +10,7 @@ from nf_core.modules.lint.main_nf import (
     check_container_link_line,
     check_nf_module_name_modularity,
     check_process_labels,
+    check_process_name_format,
     check_process_section,
     check_script_section,
 )
@@ -34,6 +35,29 @@ def test_module_name_granularity(content, passed, warned, failed):
     """Test module name granularity"""
     mock_lint = MockModuleLint()
     check_nf_module_name_modularity(mock_lint, content)
+
+    assert len(mock_lint.passed) == passed
+    assert len(mock_lint.warned) == warned
+    assert len(mock_lint.failed) == failed
+
+
+@pytest.mark.parametrize(
+    "process_name,component_name,passed,warned,failed",
+    [
+        # Valid process name
+        ("STAR_ALIGN", "star/align", 2, 0, 0),
+        # Valid process name with dash
+        ("EAUTILS_GTF2BED", "ea-utils/gtf2bed", 2, 0, 0),
+        # Invalid process name, missing tool name
+        ("EIGSCIS", "cooltools/eigscis", 1, 0, 1),
+        # Invalid process name, missing tool name and small caps
+        ("cooltools/eigscis", "cooltools/eigscis", 0, 0, 2),
+    ],
+)
+def test_process_name_format(process_name, component_name, passed, warned, failed):
+    """Test process name format"""
+    mock_lint = MockModuleLint()
+    check_process_name_format(mock_lint, process_name, component_name)
 
     assert len(mock_lint.passed) == passed
     assert len(mock_lint.warned) == warned

--- a/tests/modules/lint/test_main_nf.py
+++ b/tests/modules/lint/test_main_nf.py
@@ -183,6 +183,7 @@ def test_container_links(content, passed, warned, failed):
 def test_check_process_section_additional_registries(container_line, additional_registries, should_pass, tmp_path):
     """Test that container_links passes/fails based on additional_registries from .nf-core.yml."""
     mock_lint = MockModuleLint()
+    mock_lint.component_name = "tool/subtool"
     mock_lint.process_name = "TOOL_SUBTOOL"
     mock_lint.component_dir = tmp_path
 

--- a/tests/modules/lint/test_main_nf.py
+++ b/tests/modules/lint/test_main_nf.py
@@ -46,8 +46,6 @@ def test_module_name_granularity(content, passed, warned, failed):
     [
         # Valid process name
         ("STAR_ALIGN", "star/align", 2, 0, 0),
-        # Valid process name with dash
-        ("EAUTILS_GTF2BED", "ea-utils/gtf2bed", 2, 0, 0),
         # Invalid process name, missing tool name
         ("EIGSCIS", "cooltools/eigscis", 1, 0, 1),
         # Invalid process name, missing tool name and small caps


### PR DESCRIPTION
Closes #4119

Based on the [nf-core documentation](https://nf-co.re/docs/specifications/components/modules/naming-conventions), the process name of a module should be in all-caps and derived from the module name, replacing the `/` by `_`.

In the current `main_nf` linting rules, there was already a rule named `process_capitals` that was looking at the all-caps nature. However, it looks like the `if` statement of the rule is truthy, probably due to a typo.

I fixed the first rule, added a second rule that checks for the derivation and added some tests.

In addition, some `<tool>` or `<subtool>` have a dash symbol that are not currently addressed by the naming conventions. For example, how should `ea-utils/gtf2bed` name its process? It currently uses `EAUTILS_GTF2BED` and I have used this as a current working convention for dashes (i.e. dropping the dash). I am open to any other choice.

There are a few modules in `nf-core/modules` that do not respect this naming convention. The following question would be about fixing them without introducing large breaking changes? Not sure how this is handle in nf-core.