### PR TITLE
Log subworkflow dependencies on install (#3871)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # nf-core/tools: Changelog
 
+## v4.x.xdev
+
+### Subworkflows
+
+- Log subworkflow dependencies on install ([#4357](https://github.com/nf-core/tools/pull/4357))
+
 ## [v4.1.0 - Marshalled Mamba](https://github.com/nf-core/tools/releases/tag/4.1.0) - [2026-07-29]
 
 ### General

--- a/nf_core/components/install.py
+++ b/nf_core/components/install.py
@@ -52,7 +52,11 @@ class ComponentInstall(ComponentCommand):
         else:
             self.installed_by = [self.component_type]
 
-    def install(self, component: str | dict[str, str], silent: bool = False) -> bool:
+    def install(
+        self,
+        component: str | dict[str, str],
+        silent: bool = False,
+    ) -> bool:
         if isinstance(component, dict):
             # Override modules_repo when the component to install is a dependency from a subworkflow.
             remote_url = component.get("git_remote", self.current_remote.remote_url)
@@ -167,6 +171,7 @@ class ComponentInstall(ComponentCommand):
             self.component_type, self.modules_repo, component, version, self.installed_by, install_track
         )
 
+        dependencies: list[str] = []
         if self.component_type == "subworkflows":
             # Under --skip-deps, don't propagate --force to transitive deps so
             # already-installed ones keep their pinned SHAs and just have
@@ -175,11 +180,16 @@ class ComponentInstall(ComponentCommand):
                 original_force = self.force
                 self.force = False
                 try:
-                    self.install_included_components(component_dir)
+                    dependencies = self.install_included_components(component_dir)
                 finally:
                     self.force = original_force
             else:
-                self.install_included_components(component_dir)
+                dependencies = self.install_included_components(component_dir)
+
+        if dependencies:
+            log.info(f"Installed files for '{component}' and its dependencies '{', '.join(sorted(dependencies))}'.")
+        else:
+            log.info(f"Installed files for '{component}'.")
 
         # Update container configs for the installed module. Subworkflows have no container entries of their
         # own; their included modules each trigger this when installed above.
@@ -207,29 +217,42 @@ class ComponentInstall(ComponentCommand):
                     Console().print(
                         Syntax(f"includeConfig '{subworkflow_config}'", "groovy", theme="ansi_dark", padding=1)
                     )
+
         return True
 
-    def install_included_components(self, subworkflow_dir):
+    def install_included_components(self, subworkflow_dir) -> list[str]:
         """
         Install included modules and subworkflows
         """
+        installed_components: list[str] = []
         ini_modules_repo = self.modules_repo
         modules_to_install, subworkflows_to_install = get_components_to_install(subworkflow_dir)
-        for s_install in subworkflows_to_install:
+        for subworkflow_to_install in subworkflows_to_install:
             original_installed = self.installed_by
             self.installed_by = [Path(subworkflow_dir).parts[-1]]
-            self.install(s_install, silent=True)
+            dependency_installed = self.install(subworkflow_to_install, silent=True)
             self.installed_by = original_installed
-        for m_install in modules_to_install:
+            if dependency_installed:
+                component_name = (
+                    subworkflow_to_install["name"]
+                    if isinstance(subworkflow_to_install, dict)
+                    else subworkflow_to_install
+                )
+                installed_components.append(component_name.replace("/", "_"))
+        for module_to_install in modules_to_install:
             original_component_type = self.component_type
             self.component_type = "modules"
             original_installed = self.installed_by
             self.installed_by = [Path(subworkflow_dir).parts[-1]]
-            self.install(m_install, silent=True)
+            dependency_installed = self.install(module_to_install, silent=True)
             self.component_type = original_component_type
             self.installed_by = original_installed
+            if dependency_installed:
+                component_name = module_to_install["name"] if isinstance(module_to_install, dict) else module_to_install
+                installed_components.append(component_name.replace("/", "_"))
         # self.install will have modified self.modules_repo. Restore its original value
         self.modules_repo = ini_modules_repo
+        return installed_components
 
     def collect_and_verify_name(
         self, component: str | None, modules_repo: "nf_core.modules.modules_repo.ModulesRepo"

--- a/tests/subworkflows/test_install.py
+++ b/tests/subworkflows/test_install.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 import pytest
@@ -64,6 +65,14 @@ class TestSubworkflowsInstall(TestSubworkflows):
         assert samtools_stats_path.exists()
         assert samtools_idxstats_path.exists()
         assert samtools_flagstat_path.exists()
+
+    def test_subworkflows_install_logs_dependencies(self):
+        """Installing a subworkflow should log its module dependencies."""
+        self.caplog.set_level(logging.INFO)
+        assert self.subworkflow_install.install("bam_sort_stats_samtools") is not False
+        assert "Installed files for 'bam_sort_stats_samtools' and its dependencies" in self.caplog.text
+        assert "samtools_index" in self.caplog.text
+        assert "bam_stats_samtools" in self.caplog.text
 
     def test_subworkflow_install_nopipeline(self):
         """Test installing a subworkflow - no pipeline given"""


### PR DESCRIPTION
Mirror remove.py by logging installed components and their dependencies during subworkflow install, and add a test for the dependency log output.