### PR TITLE
modules bump-versions: match nf-core container formatting in main.nf

### DIFF
--- a/nf_core/modules/containers.py
+++ b/nf_core/modules/containers.py
@@ -322,10 +322,10 @@ class ModuleContainers:
             indent = match.group(1)
             inner_indent = indent + "    "
             return (
-                f"{indent}container \"${{ workflow.containerEngine in ['singularity', 'apptainer'] "
+                f"{indent}container \"${{workflow.containerEngine in ['singularity', 'apptainer'] "
                 "&& !task.ext.singularity_pull_docker_container\n"
-                f"? {inner_indent}'{singularity_image}'\n"
-                f": {inner_indent}'{docker_image}' }}\""
+                f"{inner_indent}? '{singularity_image}'\n"
+                f"{inner_indent}: '{docker_image}'}}\""
             )
 
         new_content = re.sub(

--- a/tests/modules/test_containers.py
+++ b/tests/modules/test_containers.py
@@ -350,6 +350,30 @@ class TestModuleContainers(TestModules):
         assert result is not None
         assert result == MetaYmlContainers.model_validate(containers)
 
+    def test_update_main_nf_container_matches_nf_core_formatting(self):
+        """The rewritten directive must match the formatting used across nf-core/modules.
+
+        The ternary operators belong at the start of the indented continuation lines,
+        and there is no padding inside `${...}`.
+        """
+        singularity = "https://community-cr-prod.seqera.io/blobs/sha256/e6/e613097/data"
+        docker = "community.wave.seqera.io/library/bpipe_test:0.1.0--abc123"
+        self.module_containers.containers = MetaYmlContainers(
+            docker={p: ContainerEntry(name=docker) for p in CONTAINER_PLATFORMS},
+            singularity={p: ContainerEntry(name=singularity) for p in CONTAINER_PLATFORMS},
+        )
+
+        main_nf = self.bpipe_test_module_path / "main.nf"
+        self.module_containers.update_main_nf_container(force=True)
+
+        expected = (
+            "    container \"${workflow.containerEngine in ['singularity', 'apptainer'] "
+            "&& !task.ext.singularity_pull_docker_container\n"
+            f"        ? '{singularity}'\n"
+            f"        : '{docker}'}}\""
+        )
+        assert expected in main_nf.read_text()
+
     def test_update_containers_in_meta_merges(self):
         self._write_meta({"name": "bpipe/test", "containers": {"docker": {"linux/amd64": {"name": "old"}}}})
         containers = self._containers_by_system("new")


### PR DESCRIPTION
`nf-core modules bump-versions` rewrites the container directive in `main.nf` after the Wave build, and the block it writes puts the ternary operators at column 0 and pads the inside of `${...}`:

```groovy
    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
?         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/e6/e613097.../data'
:         'community.wave.seqera.io/library/fgumi:0.6.0--c97194d17da0d1cd' }"
```

That is the shape nf-core/modules#12756 had to undo by hand across every bumped module.

Everywhere else in nf-core/modules, and in the modules this repo ships in `nf_core/pipeline-template/modules/nf-core/{fastqc,multiqc}/main.nf`, the directive reads:

```groovy
    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/e6/e613097.../data'
        : 'community.wave.seqera.io/library/fgumi:0.6.0--c97194d17da0d1cd'}"
```

`update_main_nf_container()` in `nf_core/modules/containers.py` builds the replacement from an f-string that emits `? {inner_indent}` where it means `{inner_indent}? `. Moving the operators behind the indent and dropping the padding inside `${...}` is the whole change.

## Verification

`tests/modules/test_containers.py` does not run on my machine: `TestModules.setUp` builds a pipeline through `nextflow config`, and nextflow is not installed here. On unmodified `dev` all 38 tests in that file error out in setup, so a local pass/fail there would mean nothing either way — the new test is written for CI.

What I could check directly, by driving `ModuleContainers.update_main_nf_container()` against a temporary modules repo:

- on `dev`, the rewritten directive is byte-identical to the broken block above
- with this patch, it is byte-identical to `modules/nf-core/samtools/sort/main.nf` on nf-core/modules `master`

`ruff check` and `ruff format --check` are clean on both changed files.

## CHANGELOG

Not touched. `CHANGELOG.md` has no running dev section since 4.1.0 shipped, and `.github/workflows/changelog.py` appends into one that already exists — happy for `@nf-core-bot changelog` to add the entry once there is a section to add it to, or to add it myself if you would rather pick the version heading now.

Fixes #4452
