### PR TITLE
Do not run test with NXF_VER latest-everything on releases

### DIFF
--- a/nf_core/pipeline-template/.github/workflows/nf-test.yml
+++ b/nf_core/pipeline-template/.github/workflows/nf-test.yml
@@ -79,6 +79,8 @@ jobs:
             profile: "conda"
           - isMain: false
             profile: "singularity"
+          - isMain: true
+            NXF_VER: "latest-everything"
         NXF_VER:
           - "25.10.4"
           - "latest-everything"


### PR DESCRIPTION
I do think running test on latest-everything on dev is enough.
We already run on conda, docker and singularity, that would lower the number of tests being run by ~3.

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/main/.github/CONTRIBUTING.md
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
