### PR TITLE
VSCode: add recommended extensions, fix link to admonition styling CSS for markdown previews

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+    // See https://github.com/nf-core/vscode-extensionpack
+    "recommendations": [
+        "charliermarsh.ruff",
+        "codezombiech.gitignore",
+        "esbenp.prettier-vscode",
+        "jebbs.markdown-extended",
+        "mechatroner.rainbow-csv",
+        "nextflow.nextflow",
+        "onnovalkering.vscode-singularity",
+        "redhat.vscode-yaml"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,10 @@
             "source.fixAll": "explicit",
             "source.organizeImports": "explicit"
         }
-    }
+    },
+
+    // Render nf-core website admonitions nicely in markdown previews
+    // https://github.com/nf-core/website/pull/2579
+    "markdown.styles": ["https://nf-co.re/vscode_markdown.css"]
+
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,4 @@
     // Render nf-core website admonitions nicely in markdown previews
     // https://github.com/nf-core/website/pull/2579
     "markdown.styles": ["https://nf-co.re/vscode_markdown.css"]
-
 }

--- a/nf_core/pipeline-template/.vscode/extensions.json
+++ b/nf_core/pipeline-template/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+    // See https://github.com/nf-core/vscode-extensionpack
+    "recommendations": [
+        "codezombiech.gitignore",
+        "esbenp.prettier-vscode",
+        "jebbs.markdown-extended",
+        "mechatroner.rainbow-csv",
+        "nextflow.nextflow",
+        "onnovalkering.vscode-singularity",
+        "redhat.vscode-yaml"
+    ]
+}

--- a/nf_core/pipeline-template/.vscode/settings.json
+++ b/nf_core/pipeline-template/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-    "markdown.styles": ["public/vscode_markdown.css"]
+    // Render nf-core website admonitions nicely in markdown previews
+    // https://github.com/nf-core/website/pull/2579
+    "markdown.styles": ["https://nf-co.re/vscode_markdown.css"]
 }


### PR DESCRIPTION
I added in the settings file to point to the CSS file for docs admonition styling in markdown previews, back in 2024. But I made a copy-paste error so it never worked. See https://github.com/nf-core/website/pull/2579 for original feature.

Fixing the path here to be a URL, that does something and actually works now (tested locally).

Also added a new `extensions.json` file that gets VS Code to show a little pop-up recommending that the user installs the listed plugins. I've done it as a slightly conservative sub-list of https://github.com/nf-core/vscode-extensionpack

These recommended extensions include [Markdown Extended](https://marketplace.visualstudio.com/items?itemName=jebbs.markdown-extended), which is needed for the admonition styling to work.

Side note: comments are tolerated in JSON files for VSCode. Tested locally and fine.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
