### PR TITLE
Fix false nf-test failure on empty stderr

### DIFF
--- a/nf_core/components/components_test.py
+++ b/nf_core/components/components_test.py
@@ -188,7 +188,7 @@ class ComponentsTest(ComponentCommand):  # type: ignore[misc]
                     # update snapshot using nf-test --update-snapshot
                     self.generate_snapshot()
 
-            else:
+            elif nftest_err:
                 self.errors.append("nf-test failed")
 
     def generate_snapshot(self) -> bool:

--- a/tests/components/test_components_snapshot_test.py
+++ b/tests/components/test_components_snapshot_test.py
@@ -11,6 +11,20 @@ from nf_core.utils import set_wd
 from ..test_components import TestComponents
 
 
+@pytest.mark.parametrize(
+    ("nftest_err", "expected_errors"),
+    [(b"", []), (b"error", ["nf-test failed"]), (b"Different Snapshot:", [])],
+)
+def test_display_nftest_output_stderr(nftest_err, expected_errors):
+    """Only report an nf-test failure when stderr is non-empty."""
+    tester = ComponentsTest.__new__(ComponentsTest)
+    tester.no_prompts = False
+    tester.update = False
+    tester.errors = []
+    tester.display_nftest_output(b"", nftest_err)
+    assert tester.errors == expected_errors
+
+
 class TestTestComponentsUtils(TestComponents):
     def test_components_test_check_inputs(self):
         """Test the check_inputs() function - raise UserWarning because module doesn't exist"""


### PR DESCRIPTION
## What changed

- only append the interactive `nf-test failed` error when stderr is non-empty
- preserve the existing snapshot-difference and `--no-prompts` behavior
- add a focused regression test for empty stderr, ordinary stderr, and snapshot-difference stderr

The previous bare `else` was attached to the snapshot-difference check, so a successful interactive nf-test run with empty stderr still appended an error. Snapshot stability runs the command twice, producing the two false failures reported in the issue.

Fixes #4327.

## Validation

- `python -m pytest tests/components/test_components_snapshot_test.py -k display_nftest_output_stderr -q` (`3 passed`)
- Ruff 0.15.12 check and format check on both changed files
- `python -m py_compile` on both changed Python files
- `git diff --check`

## PR checklist

- [x] The change is based on and targets `dev`
- [x] The change includes a focused regression test
- [x] The commit includes a DCO sign-off

## Automation disclosure

This small bug fix was prepared and tested with OpenAI Codex automation and independently red-teamed by a separate local agent. The contributor remains responsible for the submitted change; no human review is claimed.
