### PR TITLE
Add TODO for module tags without metadata

### DIFF
--- a/nf_core/module-template/main.nf
+++ b/nf_core/module-template/main.nf
@@ -18,7 +18,10 @@
 {%- endif %}
 
 process {{ component_name_underscore|upper }} {
-    tag {{ '"$meta.id"' if has_meta else "'$bam'" }}
+    {% if not has_meta -%}
+    // TODO nf-core: Update the variable name used in the tag
+    {% endif -%}
+    tag {{ '"$meta.id"' if has_meta else '"$bam"' }}
     label '{{ process_label }}'
 
     {% if not_empty_template -%}


### PR DESCRIPTION
## What changed

- add a focused TODO above generated module tags when no metadata map is used
- render the placeholder tag as `"$bam"` so Nextflow interpolates the variable
- leave the existing metadata tag output unchanged

Fixes #2536.

## Validation

- rendered `nf_core/module-template/main.nf` with Jinja2 for both branches:
  - `has_meta=true`: `tag "$meta.id"`, no new TODO
  - `has_meta=false`: one TODO immediately before `tag "$bam"`
- `.venv\Scripts\prek.exe run --config .pre-commit-config.yaml --files nf_core/module-template/main.nf`
- `git diff --check`

`tests/modules/test_create.py` could not reach its assertions locally because all 12 tests require a Nextflow executable during shared setup, which is unavailable in this Windows environment. No test failure was caused by the rendered template.

## PR checklist

- [x] This comment contains a description of changes and the reason
- [ ] `CHANGELOG.md` is updated (left for the repository bot)

## Automation disclosure

This small template change was prepared and tested with OpenAI Codex automation. It received advisory AI reviews from an independent local agent and ChatGPT Web; both returned approval. No human review is claimed.
