### PR TITLE
Remove ext.use_gpu remnants (superseded by task.accelerator)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # nf-core/tools: Changelog
 
+## v4.1.1dev
+
+### General
+
+### Linting
+
+- remove `ext.use_gpu` as a permitted ext key, superseded by `task.accelerator` ([#4445](https://github.com/nf-core/tools/pull/4445))
+
+### Modules
+
+### Subworkflows
+
+### Template
+
+- remove redundant `ext.use_gpu` from the `process_gpu` label, use `accelerator` only ([#4445](https://github.com/nf-core/tools/pull/4445))
+
+#### Version updates
+
 ## [v4.1.0 - Marshalled Mamba](https://github.com/nf-core/tools/releases/tag/4.1.0) - [2026-07-29]
 
 ### General

--- a/nf_core/modules/lint/main_nf.py
+++ b/nf_core/modules/lint/main_nf.py
@@ -409,7 +409,7 @@ def check_script_section(self, lines):
         )
 
     # Validate ext keys
-    permitted_ext_keys = {"ext.args", "ext.prefix", "ext.prefix2", "ext.use_gpu"}
+    permitted_ext_keys = {"ext.args", "ext.prefix", "ext.prefix2"}
     invalid_ext_keys = [
         key
         for key in re.findall(r"\bext\.\w+", script)

--- a/nf_core/pipeline-template/conf/base.config
+++ b/nf_core/pipeline-template/conf/base.config
@@ -63,7 +63,6 @@ process {
         maxRetries    = 2
     }
     withLabel: process_gpu {
-        ext.use_gpu = { workflow.profile.contains('gpu') }
         accelerator = { workflow.profile.contains('gpu') ? 1 : null }
     }
 }

--- a/nf_core/pipelines/create/template_features.yml
+++ b/nf_core/pipelines/create/template_features.yml
@@ -385,7 +385,7 @@ configurations:
       short_description: "Use GPU"
       description: "Add GPU support to the pipeline"
       help_text: |
-        This will add GPU support to the pipeline. It will add a `use_gpu` parameter to the pipeline.
+        This will add GPU support to the pipeline via the `process_gpu` label, using the `accelerator` directive.
         The pipeline will be able to run on GPU-enabled compute environments.
       nfcore_pipelines: True
       custom_pipelines: True

--- a/tests/data/mock_pipeline_containers/conf/base.config
+++ b/tests/data/mock_pipeline_containers/conf/base.config
@@ -60,7 +60,6 @@ process {
         maxRetries    = 2
     }
     withLabel: process_gpu {
-        ext.use_gpu = { workflow.profile.contains('gpu') }
         accelerator = { workflow.profile.contains('gpu') ? 1 : null }
     }
 }

--- a/tests/modules/lint/test_main_nf.py
+++ b/tests/modules/lint/test_main_nf.py
@@ -1250,7 +1250,6 @@ def test_validate_ext_keys():
     def args3 = task.ext.args3 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def prefix2 = task.ext.prefix2 ?: ''
-    def use_gpu = task.ext.use_gpu ? '--gpu' : ''
     """
         ],
     )
@@ -1268,6 +1267,7 @@ def test_validate_ext_keys():
     def prefix1 = task.ext.prefix1 ?: ''
     def prefix3 = task.ext.prefix3 ?: ''
     def prefix22 = task.ext.prefix22 ?: ''
+    def use_gpu = task.ext.use_gpu ? '--gpu' : ''
     """
         ],
     )
@@ -1278,6 +1278,7 @@ def test_validate_ext_keys():
     assert "ext.prefix1" in mock_lint.failed[0][2]
     assert "ext.prefix3" in mock_lint.failed[0][2]
     assert "ext.prefix22" in mock_lint.failed[0][2]
+    assert "ext.use_gpu" in mock_lint.failed[0][2]
 
     # ext.argsN where N >= 2 should be valid
     mock_lint.passed, mock_lint.failed = [], []


### PR DESCRIPTION
## Summary
`ext.use_gpu` is superseded by Nextflow's native `task.accelerator` directive. This removes the remaining `ext.use_gpu` references:

- Removed the redundant `ext.use_gpu` line from the `process_gpu` label in the pipeline template's `base.config`
- Removed `ext.use_gpu` from the module linter's permitted ext keys
- Updated the `create` wizard's `gpu` feature help text to describe `accelerator` instead of a nonexistent `use_gpu` parameter