### PR TITLE
add section about human-to-human communication to AI pollicy

### DIFF
--- a/nf_core/pipeline-template/docs/CONTRIBUTING.md
+++ b/nf_core/pipeline-template/docs/CONTRIBUTING.md
@@ -50,6 +50,8 @@ If you’re using AI tools, try to stick by these guidelines:
 - Avoid any unnecessary changes, such as moving or refactoring code (unless that is the explicit intention of the PR)
 - Review all generated code yourself before opening a PR, and ensure that you understand it
 - Engage with the community review process and expect to make revisions
+- We expect you to communicate with the community in your own words, that includes the content of GitHub issues and pull requests. Do not copy responses from the LLMs when replying to questions from maintainers.
+- If you wish to include context from an interaction with LLMs in your comments, it must be in a quote block (e.g., using >) and disclosed as such. Do not share long snippets.
 
 For more detail, see the [blog post](https://nf-co.re/blog/2026/statement-on-ai) for a statement from the nf-core/core team.
 

--- a/nf_core/pipeline-template/docs/CONTRIBUTING.md
+++ b/nf_core/pipeline-template/docs/CONTRIBUTING.md
@@ -51,7 +51,9 @@ If you’re using AI tools, try to stick by these guidelines:
 - Review all generated code yourself before opening a PR, and ensure that you understand it
 - Engage with the community review process and expect to make revisions
 - We expect you to communicate with the community in your own words, that includes the content of GitHub issues and pull requests. Do not copy responses from the LLMs when replying to questions from maintainers.
-- If you wish to include context from an interaction with LLMs in your comments, it must be in a quote block (e.g., using >) and disclosed as such. Do not share long snippets.
+- If you wish to include context from an interaction with LLMs in your comments, it must be in a quote block (e.g., using `>`) and disclosed as such. Do not share long snippets.
+- If you use LLMs to avoid language barriers, please make sure the output reflects your own ideas. Write in your native language and provide the translated text in a quote block (e.g., using `>`).
+
 
 For more detail, see the [blog post](https://nf-co.re/blog/2026/statement-on-ai) for a statement from the nf-core/core team.
 

--- a/nf_core/pipeline-template/docs/CONTRIBUTING.md
+++ b/nf_core/pipeline-template/docs/CONTRIBUTING.md
@@ -54,7 +54,6 @@ If you’re using AI tools, try to stick by these guidelines:
 - If you wish to include context from an interaction with LLMs in your comments, it must be in a quote block (e.g., using `>`) and disclosed as such. Do not share long snippets.
 - If you use LLMs to avoid language barriers, please make sure the output reflects your own ideas. Write in your native language and provide the translated text in a quote block (e.g., using `>`).
 
-
 For more detail, see the [blog post](https://nf-co.re/blog/2026/statement-on-ai) for a statement from the nf-core/core team.
 
 ### Getting help


### PR DESCRIPTION
As a response to the influx of frustrating copy-paste conversations between maintainers and new contributors on the one hand, and overly verbose PR and issue texts on the other — 

heavily insipired by https://github.com/astral-sh/.github/blob/c5187e200db51bfe11d56e13053d29bd3793fdd8/AI_POLICY.md