### PR TITLE
template: add pr-comment for nf-test silent failures with `latest-everything`

### DIFF
--- a/nf_core/pipeline-template/.github/workflows/nf-test.yml
+++ b/nf_core/pipeline-template/.github/workflows/nf-test.yml
@@ -118,6 +118,22 @@ jobs:
             fi
           fi
 
+      # continue-on-error keeps latest-everything from failing the job, so it never shows up in
+      # `needs.nf-test.result` downstream and CI stays green. Surface it via a PR comment instead;
+      # other NXF_VER failures already fail the job/CI directly, so no comment is needed for those.
+      - name: Prepare PR comment fragment
+        if: ${{ always() && steps.run_nf_test.outcome == 'failure' && matrix.NXF_VER == 'latest-everything' }}
+        run: |
+          mkdir -p pr-comment-fragment
+          echo "* ❌ \`${{ matrix.profile }}\` | \`${{ matrix.NXF_VER }}\` | Shard ${{ matrix.shard }}/${{ env.TOTAL_SHARDS }}" > pr-comment-fragment/fragment.md
+
+      - name: Upload PR comment fragment
+        if: ${{ always() && steps.run_nf_test.outcome == 'failure' && matrix.NXF_VER == 'latest-everything' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pr-comment-fragment-${{ strategy.job-index }}
+          path: pr-comment-fragment/
+
   confirm-pass:
     needs: [nf-test]
     if: always()
@@ -144,4 +160,44 @@ jobs:
           echo "::group::DEBUG: `needs` Contents"
           echo "DEBUG: toJSON(needs) = ${{ toJSON(needs) }}"
           echo "DEBUG: toJSON(needs.*.result) = ${{ toJSON(needs.*.result) }}"
-          echo "::endgroup::"{% endraw %}
+          echo "::endgroup::"
+
+      - name: Download PR comment fragments
+        if: ${{ always() }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          pattern: pr-comment-fragment-*
+          path: pr-comment-fragments
+          merge-multiple: true
+
+      # Build a comment for the shared pr-comment.yml poster to publish on the PR.
+      # Based on the fragments above (not needs.*.result) so non-blocking failures are still reported.
+      - name: Prepare PR comment
+        if: ${{ always() }}
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          mkdir -p pr-comment
+          echo "$PR_NUMBER" > pr-comment/pr_number.txt
+          echo "nf-test" > pr-comment/header.txt
+          if [ -d pr-comment-fragments ] && [ -n "$(ls -A pr-comment-fragments)" ]; then
+            {
+              echo "## ❌ nf-test failed"
+              echo ""
+              echo "> [!NOTE]:"
+              echo "> Tests with `latest-everything` failed but will not cause a CI workflow failure. Please check if the error is expected with newer (edge-)releases of Nextflow or if it needs fixing."
+              echo ""
+              cat pr-comment-fragments/*.md
+              echo ""
+              echo "See the [full run](${RUN_URL}) for details."
+            } > pr-comment/comment.md
+          fi
+
+      - name: Upload PR comment artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pr-comment
+          path: pr-comment/{% endraw %}

--- a/nf_core/pipeline-template/.github/workflows/nf-test.yml
+++ b/nf_core/pipeline-template/.github/workflows/nf-test.yml
@@ -184,10 +184,11 @@ jobs:
           echo "nf-test" > pr-comment/header.txt
           if [ -d pr-comment-fragments ] && [ -n "$(ls -A pr-comment-fragments)" ]; then
             {
-              echo "## ❌ nf-test failed"
+              echo "## ❌ nf-test failed with latest Nextflow version"
               echo ""
-              echo "> [!NOTE]:"
-              echo "> Tests with `latest-everything` failed but will not cause a CI workflow failure. Please check if the error is expected with newer (edge-)releases of Nextflow or if it needs fixing."
+              echo "> [!NOTE]"
+              echo "> Tests with Nextflow's latest version failed but it will not cause a CI workflow failure."
+              echo "> Please check if the failure is expected with newer (edge-)releases of Nextflow or if it needs fixing."
               echo ""
               cat pr-comment-fragments/*.md
               echo ""

--- a/nf_core/pipeline-template/.github/workflows/pr-comment.yml
+++ b/nf_core/pipeline-template/.github/workflows/pr-comment.yml
@@ -35,6 +35,7 @@ jobs:
         with:{% raw %}
           run_id: ${{ github.event.workflow_run.id }}
           name: pr-comment
+          path: pr-comment
           if_no_artifact_found: ignore
 
       - name: Read comment metadata

--- a/nf_core/pipeline-template/.github/workflows/pr-comment.yml
+++ b/nf_core/pipeline-template/.github/workflows/pr-comment.yml
@@ -18,6 +18,7 @@ on:
       - "nf-core linting"
       - "nf-core template version comment"
       - "nf-core branch protection"
+      - "Run nf-test"
 
 permissions:
   actions: read
@@ -27,7 +28,6 @@ permissions:
 jobs:
   post-comment:
     runs-on: ubuntu-latest
-    # Only act on runs that were triggered by a pull request.
     if: github.event.workflow_run.event == 'pull_request'
     steps:
       - name: Download PR comment artifact

--- a/nf_core/pipeline-template/.github/workflows/pr-comment.yml
+++ b/nf_core/pipeline-template/.github/workflows/pr-comment.yml
@@ -40,11 +40,23 @@ jobs:
       - name: Read comment metadata
         id: meta
         run: |
-          # No comment body means there is nothing to post.
-          [ -f pr-comment/comment.md ] || exit 0
+          echo "::group::Downloaded pr-comment contents"
+          ls -la pr-comment 2>/dev/null || echo "No pr-comment/ directory was downloaded."
+          echo "::endgroup::"
+
+          if [ ! -d pr-comment ]; then
+            echo "No pr-comment artifact found; nothing to post."
+            exit 0
+          fi
+
+          if [ ! -f pr-comment/comment.md ]; then
+            echo "Artifact present but no comment.md; nothing to post."
+            exit 0
+          fi
 
           pr_number=$(cat pr-comment/pr_number.txt)
           header=$(cat pr-comment/header.txt)
+          echo "Found comment.md (header='$header', pr_number='$pr_number')."
 
           # Guard against anything unexpected ending up in the PR number.
           case "$pr_number" in
@@ -57,6 +69,7 @@ jobs:
           echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
           echo "header=$header" >> "$GITHUB_OUTPUT"
           echo "post=true" >> "$GITHUB_OUTPUT"
+          echo "Will post comment to PR #${pr_number}."
 
       - name: Post PR comment
         if: steps.meta.outputs.post == 'true'


### PR DESCRIPTION
Currently nf-test failures with `latest-everything` fail silently (they post in the summary, but nobody reads that). 
This makes their hidden failure more visible be posting to the PR itself.

Includes debugging and fixes for `pr-comment.yml` as tested in the [testpipeline](https://github.com/nf-core/testpipeline/pull/149).