### PR TITLE
feat: lint for module name lowercase and punctuation

### DIFF
--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -68,8 +68,8 @@ def main_nf(
     emits: list[str] = []
     topics: list[str] = []
 
-    # Check the module name granularity
-    check_nf_module_name_modularity(module, module.component_name)
+    # Check the module name
+    check_nf_module_name(module, module.component_name)
 
     # Check if we have a patch file affecting the 'main.nf' file
     # otherwise read the lines directly from the module
@@ -279,11 +279,29 @@ def main_nf(
     return inputs, emits
 
 
-def check_nf_module_name_modularity(self, component_name):
+def check_nf_module_name(self, component_name):
     """
-    Lint the module granularity
-    Checks whether the module name has at most two levels of granularity.
+    Lint the module name
+    Checks whether the module name has at most two levels of granularity, no
+    punctuation and lowercase.
     """
+    # Module name is lowercase
+    if component_name.islower():
+        self.passed.append(("main_nf", "main_nf_module_lowercase", "Process name is lowercase", self.main_nf))
+    else:
+        self.failed.append(("main_nf", "main_nf_module_lowercase", "Process name should be lowercase", self.main_nf))
+
+    # Module name has no punctuation
+    if component_name.replace("/", "").isalnum():
+        self.passed.append(
+            ("main_nf", "main_nf_module_no_punctuation", "Module properly named without punctuation", self.main_nf)
+        )
+    else:
+        self.failed.append(
+            ("main_nf", "main_nf_module_no_punctuation", "Module name should not have any punctuation", self.main_nf)
+        )
+
+    # Module name granularity
     if component_name.count("/") > 1:
         self.failed.append(
             ("main_nf", "main_nf_module_granularity", "Module not named as `<tool>` or `<tool/subtool>`", self.main_nf)

--- a/tests/modules/lint/test_main_nf.py
+++ b/tests/modules/lint/test_main_nf.py
@@ -8,7 +8,7 @@ from nf_core.components.nfcore_component import NFCoreComponent
 from nf_core.modules.lint.main_nf import (
     _parse_output_topics,
     check_container_link_line,
-    check_nf_module_name_modularity,
+    check_nf_module_name,
     check_process_labels,
     check_process_name_format,
     check_process_section,
@@ -24,17 +24,19 @@ from .test_lint_utils import MockModuleLint
     "content,passed,warned,failed",
     [
         # Valid module <tool> name
-        ("tar", 1, 0, 0),
+        ("tar", 3, 0, 0),
         # Valid module <tool/subtool> name
-        ("tabix/tabix", 1, 0, 0),
+        ("tabix/tabix", 3, 0, 0),
+        # Invalid module name with punctuation and capital letters
+        ("ea-utils/GTF2BED", 1, 0, 2),
         # Invalid module <tool/subtool/subtool> name
-        ("aws/s3/ls", 0, 0, 1),
+        ("aws/s3/ls", 2, 0, 1),
     ],
 )
-def test_module_name_granularity(content, passed, warned, failed):
-    """Test module name granularity"""
+def test_module_name_format(content, passed, warned, failed):
+    """Test module name format"""
     mock_lint = MockModuleLint()
-    check_nf_module_name_modularity(mock_lint, content)
+    check_nf_module_name(mock_lint, content)
 
     assert len(mock_lint.passed) == passed
     assert len(mock_lint.warned) == warned


### PR DESCRIPTION
Closes #4334 

Another linting update, following the [naming conventions](https://nf-co.re/docs/specifications/components/modules/naming-conventions). I repurposed the granularity function to lint all of the requirements for the module name at the same place (lowercase, punctuation and granularity). 