### PR TITLE
specify required containers to not require arm

### DIFF
--- a/nf_core/modules/containers.py
+++ b/nf_core/modules/containers.py
@@ -493,6 +493,22 @@ class ModuleContainers:
 
         return containers, not has_failures
 
+    @staticmethod
+    def _raise_if_build_failed(result: dict, build_ref: str, details_uri: str = "") -> None:
+        """
+        Raise a uniform error if a finished Wave build did not succeed.
+
+        Accepts either the container submit response or a ``/status`` response — both
+        expose ``succeeded``/``reason``/``detailsUri`` — so the failure contract lives
+        in one place. ``details_uri`` overrides the value on ``result`` (the status
+        poller keeps the last non-empty build-log URL it saw).
+        """
+        if result.get("succeeded"):
+            return
+        reason = result.get("reason") or "no reason provided"
+        details = details_uri or result.get("detailsUri") or ""
+        raise RuntimeError(f"Wave build {build_ref} failed: {reason}. Build log: {details}")
+
     @classmethod
     def _await_build(
         cls,
@@ -528,9 +544,7 @@ class ModuleContainers:
             status = wave_request("get", status_url, error_context=f"Wave status check for request {request_id}")
             details_uri = status.get("detailsUri") or details_uri
             if status.get("status") == "DONE":
-                if not status.get("succeeded"):
-                    reason = status.get("reason") or "no reason provided"
-                    raise RuntimeError(f"Wave build {request_id} failed: {reason}. Build log: {details_uri}")
+                cls._raise_if_build_failed(status, request_id, details_uri)
                 log.debug(f"Wave build {request_id} completed in {status.get('duration')}s")
                 return
             if time.monotonic() > deadline:
@@ -589,10 +603,15 @@ class ModuleContainers:
         if build_id and on_build_id is not None:
             on_build_id(build_id)
 
-        # A build that is cached (or already reported DONE in the submit response) is
-        # resolved immediately; otherwise poll the container status endpoint until it
-        # finishes.
-        if not meta_data.get("cached") and meta_data.get("status") != "DONE":
+        # Wave returns a targetImage/buildId even for failed builds, so a cached/DONE
+        # submit response must still be checked for success — not only the polling path.
+        succeeded = meta_data.get("succeeded")
+        is_final = bool(meta_data.get("cached")) or meta_data.get("status") == "DONE"
+        if is_final and succeeded is not None:
+            # Submit response already carries an authoritative result.
+            cls._raise_if_build_failed(meta_data, build_id or request_id)
+        elif not is_final or request_id:
+            # Not final, or final but ambiguous: the status endpoint is authoritative.
             cls._await_build(request_id, cancel_event=cancel_event)
 
         image = meta_data.get("targetImage") or meta_data.get("containerImage") or ""

--- a/nf_core/modules/lint/module_containers.py
+++ b/nf_core/modules/lint/module_containers.py
@@ -6,7 +6,6 @@ from pydantic_core import ValidationError
 
 from nf_core.components.nfcore_component import NFCoreComponent
 from nf_core.modules.modules_utils import ContainerEntry, MetaYmlContainers, module_uses_dockerfile
-from nf_core.utils import CONTAINER_PLATFORMS
 
 log = logging.getLogger(__name__)
 
@@ -210,7 +209,7 @@ def lint_meta_yml_containers(module: NFCoreComponent, skip_docker=False, skip_co
                     )
                 )
 
-        for plat in CONTAINER_PLATFORMS:
+        for plat in containers.conda:
             conda_entry = containers.conda.get(plat)
             docker_entry = containers.docker.get(plat) if containers.docker else None
             conda_lock = conda_entry.lock_file if conda_entry else ""

--- a/nf_core/modules/modules_utils.py
+++ b/nf_core/modules/modules_utils.py
@@ -6,7 +6,12 @@ from urllib.parse import urlparse
 import requests
 from pydantic import BaseModel, ValidationInfo, field_validator, model_validator
 
-from nf_core.utils import CONTAINER_PLATFORMS, CONTAINER_SYSTEMS, NFCORE_CACHE_DIR
+from nf_core.utils import (
+    CONTAINER_PLATFORMS,
+    CONTAINER_SYSTEMS,
+    NFCORE_CACHE_DIR,
+    REQUIRED_CONTAINER_PLATFORMS,
+)
 
 from ..components.nfcore_component import NFCoreComponent
 
@@ -88,10 +93,13 @@ class MetaYmlContainers(BaseModel):
     @model_validator(mode="after")
     def check_container_systems_complete(self, info: ValidationInfo) -> "MetaYmlContainers":
         """
-        Require a non-empty section with an entry for every platform, for each container
-        system named in ``context={"require_complete": [...]}`` (``True`` means all of
-        ``CONTAINER_SYSTEMS``, i.e. conda is exempt). Plain construction (e.g. the partial
-        states built up during container builds) is not affected.
+        Require a non-empty section with an entry for every *required* platform
+        (``REQUIRED_CONTAINER_PLATFORMS``), for each container system named in
+        ``context={"require_complete": [...]}`` (``True`` means all of
+        ``CONTAINER_SYSTEMS``, i.e. conda is exempt). Optional platforms such as
+        ``linux/arm64`` are validated when present but never required. Plain
+        construction (e.g. the partial states built up during container builds) is
+        not affected.
         """
         require = (info.context or {}).get("require_complete")
         if not require:
