### PR TITLE
fix changelog action

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,27 +3,46 @@ on:
   issue_comment:
     types: [created] # Add "@nf-core-bot changelog" as a PR comment to trigger this workflow.
 
+permissions: {}
+
 jobs:
   update_changelog:
     runs-on: ubuntu-latest
-    if: contains(github.event.comment.body, '@nf-core-bot changelog')
+    if: >
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '@nf-core-bot changelog')
 
     steps:
-      - name: branch-deploy
-        id: branch-deploy
-        if: github.event_name == 'issue_comment'
-        uses: github/branch-deploy@f0984057ffe1aa340aa017b6eafb894310aed88e # v12.0.0
-        with:
-          trigger: "@nf-core-bot changelog"
-          reaction: "eyes"
-          stable_branch: "dev"
+      - name: Verify commenter is on the nf-core/infrastructure team
+        env:
+          GH_TOKEN: ${{ secrets.NF_CORE_BOT_AUTH_TOKEN }}
+          ACTOR: ${{ github.event.comment.user.login }}
+        run: |
+          state=$(gh api "orgs/nf-core/teams/infrastructure/memberships/${ACTOR}" --jq '.state' 2>/dev/null || true)
+          if [ "$state" != "active" ]; then
+            echo "::error::@${ACTOR} is not an active member of nf-core/infrastructure; refusing to run."
+            exit 1
+          fi
+          echo "@${ACTOR} is on nf-core/infrastructure — proceeding."
 
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: React to the triggering comment
+        env:
+          GH_TOKEN: ${{ secrets.NF_CORE_BOT_AUTH_TOKEN }}
+        run: |
+          gh api --method POST \
+            "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content=eyes
+
+      # Checks out the base ref (the trusted version of the repo) first.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.NF_CORE_BOT_AUTH_TOKEN }}
 
-      # Action runs on the issue comment, so we don't get the PR by default.
-      # Use the GitHub CLI to check out the PR:
+      - name: Save trusted scripts
+        run: |
+          cp "${GITHUB_WORKSPACE}/.github/workflows/changelog.py" "${RUNNER_TEMP}/changelog.py"
+          cp "${GITHUB_WORKSPACE}/.pre-commit-config.yaml" "${RUNNER_TEMP}/pre-commit-config.yaml"
+
       - name: Checkout Pull Request
         env:
           GH_TOKEN: ${{ secrets.NF_CORE_BOT_AUTH_TOKEN }}
@@ -45,19 +64,19 @@ jobs:
           PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.issue.title || github.event.pull_request.title }}
         run: |
-          python ${GITHUB_WORKSPACE}/.github/workflows/changelog.py
+          python "${RUNNER_TEMP}/changelog.py"
 
       - name: Check if CHANGELOG.md actually changed
         id: file_changed
         run: |
           # Show the diff for debugging
-          git diff -- ${GITHUB_WORKSPACE}/CHANGELOG.md
+          git diff -- "${GITHUB_WORKSPACE}/CHANGELOG.md"
 
           # Check if file has unstaged changes
-          [ -n "$(git diff -- ${GITHUB_WORKSPACE}/CHANGELOG.md)" ] && file_changed="TRUE" || file_changed="FALSE"
+          [ -n "$(git diff -- "${GITHUB_WORKSPACE}/CHANGELOG.md")" ] && file_changed="TRUE" || file_changed="FALSE"
 
           echo "File changed: $file_changed"
-          echo "changed=$file_changed" >> $GITHUB_OUTPUT
+          echo "changed=$file_changed" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python 3.14
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
@@ -65,10 +84,11 @@ jobs:
           python-version: "3.14"
 
       - name: Run pre-commit rules with prek
+        if: steps.file_changed.outputs.changed == 'TRUE'
         uses: j178/prek-action@5337cb91e0fa35a7ff31b9ca345126d8bbbcdf16 # v2
         continue-on-error: true
         with:
-          extra-args: --config .pre-commit-config.yaml --all-files
+          extra-args: --config ${{ runner.temp }}/pre-commit-config.yaml --files CHANGELOG.md
 
       - name: Commit and push changes
         if: steps.file_changed.outputs.changed == 'TRUE'
@@ -77,7 +97,7 @@ jobs:
         run: |
           git config user.email "core@nf-co.re"
           git config user.name "nf-core-bot"
-          git add ${GITHUB_WORKSPACE}/CHANGELOG.md
+          git add "${GITHUB_WORKSPACE}/CHANGELOG.md"
           git status
           git commit -m "[automated] Update CHANGELOG.md [skip ci]"
           git push


### PR DESCRIPTION
Switches from the broken branch-deploy action to a one just triggered through a comment from an nf-core member. 
Only runs the script from the nf-core repo to avoid code injections.