### PR TITLE
Accept a bare `pull_request:` in the nf-test workflow trigger

### DIFF
--- a/nf_core/pipelines/lint/actions_nf_test.py
+++ b/nf_core/pipelines/lint/actions_nf_test.py
@@ -51,8 +51,9 @@ def actions_nf_test(self):
     # Check that the action is turned on for the correct events
     try:
         # NB: YAML dict key 'on' is evaluated to a Python dict key True
-        pr_subtree = ciwf[True]["pull_request"]
-        if pr_subtree is None:
+        # `pull_request:` with no subtree is valid and parses to None, so test for
+        # the key rather than its value.
+        if "pull_request" not in ciwf[True]:
             raise AssertionError
         if "published" not in ciwf[True]["release"]["types"]:
             raise AssertionError

--- a/tests/pipelines/lint/test_actions_nf_test.py
+++ b/tests/pipelines/lint/test_actions_nf_test.py
@@ -20,6 +20,23 @@ class TestLintActionsNfTest(TestLint):
         assert len(results.get("failed", [])) == 0
         assert len(results.get("ignored", [])) == 0
 
+    def test_actions_nf_test_pass_bare_pull_request(self):
+        """Lint test: actions_nf_test - PASS - `pull_request:` carries no subtree"""
+
+        new_pipeline = self._make_pipeline_copy()
+        with open(Path(new_pipeline, ".github", "workflows", "nf-test.yml")) as fh:
+            ci_yml = yaml.safe_load(fh)
+        ci_yml[True]["pull_request"] = None
+        with open(Path(new_pipeline, ".github", "workflows", "nf-test.yml"), "w") as fh:
+            yaml.dump(ci_yml, fh)
+
+        lint_obj = nf_core.pipelines.lint.PipelineLint(new_pipeline)
+        lint_obj._load()
+
+        results = lint_obj.actions_nf_test()
+        assert "'.github/workflows/nf-test.yml' is triggered on expected events" in results["passed"]
+        assert len(results.get("failed", [])) == 0
+
     def test_actions_nf_test_fail_wrong_nf(self):
         """Lint test: actions_nf_test - FAIL - wrong minimum version of Nextflow tested"""
         self.lint_obj._load()


### PR DESCRIPTION
`actions_nf_test` documents the expected trigger as a bare `pull_request:`, then fails when that subtree parses to `None` — which is exactly what a bare key gives, so the documented form is rejected. This tests for the key instead of its value, which is what `test_actions_nf_test_fail_wrong_trigger` already assumes: it pops the key entirely to provoke the failure. A test for the bare form comes with it.

I ran into this removing `paths-ignore` from a pipeline's `nf-test.yml` so that a required `confirm-pass` check could report on docs-only PRs — without that filter the workflow is skipped, the check never reports, and the PR is permanently blocked. Happy to add a CHANGELOG entry; `dev` has no unreleased section open yet so I left it alone.

<details>
<summary>Behaviour across the four trigger shapes (AI-assisted)</summary>

| `on:` shape | before | after |
| --- | --- | --- |
| template form, `paths-ignore` present | pass | pass |
| **documented form, bare `pull_request:`** | **fail** | **pass** |
| explicit `types: [opened, …]` | pass | pass |
| `pull_request` key absent (existing failure test) | fail | fail |

So one case changes and the two existing tests are unaffected.

</details>
