### PR TITLE
improve singularity_tag linting check (add skip, handle exceptions correctly, check against oras)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - accept `process_low_memory` as a standard module label ([#4264](https://github.com/nf-core/tools/pull/4264))
 - improve linting for `modules.json` to add support for only installing subworkflows from a repository and provide more explicit error messages ([#4287](https://github.com/nf-core/tools/pull/4287))
+- improve singularity_tag linting check (add skip, handle exceptions correctly, check against oras) ([#4358](https://github.com/nf-core/tools/pull/4358))
 
 ### Modules
 

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -10,6 +10,7 @@ from rich.progress import Progress
 
 from nf_core.components.components_differ import ComponentsDiffer
 from nf_core.components.nfcore_component import NFCoreComponent
+from nf_core.modules.lint.meta_yml import _load_skip_nf_test_sets
 
 log = logging.getLogger(__name__)
 
@@ -441,7 +442,15 @@ def check_process_section(
     if singularity_container is not None and not singularity_container.startswith(("https:", "oras:")):
         singularity_container = None
 
-    if singularity_container is not None:
+    # Modules listed under "singularity" in .github/skip_nf_test.json have no singularity
+    # container on purpose, so the singularity_tag check is skipped for them.
+    skip_singularity = str(Path(self.component_dir).resolve()) in _load_skip_nf_test_sets(str(self.base_dir)).get(
+        "singularity", frozenset()
+    )
+
+    if skip_singularity:
+        log.debug(f"Skipping singularity_tag check for {self.component_name} (skipped in skip_nf_test.json)")
+    elif singularity_container is not None:
         self.passed.append(
             ("main_nf", "singularity_tag", f"Found singularity container: {singularity_container}", self.main_nf)
         )

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -42,11 +42,12 @@ def main_nf(
       is issued if they do not match. Modules using the newer docker-only format
       (no singularity container) skip this check.
 
-    * ``singularity_tag``: The Singularity container must be resolvable via
-      ``nextflow inspect -profile singularity``. The check fails if no genuine
-      Singularity container (an ``https://`` or ``oras://`` URL) can be resolved.
-      It is skipped for modules listed under ``singularity`` in
-      ``.github/skip_nf_test.json``.
+    * ``singularity_tag``: A Singularity container must be resolvable via
+      ``nextflow inspect -profile singularity``. The check fails if none can be
+      resolved or if it falls back to a docker container that has an automatic
+      singularity equivalent, i.e., ``quay.io/biocontainers/`` or
+      ``community.wave.seqera.io/``.
+      It is skipped for modules listed under ``singularity`` in ``.github/skip_nf_test.json``.
 
     * ``oras_singularity_tag``: The resolved Singularity container must not be
       served over the ``oras://`` scheme; it should be a plain ``https://`` URL.

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -42,6 +42,16 @@ def main_nf(
       is issued if they do not match. Modules using the newer docker-only format
       (no singularity container) skip this check.
 
+    * ``singularity_tag``: The Singularity container must be resolvable via
+      ``nextflow inspect -profile singularity``. The check fails if no genuine
+      Singularity container (an ``https://`` or ``oras://`` URL) can be resolved.
+      It is skipped for modules listed under ``singularity`` in
+      ``.github/skip_nf_test.json``.
+
+    * ``oras_singularity_tag``: The resolved Singularity container must not be
+      served over the ``oras://`` scheme; it should be a plain ``https://`` URL.
+      The check fails if an ``oras://`` container is used.
+
     * ``main_nf_script_shell``: Exactly one of ``script:``, ``shell:``, or ``exec:``
       blocks must be present.
 
@@ -436,10 +446,12 @@ def check_process_section(
     singularity_container = self.get_container_with_inspect(profile="singularity")
 
     # `nextflow inspect -profile singularity` falls back to the docker container when the
-    # module has no singularity-specific image. It is fine to use a docker container, as
-    # long as it  doens't have a pre-build singularity container, e.g. from seqera containers
-    # or biocontainers.
-    if singularity_container is not None and not singularity_container.startswith("https:") and singularity_container.startswith(("quay.io/biocontainers/", "community.wave.seqera.io/")):
+    # module has no singularity-specific image. A bare biocontainers/Seqera docker image is
+    # such a fallback (a genuine singularity image would be an `https://` or `oras://` URL),
+    # so it must not be treated as a singularity container.
+    if singularity_container is not None and singularity_container.startswith(
+        ("quay.io/biocontainers/", "community.wave.seqera.io/")
+    ):
         singularity_container = None
 
     # Modules listed under "singularity" in .github/skip_nf_test.json have no singularity
@@ -454,6 +466,15 @@ def check_process_section(
         self.passed.append(
             ("main_nf", "singularity_tag", f"Found singularity container: {singularity_container}", self.main_nf)
         )
+        if singularity_container.startswith("oras://"):
+            self.failed.append(
+                ("main_nf", "oras_singularity_tag", "Singularity container should not use oras:// scheme", self.main_nf)
+            )
+        else:
+            self.passed.append(
+                ("main_nf", "oras_singularity_tag", "Singularity container uses valid scheme", self.main_nf)
+            )
+
     else:
         self.failed.append(("main_nf", "singularity_tag", "Unable to resolve singularity container", self.main_nf))
     if docker_container is not None:

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -436,10 +436,10 @@ def check_process_section(
     singularity_container = self.get_container_with_inspect(profile="singularity")
 
     # `nextflow inspect -profile singularity` falls back to the docker container when the
-    # module has no singularity-specific image. A genuine singularity reference is a remote
-    # URL (`https://…`) or an `oras://…` reference, so anything else is the docker fallback
-    # and must not be treated as a singularity container.
-    if singularity_container is not None and not singularity_container.startswith(("https:", "oras:")):
+    # module has no singularity-specific image. It is fine to use a docker container, as
+    # long as it  doens't have a pre-build singularity container, e.g. from seqera containers
+    # or biocontainers.
+    if singularity_container is not None and not singularity_container.startswith("https:") and singularity_container.startswith(("quay.io/biocontainers/", "community.wave.seqera.io/")):
         singularity_container = None
 
     # Modules listed under "singularity" in .github/skip_nf_test.json have no singularity
@@ -675,7 +675,7 @@ def check_container_link_line(self, raw_line, registry):
                     (
                         "main_nf",
                         "container_links",
-                        f"Container prefix is not correct. Please add one of the allowed registry prefixes: {', '.join(registry) if isinstance(registry, tuple) else registry}",
+                        f"Container prefix is not correct. Please add one of the allowed registry prefixes: {', '.join(registry)}",
                         self.main_nf,
                     )
                 )

--- a/tests/modules/lint/test_lint_utils.py
+++ b/tests/modules/lint/test_lint_utils.py
@@ -20,7 +20,6 @@ class MockModuleLint:
         # drive the `nextflow inspect` based container resolution without a real Nextflow.
         self.inspect_containers: dict[str | None, str | None] = {}
 
-
         self.component_name = ""
         self.process_name = ""
         self.component_dir = None

--- a/tests/modules/lint/test_lint_utils.py
+++ b/tests/modules/lint/test_lint_utils.py
@@ -20,6 +20,12 @@ class MockModuleLint:
         # drive the `nextflow inspect` based container resolution without a real Nextflow.
         self.inspect_containers: dict[str | None, str | None] = {}
 
+
+        self.component_name = ""
+        self.process_name = ""
+        self.component_dir = None
+        self.base_dir = None
+
     def get_container_with_inspect(self, profile=None):
         return self.inspect_containers.get(profile)
 

--- a/tests/modules/lint/test_main_nf.py
+++ b/tests/modules/lint/test_main_nf.py
@@ -210,6 +210,106 @@ def test_check_process_section_additional_registries(container_line, additional_
         assert not prefix_passed, f"Container prefix should not pass; passed={mock_lint.passed}"
 
 
+@pytest.mark.parametrize(
+    "singularity_container,singularity_should_fail",
+    [
+        # `nextflow inspect -profile singularity` fell back to a bare docker image (a
+        # biocontainers / seqera prefix, no https:/oras: URL) -> nulled -> fail. Both
+        # prefixes in the production startswith() tuple are covered.
+        ("quay.io/biocontainers/gatk4:4.4.0.0--py36hdfd78af_0", True),
+        ("community.wave.seqera.io/library/gatk4:4.4.0.0--abc123", True),
+        # Genuine singularity URL survives -> passes
+        ("https://depot.galaxyproject.org/singularity/gatk4:4.4.0.0--py36hdfd78af_0", False),
+    ],
+)
+def test_check_process_section_singularity_fallback(singularity_container, singularity_should_fail, tmp_path):
+    """A quay.io/biocontainers or community.wave.seqera.io docker image must have a genuine
+    singularity equivalent. When `nextflow inspect -profile singularity` falls back to the
+    docker container, the singularity_tag check must fail. The outcome depends only on the
+    resolved singularity container, so a fixed docker container is used."""
+    docker_container = "quay.io/biocontainers/gatk4:4.4.0.0--py36hdfd78af_0"
+    mock_lint = MockModuleLint()
+    mock_lint.component_name = "tool/subtool"
+    mock_lint.process_name = "TOOL_SUBTOOL"
+    mock_lint.component_dir = tmp_path
+    mock_lint.base_dir = tmp_path
+    mock_lint.inspect_containers = {"docker": docker_container, "singularity": singularity_container}
+
+    check_process_section(
+        mock_lint,
+        [f"container '{docker_container}'"],
+        ("quay.io", "community.wave.seqera.io/library/"),
+        False,
+        None,
+    )
+
+    singularity_failed = any(r[1] == "singularity_tag" for r in mock_lint.failed)
+    singularity_passed = any(r[1] == "singularity_tag" for r in mock_lint.passed)
+
+    if singularity_should_fail:
+        assert singularity_failed, f"Expected singularity_tag failure; failed={mock_lint.failed}"
+        assert not singularity_passed, f"singularity_tag should not pass; passed={mock_lint.passed}"
+    else:
+        assert singularity_passed, f"Expected singularity_tag to pass; passed={mock_lint.passed}"
+        assert not singularity_failed, f"singularity_tag should not fail; failed={mock_lint.failed}"
+
+
+@pytest.mark.parametrize(
+    "singularity_container,oras_outcome",
+    [
+        # oras:// scheme is not allowed -> oras_singularity_tag fails
+        (
+            "oras://community.wave.seqera.io/library/gatk4:4.4.0.0--abc123",
+            "fail",
+        ),
+        # https:// scheme is the valid form -> oras_singularity_tag passes
+        (
+            "https://depot.galaxyproject.org/singularity/gatk4:4.4.0.0--py36hdfd78af_0",
+            "pass",
+        ),
+        # docker fallback gets nulled out -> no singularity container, so the
+        # oras_singularity_tag check is not emitted at all
+        (
+            "quay.io/biocontainers/gatk4:4.4.0.0--py36hdfd78af_0",
+            "absent",
+        ),
+    ],
+)
+def test_check_process_section_oras_singularity_tag(singularity_container, oras_outcome, tmp_path):
+    """The resolved Singularity container must not use the oras:// scheme (it should be a
+    plain https:// URL). oras_singularity_tag fails for oras:// containers, passes for
+    https:// containers, and is not emitted when no genuine singularity container resolves."""
+    docker_container = "quay.io/biocontainers/gatk4:4.4.0.0--py36hdfd78af_0"
+    mock_lint = MockModuleLint()
+    mock_lint.component_name = "tool/subtool"
+    mock_lint.process_name = "TOOL_SUBTOOL"
+    mock_lint.component_dir = tmp_path
+    mock_lint.base_dir = tmp_path
+    mock_lint.inspect_containers = {"docker": docker_container, "singularity": singularity_container}
+
+    check_process_section(
+        mock_lint,
+        [f"container '{docker_container}'"],
+        ("quay.io", "community.wave.seqera.io/library/"),
+        False,
+        None,
+    )
+
+    oras_failed = any(r[1] == "oras_singularity_tag" for r in mock_lint.failed)
+    oras_passed = any(r[1] == "oras_singularity_tag" for r in mock_lint.passed)
+
+    if oras_outcome == "fail":
+        assert oras_failed, f"Expected oras_singularity_tag failure; failed={mock_lint.failed}"
+        assert not oras_passed, f"oras_singularity_tag should not pass; passed={mock_lint.passed}"
+    elif oras_outcome == "pass":
+        assert oras_passed, f"Expected oras_singularity_tag to pass; passed={mock_lint.passed}"
+        assert not oras_failed, f"oras_singularity_tag should not fail; failed={mock_lint.failed}"
+    else:  # absent
+        assert not oras_failed and not oras_passed, (
+            f"oras_singularity_tag should not be emitted; passed={mock_lint.passed}, failed={mock_lint.failed}"
+        )
+
+
 class TestMainNfLinting(TestModules):
     """
     Test main.nf linting functionality.

--- a/tests/modules/lint/test_main_nf.py
+++ b/tests/modules/lint/test_main_nf.py
@@ -247,9 +247,7 @@ class TestMainNfLinting(TestModules):
         module_lint = nf_core.modules.lint.ModuleLint(directory=self.pipeline_dir)
         module_lint.lint(print_results=False, module="samtools/sort")
 
-        # TODO: set to 0 once samtools/sort module is converted to new container syntax
-        assert len(module_lint.failed) == 1
-        assert module_lint.failed[0].lint_test == "has_meta_containers"
+        assert len(module_lint.failed) == 0
         assert len(module_lint.passed) > 0
 
     def test_additional_registry_from_nf_core_yml_passes_container_link(self):

--- a/tests/modules/lint/test_main_nf.py
+++ b/tests/modules/lint/test_main_nf.py
@@ -211,22 +211,28 @@ def test_check_process_section_additional_registries(container_line, additional_
 
 
 @pytest.mark.parametrize(
-    "singularity_container,singularity_should_fail",
+    "singularity_container,singularity_tag,oras_singularity_tag",
     [
         # `nextflow inspect -profile singularity` fell back to a bare docker image (a
-        # biocontainers / seqera prefix, no https:/oras: URL) -> nulled -> fail. Both
-        # prefixes in the production startswith() tuple are covered.
-        ("quay.io/biocontainers/gatk4:4.4.0.0--py36hdfd78af_0", True),
-        ("community.wave.seqera.io/library/gatk4:4.4.0.0--abc123", True),
-        # Genuine singularity URL survives -> passes
-        ("https://depot.galaxyproject.org/singularity/gatk4:4.4.0.0--py36hdfd78af_0", False),
+        # biocontainers / seqera prefix, no https:/oras: URL) -> nulled -> singularity_tag
+        # fails and the oras check is not emitted. Both prefixes in the production
+        # startswith() tuple are covered.
+        ("quay.io/biocontainers/gatk4:4.4.0.0--py36hdfd78af_0", "fail", "absent"),
+        ("community.wave.seqera.io/library/gatk4:4.4.0.0--abc123", "fail", "absent"),
+        # Genuine https:// singularity URL -> both checks pass
+        ("https://depot.galaxyproject.org/singularity/gatk4:4.4.0.0--py36hdfd78af_0", "pass", "pass"),
+        # oras:// resolves a container (singularity_tag passes) but the scheme is invalid
+        ("oras://community.wave.seqera.io/library/gatk4:4.4.0.0--abc123", "pass", "fail"),
     ],
 )
-def test_check_process_section_singularity_fallback(singularity_container, singularity_should_fail, tmp_path):
-    """A quay.io/biocontainers or community.wave.seqera.io docker image must have a genuine
-    singularity equivalent. When `nextflow inspect -profile singularity` falls back to the
-    docker container, the singularity_tag check must fail. The outcome depends only on the
-    resolved singularity container, so a fixed docker container is used."""
+def test_check_process_section_singularity_container(
+    singularity_container, singularity_tag, oras_singularity_tag, tmp_path
+):
+    """A biocontainers/seqera docker image must have a genuine https:// singularity equivalent.
+    When `nextflow inspect -profile singularity` falls back to the docker container the
+    singularity_tag check fails, and an oras:// container fails the oras_singularity_tag check.
+    The outcome depends only on the resolved singularity container, so a fixed docker container
+    is used."""
     docker_container = "quay.io/biocontainers/gatk4:4.4.0.0--py36hdfd78af_0"
     mock_lint = MockModuleLint()
     mock_lint.component_name = "tool/subtool"
@@ -243,71 +249,18 @@ def test_check_process_section_singularity_fallback(singularity_container, singu
         None,
     )
 
-    singularity_failed = any(r[1] == "singularity_tag" for r in mock_lint.failed)
-    singularity_passed = any(r[1] == "singularity_tag" for r in mock_lint.passed)
+    def assert_outcome(lint_test, expected):
+        passed = any(r[1] == lint_test for r in mock_lint.passed)
+        failed = any(r[1] == lint_test for r in mock_lint.failed)
+        if expected == "pass":
+            assert passed and not failed, f"Expected {lint_test} to pass; passed={passed}, failed={failed}"
+        elif expected == "fail":
+            assert failed and not passed, f"Expected {lint_test} to fail; passed={passed}, failed={failed}"
+        else:  # absent
+            assert not passed and not failed, f"Expected {lint_test} to be absent; passed={passed}, failed={failed}"
 
-    if singularity_should_fail:
-        assert singularity_failed, f"Expected singularity_tag failure; failed={mock_lint.failed}"
-        assert not singularity_passed, f"singularity_tag should not pass; passed={mock_lint.passed}"
-    else:
-        assert singularity_passed, f"Expected singularity_tag to pass; passed={mock_lint.passed}"
-        assert not singularity_failed, f"singularity_tag should not fail; failed={mock_lint.failed}"
-
-
-@pytest.mark.parametrize(
-    "singularity_container,oras_outcome",
-    [
-        # oras:// scheme is not allowed -> oras_singularity_tag fails
-        (
-            "oras://community.wave.seqera.io/library/gatk4:4.4.0.0--abc123",
-            "fail",
-        ),
-        # https:// scheme is the valid form -> oras_singularity_tag passes
-        (
-            "https://depot.galaxyproject.org/singularity/gatk4:4.4.0.0--py36hdfd78af_0",
-            "pass",
-        ),
-        # docker fallback gets nulled out -> no singularity container, so the
-        # oras_singularity_tag check is not emitted at all
-        (
-            "quay.io/biocontainers/gatk4:4.4.0.0--py36hdfd78af_0",
-            "absent",
-        ),
-    ],
-)
-def test_check_process_section_oras_singularity_tag(singularity_container, oras_outcome, tmp_path):
-    """The resolved Singularity container must not use the oras:// scheme (it should be a
-    plain https:// URL). oras_singularity_tag fails for oras:// containers, passes for
-    https:// containers, and is not emitted when no genuine singularity container resolves."""
-    docker_container = "quay.io/biocontainers/gatk4:4.4.0.0--py36hdfd78af_0"
-    mock_lint = MockModuleLint()
-    mock_lint.component_name = "tool/subtool"
-    mock_lint.process_name = "TOOL_SUBTOOL"
-    mock_lint.component_dir = tmp_path
-    mock_lint.base_dir = tmp_path
-    mock_lint.inspect_containers = {"docker": docker_container, "singularity": singularity_container}
-
-    check_process_section(
-        mock_lint,
-        [f"container '{docker_container}'"],
-        ("quay.io", "community.wave.seqera.io/library/"),
-        False,
-        None,
-    )
-
-    oras_failed = any(r[1] == "oras_singularity_tag" for r in mock_lint.failed)
-    oras_passed = any(r[1] == "oras_singularity_tag" for r in mock_lint.passed)
-
-    if oras_outcome == "fail":
-        assert oras_failed, f"Expected oras_singularity_tag failure; failed={mock_lint.failed}"
-        assert not oras_passed, f"oras_singularity_tag should not pass; passed={mock_lint.passed}"
-    elif oras_outcome == "pass":
-        assert oras_passed, f"Expected oras_singularity_tag to pass; passed={mock_lint.passed}"
-        assert not oras_failed, f"oras_singularity_tag should not fail; failed={mock_lint.failed}"
-    else:  # absent
-        assert not oras_failed and not oras_passed, (
-            f"oras_singularity_tag should not be emitted; passed={mock_lint.passed}, failed={mock_lint.failed}"
-        )
+    assert_outcome("singularity_tag", singularity_tag)
+    assert_outcome("oras_singularity_tag", oras_singularity_tag)
 
 
 class TestMainNfLinting(TestModules):

--- a/tests/modules/lint/test_main_nf.py
+++ b/tests/modules/lint/test_main_nf.py
@@ -221,6 +221,9 @@ def test_check_process_section_additional_registries(container_line, additional_
         ("community.wave.seqera.io/library/gatk4:4.4.0.0--abc123", "fail", "absent"),
         # Genuine https:// singularity URL -> both checks pass
         ("https://depot.galaxyproject.org/singularity/gatk4:4.4.0.0--py36hdfd78af_0", "pass", "pass"),
+        # Allowed docker container fallback
+        ("quay.io/nf-core/bclconvert:4.5.4", "pass", "pass"),
+        ("nvcr.io/nvidia/clara/clara-parabricks:4.6.0-1", "pass", "pass"),
         # oras:// resolves a container (singularity_tag passes) but the scheme is invalid
         ("oras://community.wave.seqera.io/library/gatk4:4.4.0.0--abc123", "pass", "fail"),
     ],

--- a/tests/modules/lint/test_module_lint_integration.py
+++ b/tests/modules/lint/test_module_lint_integration.py
@@ -11,9 +11,7 @@ class TestModulesLintIntegration(TestModules):
         self.mods_install.install("trimgalore")
         module_lint = nf_core.modules.lint.ModuleLint(directory=self.pipeline_dir)
         module_lint.lint(print_results=False, module="trimgalore")
-        # TODO: set to 0 once trimgalore module is converted to new container syntax
-        assert len(module_lint.failed) == 1
-        assert module_lint.failed[0].lint_test == "has_meta_containers"
+        assert len(module_lint.failed) == 0
         assert len(module_lint.warned) >= 0
 
     def test_modules_lint_trinity(self):
@@ -30,9 +28,7 @@ class TestModulesLintIntegration(TestModules):
         self.mods_install.install("tabix/tabix")
         module_lint = nf_core.modules.lint.ModuleLint(directory=self.pipeline_dir)
         module_lint.lint(print_results=False, module="tabix/tabix")
-        # TODO: set to 0 once tabix/tabix module is converted to new container syntax
-        assert len(module_lint.failed) == 1
-        assert module_lint.failed[0].lint_test == "has_meta_containers"
+        assert len(module_lint.failed) == 0
         assert len(module_lint.passed) > 0
         assert len(module_lint.warned) >= 0
 

--- a/tests/modules/lint/test_module_lint_remotes.py
+++ b/tests/modules/lint/test_module_lint_remotes.py
@@ -27,7 +27,10 @@ class TestModulesLintRemotes(TestModules):
         self.mods_install_gitlab_nftest.install("multiqc")
         module_lint = nf_core.modules.lint.ModuleLint(directory=self.pipeline_dir, remote_url=GITLAB_URL)
         module_lint.lint(print_results=False, all_modules=True)
-        assert len(module_lint.failed) == 4
+        assert len(module_lint.failed) == 3
+        # check that the failed tests are environment_yml_valid, main_nf_versio_ topic (twice)
+        for result in module_lint.failed:
+            assert result.lint_test in ["environment_yml_valid", "main_nf_version_topic"]
         assert len(module_lint.passed) > 0
         assert len(module_lint.warned) >= 0
 


### PR DESCRIPTION
- skips linting tests if module is mentioned in `skip-nf-test.json`
- accepts docker container as singularity tag as long as it not pointing to biocontainers or seqera containers
- fail linting if oras: url is used