### PR TITLE
Template: remove date placeholder from changelog title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 - add `process_low_memory` resource label to `base.config` ([#4264](https://github.com/nf-core/tools/pull/4264))
 - fix dead link ([#4307](https://github.com/nf-core/tools/pull/4307))
+- remove date placeholder from changelog title ([#4333](https://github.com/nf-core/tools/pull/4333))
 
 #### Version updates
 

--- a/nf_core/pipeline-template/CHANGELOG.md
+++ b/nf_core/pipeline-template/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v{{ version }} - [unreleased<!-- TODO replace with date on release -->]
+## v{{ version }} - [unreleased<!-- TODO nf-core: replace with date on release -->]
 
 Initial release of {{ name }}, created with the [nf-core](https://nf-co.re/) template.
 

--- a/nf_core/pipeline-template/CHANGELOG.md
+++ b/nf_core/pipeline-template/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v{{ version }} - [unreleased <!-- TODO replace with date on release -->]
+## v{{ version }} - [unreleased<!-- TODO replace with date on release -->]
 
 Initial release of {{ name }}, created with the [nf-core](https://nf-co.re/) template.
 

--- a/nf_core/pipeline-template/CHANGELOG.md
+++ b/nf_core/pipeline-template/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v{{ version }} - [date]
+## v{{ version }} - [unreleased <!-- TODO replace with date on release -->]
 
 Initial release of {{ name }}, created with the [nf-core](https://nf-co.re/) template.
 


### PR DESCRIPTION
Minor nitpick, but it's always bothered me that if someone is looking at a dev branch the changelog title for that release says `[date]` as I dont' think that is very clear.

I prefer to have my dev branch to very explicitly say `[unreleased]` so a user knows very clearly they are looking at a non-production-ready code base branch.

This switches to `[unreleased]` but with a comment saying to replace with the date on release.

Coudl also replace with `upcoming` or something if we want a more time-based phrasing.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