@@ -100,7 +108,7 @@ class MetaYmlContainers(BaseModel):
             entries = getattr(self, system)
             if not entries:
                 raise ValueError(f"No containers specified for {system}")
-            for plf in CONTAINER_PLATFORMS:
+            for plf in REQUIRED_CONTAINER_PLATFORMS:
                 if plf not in entries:
                     raise ValueError(f"No {system} entries found for expected platform: {plf}")
         return self

--- a/nf_core/utils.py
+++ b/nf_core/utils.py
@@ -109,6 +109,9 @@ NFCORE_DIR = Path(
 
 CONTAINER_SYSTEMS = ["docker", "singularity"]
 CONTAINER_PLATFORMS = ["linux/amd64", "linux/arm64"]
+# Platforms a module must provide containers for. Others (e.g. linux/arm64) are
+# supported and validated when present, but not required.
+REQUIRED_CONTAINER_PLATFORMS = ["linux/amd64"]
 
 
 class ContainerRegistryUrls(Enum):

--- a/tests/modules/test_containers.py
+++ b/tests/modules/test_containers.py
@@ -255,13 +255,26 @@ class TestModuleContainers(TestModules):
         assert result is None
         assert "No containers specified for docker" in self.caplog.text
 
-    def test_get_containers_from_meta_missing_platform_key(self):
+    def test_get_containers_from_meta_optional_platform_missing_ok(self):
+        """An optional platform (e.g. linux/arm64) may be absent - amd64 alone is valid."""
         containers = {
             "docker": {CONTAINER_PLATFORMS[0]: {"name": "img:1.0"}},
             "singularity": {CONTAINER_PLATFORMS[0]: {"name": "sif:1.0"}},
         }
         self._write_meta({"name": "bpipe/test", "containers": containers})
-        missing_platform = CONTAINER_PLATFORMS[1]
+        result = self.module_containers.get_containers_from_meta()
+        assert result is not None
+        assert CONTAINER_PLATFORMS[0] in result.docker
+        assert CONTAINER_PLATFORMS[1] not in result.docker
+
+    def test_get_containers_from_meta_missing_required_platform(self):
+        """A required platform (linux/amd64) must be present, or the section is invalid."""
+        containers = {
+            "docker": {CONTAINER_PLATFORMS[1]: {"name": "img:1.0"}},
+            "singularity": {CONTAINER_PLATFORMS[1]: {"name": "sif:1.0"}},
+        }
+        self._write_meta({"name": "bpipe/test", "containers": containers})
+        missing_platform = CONTAINER_PLATFORMS[0]
         self.caplog.set_level(logging.DEBUG, logger="nf_core.modules.containers")
         result = self.module_containers.get_containers_from_meta()
         assert result is None

--- a/tests/modules/test_containers.py
+++ b/tests/modules/test_containers.py
@@ -186,6 +186,43 @@ class TestModuleContainers(TestModules):
         # Polled the v1alpha2 container status endpoint with the requestId
         assert mock_get.call_args[0][0].endswith("/v1alpha2/container/req-fail/status")
 
+    @mock.patch("nf_core.modules.containers.requests.get")
+    @mock.patch("nf_core.modules.containers.requests.post")
+    def test_request_container_cached_failed_build_raises(self, mock_post, mock_get):
+        # Wave reports a previously-failed build as cached/DONE but still returns a
+        # targetImage. The submit-response success flag must be honoured so the failed
+        # build is not silently recorded as a valid container.
+        mock_post.return_value = self._fake_response(
+            {
+                "buildId": "bd-aa7e45b61425a0b2_7",
+                "requestId": "req-cached",
+                "cached": True,
+                "status": "DONE",
+                "succeeded": False,
+                "reason": "arm64 build failed",
+                "detailsUri": "https://wave/log",
+                "targetImage": "community.wave.seqera.io/library/busco:6.1.0--aa7e45b61425a0b2",
+            }
+        )
+        with pytest.raises(RuntimeError, match="Wave build bd-aa7e45b61425a0b2_7 failed: arm64 build failed"):
+            ModuleContainers.request_container("docker", CONTAINER_PLATFORMS[0], self.environment_yml)
+        # A cached failure is resolved from the submit response alone - no status poll.
+        mock_get.assert_not_called()
+
+    @mock.patch("nf_core.modules.containers.requests.get")
+    @mock.patch("nf_core.modules.containers.requests.post")
+    def test_request_container_cached_without_result_polls_status(self, mock_post, mock_get):
+        # Cached/DONE submit response with no explicit success flag -> fall back to the
+        # authoritative status endpoint before accepting the image.
+        mock_post.return_value = self._fake_response(
+            {"buildId": "bd-cached", "requestId": "req-cached", "cached": True, "targetImage": "testC:latest"}
+        )
+        mock_get.return_value = self._fake_response({"status": "DONE", "succeeded": True})
+
+        container = ModuleContainers.request_container("docker", CONTAINER_PLATFORMS[0], self.environment_yml)
+        assert container.name == "testC:latest"
+        assert mock_get.call_args[0][0].endswith("/v1alpha2/container/req-cached/status")
+
     @mock.patch("nf_core.modules.containers.requests.post")
     def test_request_container_missing_image_raises(self, mock_post):
         mock_post.return_value = self._fake_response({"buildId": "build-4", "cached": True})


### PR DESCRIPTION
Fixes also a bug where cached builds were always handled as `succeeded`