### PR TITLE
Clear the nf-test PR comment once its failure is fixed

### DIFF
--- a/nf_core/pipeline-template/.github/workflows/nf-test.yml
+++ b/nf_core/pipeline-template/.github/workflows/nf-test.yml
@@ -194,6 +194,9 @@ jobs:
               echo ""
               echo "See the [full run](${RUN_URL}) for details."
             } > pr-comment/comment.md
+          else
+            # Clear the comment a previous failing run left on this PR.
+            touch pr-comment/delete
           fi
 
       - name: Upload PR comment artifact

--- a/nf_core/pipeline-template/.github/workflows/pr-comment.yml
+++ b/nf_core/pipeline-template/.github/workflows/pr-comment.yml
@@ -11,6 +11,7 @@ name: Post PR comment
 #   pr_number.txt  - the pull request number
 #   header.txt     - sticky-comment identifier (keeps comment types separate)
 #   comment.md     - the Markdown body (omit the file to post nothing)
+#   delete         - optional marker; delete this header's existing comment
 
 on:
   workflow_run:
@@ -50,14 +51,18 @@ jobs:
             exit 0
           fi
 
-          if [ ! -f pr-comment/comment.md ]; then
-            echo "Artifact present but no comment.md; nothing to post."
+          if [ -f pr-comment/comment.md ]; then
+            action=post
+          elif [ -f pr-comment/delete ]; then
+            action=delete
+          else
+            echo "Artifact present but no comment.md or delete marker; nothing to do."
             exit 0
           fi
 
           pr_number=$(cat pr-comment/pr_number.txt)
           header=$(cat pr-comment/header.txt)
-          echo "Found comment.md (header='$header', pr_number='$pr_number')."
+          echo "Requested action: $action (header='$header', pr_number='$pr_number')."
 
           # Guard against anything unexpected ending up in the PR number.
           case "$pr_number" in
@@ -69,8 +74,8 @@ jobs:
 
           echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
           echo "header=$header" >> "$GITHUB_OUTPUT"
-          echo "post=true" >> "$GITHUB_OUTPUT"
-          echo "Will post comment to PR #${pr_number}."
+          echo "$action=true" >> "$GITHUB_OUTPUT"
+          echo "Will $action comment on PR #${pr_number}."
 
       - name: Post PR comment
         if: steps.meta.outputs.post == 'true'
@@ -79,4 +84,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ steps.meta.outputs.pr_number }}
           header: ${{ steps.meta.outputs.header }}
-          path: pr-comment/comment.md{%- endraw %}
+          path: pr-comment/comment.md
+
+      # Producers request this once their failure clears, so a fixed PR does not keep
+      # showing the previous run's failure comment.
+      - name: Delete stale PR comment
+        if: steps.meta.outputs.delete == 'true'
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ steps.meta.outputs.pr_number }}
+          header: ${{ steps.meta.outputs.header }}
+          delete: "true"{%- endraw %}


### PR DESCRIPTION
The ❌ nf-test comment for `latest-everything` failures can currently only be added, never cleared. The producer writes `pr-comment/comment.md` only when failure fragments exist, so once a PR fixes the failure the poster has nothing to publish and the previous comment stays put — a green PR keeps showing a stale cross. This adds an optional `delete` marker to the `pr-comment` artifact contract: nf-test touches it when no leg failed, and the poster deletes that header's comment instead of posting one. Producers that write neither file behave exactly as before, so linting, template-version and branch-protection comments are untouched.

<details>
<summary>Verification notes (AI-assisted)</summary>

Found on a real pipeline PR ([nf-core/riboseq#222](https://github.com/nf-core/riboseq/pull/222)), which sat fully green while displaying a failure comment that pointed at a cancelled run. The comment cannot self-clear, so it had to be corrected by hand.

- `delete` is a real input on `marocchino/sticky-pull-request-comment` at the already-pinned SHA `5770ad5` (v3.0.5): *"delete the previously created comment. Only `true` is allowed."* Deletion is scoped by `header`, so producers stay independent of one another.
- Simulated the reworked metadata step over five cases: `comment.md` present → `post`; `delete` marker only → `delete`; neither → early exit unchanged (the path the other three producers take); both present → `post` wins; `delete` marker with an empty PR number → the existing numeric guard still rejects it.
- `nf-test.yml` also fires on `release` and `workflow_dispatch`, where `github.event.pull_request.number` is empty. Those never reach the poster, which is gated on `github.event.workflow_run.event == 'pull_request'`, so the new marker cannot trip that guard.
- The new step is inside the existing `{% raw %}` block, so its `${{ ... }}` expressions are not Jinja-interpreted; `{%- endraw %}` moves to the new final line. `pr-comment.yml` parses as YAML with the raw tags stripped. `nf-test.yml`'s change is inside a `run: |` block scalar.

</details>
