### PR TITLE
Support module include statements that use double-quotes

### DIFF
--- a/nf_core/components/nfcore_component.py
+++ b/nf_core/components/nfcore_component.py
@@ -153,8 +153,7 @@ class NFCoreComponent:
                     component = line.strip().split()[-1].split(self.org)[-1].split("main")[0].strip("/")
                     component = component.replace("'../", "subworkflows/")
                     # Replace trailing quotes
-                    component = component.replace("'", "")
-                    component = component.replace('"', "")
+                    component = component.replace("'", "").replace('"', "")
                     included_components.append(component)
         return included_components
 

--- a/nf_core/components/nfcore_component.py
+++ b/nf_core/components/nfcore_component.py
@@ -152,7 +152,9 @@ class NFCoreComponent:
                     #'plugin/nf-validation'
                     component = line.strip().split()[-1].split(self.org)[-1].split("main")[0].strip("/")
                     component = component.replace("'../", "subworkflows/")
+                    # Replace trailing quotes
                     component = component.replace("'", "")
+                    component = component.replace('"', "")
                     included_components.append(component)
         return included_components
 


### PR DESCRIPTION
Hi,

We had this `test_main_tags` linting error in one of our sub-workflows:

```
╭─ [✗] 1 Subworkflow Test Failed ──────────────────────────────────────────────╮
│                             ╷                       ╷                        │
│ Subworkflow name            │ File path             │ Test message           │
│╶────────────────────────────┼───────────────────────┼───────────────────────╴│
│ odbsearch_busco_restructure │ subworkflows/sanger-… │ test_main_tags: Tags   │
│                             │                       │ do not adhere to       │
│                             │                       │ guidelines. Tags       │
│                             │                       │ missing in             │
│                             │                       │ main.nf.test:          │
│                             │                       │ ['apiscripts/getlineag │
│                             │                       │ eodbs"']               │
│                             ╵                       ╵                        │
╰──────────────────────────────────────────────────────────────────────────────╯
```

It turns out the problem was that the sub-workflow was included the module with double quotes
```
include { APISCRIPTS_GETLINEAGEODBS     } from "../../../modules/sanger-tol/apiscripts/getlineageodbs"
```

By moving to single quotes the linting error went away.

That was the only linting error, so I presume double quotes are not officially forbidden ? Therefore here's a PR to strip double-quotes too.


<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/main/.github/CONTRIBUTING.md
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
