### PR TITLE
Round-trip `ci:` block in `.nf-core.yml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### General
 
-- Round-trip the `ci:` block in `.nf-core.yml` so centralised nf-core/actions CI config is not dropped by `sync`/`bump-version` ([#4432](https://github.com/nf-core/tools/pull/4432))
+- Round-trip the `ci:` block in `.nf-core.yml` so centralised nf-core/actions CI config is not dropped by `sync`/`bump-version` ([#4453](https://github.com/nf-core/tools/pull/4453))
 
 ## [v4.1.0 - Marshalled Mamba](https://github.com/nf-core/tools/releases/tag/4.1.0) - [2026-07-29]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # nf-core/tools: Changelog
 
+## [unreleased]
+
+### General
+
+- Round-trip the `ci:` block in `.nf-core.yml` so centralised nf-core/actions CI config is not dropped by `sync`/`bump-version` ([#4432](https://github.com/nf-core/tools/pull/4432))
+
 ## [v4.1.0 - Marshalled Mamba](https://github.com/nf-core/tools/releases/tag/4.1.0) - [2026-07-29]
 
 ### General

--- a/nf_core/pydantic_models.py
+++ b/nf_core/pydantic_models.py
@@ -183,6 +183,13 @@ class NFCoreYamlConfig(BaseModel):
     """ Disable updating specific modules/subworkflows (when repository_type is pipeline). See https://nf-co.re/docs/nf-core-tools/modules/update for more information. """
     container_registry: list[str] | None = Field(default=None, alias="container-registry")
     """ Additional container registry prefixes allowed when linting container directives. """
+    ci: dict[str, Any] | None = None
+    """ Configuration passed through to the centralised nf-core/actions CI workflows.
+    Deliberately a permissive dict rather than a typed model: nf-core/actions defines and
+    adds these keys independently (see src/actions/read-config/registry.ts in that repo). A
+    strict schema here would mean every new CI setting needs a tools release plus a template
+    sync before any pipeline could use it, reintroducing the coupling that centralising the
+    workflows removed. tools only needs to round-trip this block, not validate it. """
 
     def __getitem__(self, item: str) -> Any:
         return getattr(self, item)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -272,3 +272,19 @@ class TestUtils(TestPipelines):
         files = nf_core.utils.get_wf_files(tmpdir)
         files = sorted(str(Path(f).relative_to(tmpdir)) for f in files)
         assert files == [".gitignore", "dir1/should-match-1", "should-match-2"]
+
+
+@pytest.mark.parametrize("repository_type", ["pipeline", "modules"])
+def test_nfcore_yml_ci_round_trip(repository_type):
+    """The `ci:` block (consumed by nf-core/actions) must survive a model_dump() rewrite."""
+    from nf_core.pydantic_models import NFCoreYamlConfig
+
+    ci = {
+        "nf_test_version": "0.9.0",
+        "nextflow_versions": ["24.04.2", "latest-stable"],
+        "profiles": ["docker", "singularity"],
+        "max_shards": 5,
+        "some_future_key": "value nf-core/actions may add independently",
+    }
+    config = NFCoreYamlConfig(repository_type=repository_type, ci=ci)
+    assert config.model_dump()["ci"] == ci


### PR DESCRIPTION
Tied to proof-of-concept around centralised GitHub actions in `nf-core/actions`. That repo adds new config scope in `nf-core-config.yml` and this PR lets tools know about it so that it doesn't get wiped.

Feel free to ignore until strategy around centralised actions is decided, just didn't want to forget about it.

<details>

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated

## Description

A new top-level `ci:` block in `.nf-core.yml` is consumed by the centralised workflows in nf-core/actions (keys defined in that repo at `src/actions/read-config/registry.ts`: `nf_test_version`, `nextflow_versions`, `profiles`, `max_shards`, `nf_test_workdir`, `runner`, `nextflow_lint`, `awsfulltest_required_approvals`, all optional).

`NFCoreYamlConfig` in `nf_core/pydantic_models.py` rebuilds `.nf-core.yml` from known fields only in its `model_dump()`, so any `ci:` block was silently dropped whenever tools rewrote the file (`sync`, `bump-version`), deleting a pipeline's CI configuration.

This adds an optional `ci` field so the block round-trips.

It is deliberately a permissive `dict[str, Any]` rather than a strictly typed model: nf-core/actions adds and defines these keys independently, and a strict schema here would mean every new CI setting needs a tools release plus a template sync before any pipeline could use it — reintroducing exactly the coupling that centralising the workflows removed. tools only needs to round-trip this block, not validate it.

`nf-core pipelines lint` needs no change: the `nfcore_yml` lint test only checks specific known keys and does not flag unknown top-level blocks.

Tests cover the round-trip of a config containing `ci:` for both `repository_type` values.

</details>