### PR TITLE
Fix the always-empty Nextflow version in the CodSpeed workflow

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -38,8 +38,6 @@ jobs:
 
       - name: Install Nextflow
         uses: nf-core/setup-nextflow@893c28b667aedeba26e37f296d260ccc5bc4d914 # v3
-        with:
-          version: ${{ github.event.inputs.nextflow-version || matrix.nextflow-version }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0


### PR DESCRIPTION
`codspeed.yml` passes `version: ${{ github.event.inputs.nextflow-version || matrix.nextflow-version }}` to `setup-nextflow`, but this workflow declares neither operand — its `workflow_dispatch:` is bare and the job has no `strategy:` — so the value is always an empty string, which explicitly overrides the action's own `latest-stable` default. The job fails at `Install Nextflow` with `Could not retrieve Nextflow release matching .` and has never completed. Dropping the `with:` block lets the default apply. Happy to pin an explicit version instead if you'd rather keep the benchmarks on a fixed Nextflow.

<details>
<summary>Detail (AI-assisted)</summary>

- The step looks copied from `pytest.yml`, which does declare both operands (a `workflow_dispatch` input and a `nextflow-version` matrix axis), so the same expression resolves there.
- The action's message blames the nf-co.re endpoint, but that endpoint returns well-formed JSON — the empty string after `matching` is the actual tell.
- The last 12 runs of this workflow are 11 × `failure` and 1 × `cancelled`, back to 2026-07-29, on `main` and `dev` as well as PR branches.

</details>
