### PR TITLE
fix: preserve string types in schema builder

### DIFF
--- a/nf_core/pipelines/schema.py
+++ b/nf_core/pipelines/schema.py
@@ -933,21 +933,9 @@ class PipelineSchema:
         if isinstance(p_val, float):
             return {"type": "number", "default": p_val}
 
-        # TODO: remove string branch once old text-format config caches are no longer supported
-        p_val = p_val.strip("\"'")
-        if not p_val or p_val == "null":
-            return {"type": "string"}
-        if p_val in ("true", "True"):
-            return {"type": "boolean", "default": True}
-        if p_val in ("false", "False"):
-            return {"type": "boolean"}
-        try:
-            num = float(p_val)
-            if num == int(num):
-                return {"type": "integer", "default": int(num)}
-            return {"type": "number", "default": num}
-        except ValueError:
-            return {"type": "string", "default": p_val}
+        if isinstance(p_val, str):
+            return {"type": "string", "default": p_val} if p_val else {"type": "string"}
+        raise TypeError(f"Unsupported schema parameter type: {type(p_val).__name__}")
 
     def launch_web_builder(self):
         """

--- a/tests/pipelines/test_schema.py
+++ b/tests/pipelines/test_schema.py
@@ -19,6 +19,17 @@ import nf_core.pipelines.schema
 from ..utils import with_temporary_file, with_temporary_folder
 
 
+@pytest.mark.parametrize("value", ["3", "12.34", "true", "false", "null", "text", "", "'3'", '"3"'])
+def test_build_schema_param_preserves_string_type(value):
+    param = nf_core.pipelines.schema.PipelineSchema().build_schema_param(value)
+    assert param == ({"type": "string", "default": value} if value else {"type": "string"})
+
+
+def test_build_schema_param_rejects_unknown_type():
+    with pytest.raises(TypeError, match="Unsupported schema parameter type: list"):
+        nf_core.pipelines.schema.PipelineSchema().build_schema_param([])
+
+
 class TestSchema(unittest.TestCase):
     """Class for schema tests"""
 
@@ -430,17 +441,17 @@ class TestSchema(unittest.TestCase):
 
     def test_build_schema_param_bool(self):
         """Build a new schema param from a config value (bool)"""
-        param = self.schema_obj.build_schema_param("True")
+        param = self.schema_obj.build_schema_param(True)
         assert param == {"type": "boolean", "default": True}
 
     def test_build_schema_param_int(self):
         """Build a new schema param from a config value (int)"""
-        param = self.schema_obj.build_schema_param("12")
+        param = self.schema_obj.build_schema_param(12)
         assert param == {"type": "integer", "default": 12}
 
     def test_build_schema_param_float(self):
         """Build a new schema param from a config value (float)"""
-        param = self.schema_obj.build_schema_param("12.34")
+        param = self.schema_obj.build_schema_param(12.34)
         assert param == {"type": "number", "default": 12.34}
 
     def test_build_schema(self):


### PR DESCRIPTION
## What changed

- preserve typed JSON string values as schema strings instead of re-parsing them as booleans or numbers
- keep the existing `None`, native boolean, integer, float, and empty-string behavior
- raise an explicit `TypeError` for unsupported value types rather than creating an invalid string schema
- update focused tests to reflect the typed JSON contract and cover numeric-looking, boolean-looking, null-like, quoted-content, and empty strings

Since #4271, workflow configuration is loaded with `nextflow config -o json` and `json.loads()`, so a Nextflow value such as `'3'` already reaches `build_schema_param()` as Python `str("3")`. The retained legacy string branch then converted it to an integer, losing the type declared by the pipeline author.

The pre-JSON cache format used flat `params.*` keys, while the current reader expects nested `config["params"]`; those caches do not reach this conversion branch. Cache migration is therefore kept out of this focused fix.

Fixes #4367.

## Validation

- targeted schema parser tests: `10 passed`
- direct typed boundary assertions for strings, `None`, booleans, integers, floats, and unsupported lists
- Ruff 0.15.12 check and format check on both changed files
- `python -m py_compile` on both changed Python files
- `git diff --check`

The broader `TestSchema` fixture currently stops on this Windows checkout with a pre-existing Jinja2 `TemplateNotFound` for `create/template_features.yml`; the new setup-free regression tests and direct typed assertions pass.

## PR checklist

- [x] The change is based on and targets `dev`
- [x] The change includes focused regression coverage
- [x] The commit includes a DCO sign-off

## Automation disclosure

This focused bug fix was prepared and tested with OpenAI Codex automation and independently red-teamed by a separate local agent. The contributor remains responsible for the submitted change; no human review is claimed.
