### PR TITLE
Add `manifest.diagram` to the pipeline template, with linting

### DIFF
--- a/.github/actions/create-lint-wf/action.yml
+++ b/.github/actions/create-lint-wf/action.yml
@@ -76,6 +76,15 @@ runs:
       run: find nf-core-testpipeline -not -path '*/.git/*' -type f -exec sed -i 's/\/\/ includeConfig/includeConfig/' {} \;
       working-directory: create-lint-wf
 
+    # Add a placeholder metro map and enable manifest.diagram
+    - name: add metro map
+      shell: bash
+      run: |
+        mkdir -p nf-core-testpipeline/docs/images
+        touch nf-core-testpipeline/docs/images/metro_map.svg
+        sed -i 's|// diagram|diagram|' nf-core-testpipeline/nextflow.config
+      working-directory: create-lint-wf
+
     # Replace zenodo.XXXXXX to pass readme linting
     - name: replace zenodo.XXXXXX
       shell: bash

--- a/.github/workflows/create-test-lint-wf-template.yml
+++ b/.github/workflows/create-test-lint-wf-template.yml
@@ -164,6 +164,14 @@ jobs:
         run: find my-prefix-testpipeline -type f -exec sed -i 's/\/\/ includeConfig/includeConfig/' {} \;
         working-directory: create-test-lint-wf
 
+      # Add a placeholder metro map and enable manifest.diagram
+      - name: add metro map
+        run: |
+          mkdir -p my-prefix-testpipeline/docs/images
+          touch my-prefix-testpipeline/docs/images/metro_map.svg
+          sed -i 's|// diagram|diagram|' my-prefix-testpipeline/nextflow.config
+        working-directory: create-test-lint-wf
+
       # Replace zenodo.XXXXXX to pass readme linting
       - name: replace zenodo.XXXXXX
         run: find my-prefix-testpipeline -type f -exec sed -i 's/zenodo.XXXXXX/zenodo.123456/g' {} \;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Linting
 
-- Warn if `manifest.diagram` is not set, and fail if it points at a file that does not exist ([#4460](https://github.com/nf-core/tools/pull/4460))
+- Warn if `manifest.diagram` is not set, and fail if it is not a relative path to an existing image file ([#4460](https://github.com/nf-core/tools/pull/4460))
 
 ### Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@
 
 ### Linting
 
+- Warn if `manifest.diagram` is not set, and fail if it points at a file that does not exist ([#4460](https://github.com/nf-core/tools/pull/4460))
+
 ### Modules
 
 ### Subworkflows
 
 ### Template
+
+- Add a commented-out `manifest.diagram` to `nextflow.config`, for the pipeline metro map ([#4460](https://github.com/nf-core/tools/pull/4460))
 
 ### Version updates
 

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -313,6 +313,10 @@ manifest {
     nextflowVersion = '!>=25.10.4'
     version         = '{{ version }}'
     doi             = ''
+    // TODO nf-core: Draw a metro map for your pipeline, save it to `docs/images/` and uncomment the line below.
+    //               Any SVG works, including hand-drawn ones. If you'd like a hand, nf-metro can generate one
+    //               from a config file: https://seqeralabs.github.io/nf-metro/latest/
+    // diagram      = 'docs/images/metro_map.svg'
 }
 
 {% if nf_schema -%}

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -313,9 +313,7 @@ manifest {
     nextflowVersion = '!>=25.10.4'
     version         = '{{ version }}'
     doi             = ''
-    // TODO nf-core: Draw a metro map for your pipeline, save it to `docs/images/` and uncomment the line below.
-    //               Any SVG works, including hand-drawn ones. If you'd like a hand, nf-metro can generate one
-    //               from a config file: https://seqeralabs.github.io/nf-metro/latest/
+    // TODO nf-core: Make a metro map (nf-metro or drawn) and add relative path to the SVG below
     // diagram      = 'docs/images/metro_map.svg'
 }
 

--- a/nf_core/pipelines/lint/nextflow_config.py
+++ b/nf_core/pipelines/lint/nextflow_config.py
@@ -7,6 +7,9 @@ from nf_core.utils import load_tools_config
 
 log = logging.getLogger(__name__)
 
+# Image formats that Nextflow accepts for `manifest.diagram`
+DIAGRAM_EXTENSIONS = {".svg", ".png", ".jpg", ".jpeg", ".gif", ".webp"}
+
 
 def nextflow_config(self) -> dict[str, list[str]]:
     """Checks the pipeline configuration for required variables.
@@ -74,7 +77,7 @@ def nextflow_config(self) -> dict[str, list[str]]:
       * Any SVG works, including hand-drawn ones. `nf-metro <https://seqeralabs.github.io/nf-metro/latest/>`_
         can generate one from a config file, if you'd like a hand.
       * Requires Nextflow ``26.10.0`` or later, but is safe to set for older versions - they ignore it.
-      * If set, the file must exist in the pipeline or the test **fails** (see below)
+      * If set, the value must be valid or the test **fails** (see below)
 
     * ``timeline.file``, ``trace.file``, ``report.file``, ``dag.file``
 
@@ -83,7 +86,11 @@ def nextflow_config(self) -> dict[str, list[str]]:
 
     **The following variables fail the test if they are set to an invalid value:**
 
-    * ``manifest.diagram``: must be a relative path to a file that exists in the pipeline, not a URL
+    * ``manifest.diagram``
+
+      * Must be a relative path, not a URL
+      * Must be one of the image formats that Nextflow accepts: ``.svg``, ``.png``, ``.jpg``, ``.jpeg``, ``.gif``, ``.webp``
+      * Must point at a file that exists in the pipeline
 
     **The following variables are depreciated and fail the test if they are still present:**
 
@@ -290,6 +297,11 @@ def nextflow_config(self) -> dict[str, list[str]]:
     if diagram and "manifest.diagram" not in ignore_configs:
         if re.match(r"^\w+://", diagram):
             failed.append(f"Config ``manifest.diagram`` should be a relative path, not a URL: ``{diagram}``")
+        elif Path(diagram).suffix.lower() not in DIAGRAM_EXTENSIONS:
+            failed.append(
+                f"Config ``manifest.diagram`` is not a supported image format "
+                f"({', '.join(sorted(DIAGRAM_EXTENSIONS))}): ``{diagram}``"
+            )
         elif (Path(self.wf_path) / diagram).is_file():
             passed.append(f"Config ``manifest.diagram`` file found: ``{diagram}``")
         else:

--- a/nf_core/pipelines/lint/nextflow_config.py
+++ b/nf_core/pipelines/lint/nextflow_config.py
@@ -68,10 +68,22 @@ def nextflow_config(self) -> dict[str, list[str]]:
     **The following variables throw warnings if missing:**
 
     * ``manifest.mainScript``: The filename of the main pipeline script (should be ``main.nf``)
+    * ``manifest.diagram``
+
+      * A relative path to a workflow diagram (metro map) for the pipeline, eg. ``docs/images/metro_map.svg``
+      * Any SVG works, including hand-drawn ones. `nf-metro <https://seqeralabs.github.io/nf-metro/latest/>`_
+        can generate one from a config file, if you'd like a hand.
+      * Requires Nextflow ``26.10.0`` or later, but is safe to set for older versions - they ignore it.
+      * If set, the file must exist in the pipeline or the test **fails** (see below)
+
     * ``timeline.file``, ``trace.file``, ``report.file``, ``dag.file``
 
       * Default filenames for the timeline, trace and report
       * The DAG file path should end with ``.svg`` (If Graphviz is not installed, Nextflow will generate a ``.dot`` file instead)
+
+    **The following variables fail the test if they are set to an invalid value:**
+
+    * ``manifest.diagram``: must be a relative path to a file that exists in the pipeline, not a URL
 
     **The following variables are depreciated and fail the test if they are still present:**
 
@@ -150,6 +162,7 @@ def nextflow_config(self) -> dict[str, list[str]]:
     # Throw a warning if these are missing
     config_warn = [
         ["manifest.mainScript"],
+        ["manifest.diagram"],
         ["timeline.file"],
         ["trace.file"],
         ["report.file"],
@@ -271,6 +284,16 @@ def nextflow_config(self) -> dict[str, list[str]]:
             passed.append(f"Config ``dag.file`` ended with ``{default_dag_format}``")
         else:
             failed.append(f"Config ``dag.file`` did not end with ``{default_dag_format}``")
+
+    # Check that manifest.diagram points at a file that exists in the pipeline
+    diagram = manifest.get("diagram", "")
+    if diagram and "manifest.diagram" not in ignore_configs:
+        if re.match(r"^\w+://", diagram):
+            failed.append(f"Config ``manifest.diagram`` should be a relative path, not a URL: ``{diagram}``")
+        elif (Path(self.wf_path) / diagram).is_file():
+            passed.append(f"Config ``manifest.diagram`` file found: ``{diagram}``")
+        else:
+            failed.append(f"Config ``manifest.diagram`` file not found: ``{diagram}``")
 
     # Check that the minimum nextflowVersion is set properly
     nextflow_version = manifest.get("nextflowVersion", "")

--- a/tests/pipelines/lint/test_nextflow_config.py
+++ b/tests/pipelines/lint/test_nextflow_config.py
@@ -239,6 +239,19 @@ class TestLintNextflowConfig(TestLint):
         result = self._lint_new_pipeline()
         assert "Config ``manifest.diagram`` file not found: ``docs/images/metro_map.svg``" in result["failed"]
 
+    def test_manifest_diagram_bad_format_fail(self):
+        """Test that a `manifest.diagram` that is not a supported image format fails."""
+        diagram = Path(self.new_pipeline) / "docs" / "images" / "metro_map.pdf"
+        diagram.parent.mkdir(parents=True, exist_ok=True)
+        diagram.write_text("not an image")
+        self._set_manifest_diagram("docs/images/metro_map.pdf")
+
+        result = self._lint_new_pipeline()
+        assert (
+            "Config ``manifest.diagram`` is not a supported image format "
+            "(.gif, .jpeg, .jpg, .png, .svg, .webp): ``docs/images/metro_map.pdf``" in result["failed"]
+        )
+
     def test_manifest_diagram_url_fail(self):
         """Test that a `manifest.diagram` set to a URL fails - it should be a relative path."""
         url = "https://example.com/metro_map.svg"

--- a/tests/pipelines/lint/test_nextflow_config.py
+++ b/tests/pipelines/lint/test_nextflow_config.py
@@ -7,6 +7,9 @@ import nf_core.pipelines.lint
 
 from ..test_lint import TestLint
 
+# The template ships `manifest.diagram` commented out, so a new pipeline always warns about it
+MISSING_DIAGRAM_WARNING = "Config variable not found: `manifest.diagram`"
+
 
 class TestLintNextflowConfig(TestLint):
     def setUp(self) -> None:
@@ -18,7 +21,7 @@ class TestLintNextflowConfig(TestLint):
         self.lint_obj.load_pipeline_config()
         result = self.lint_obj.nextflow_config()
         assert len(result["failed"]) == 0
-        assert len(result["warned"]) == 0
+        assert result["warned"] == [MISSING_DIAGRAM_WARNING]
 
     def test_default_values_match(self):
         """Test that the default values in nextflow.config match the default values defined in the nextflow_schema.json."""
@@ -26,7 +29,7 @@ class TestLintNextflowConfig(TestLint):
         lint_obj.load_pipeline_config()
         result = lint_obj.nextflow_config()
         assert len(result["failed"]) == 0
-        assert len(result["warned"]) == 0
+        assert result["warned"] == [MISSING_DIAGRAM_WARNING]
         assert "Config default value correct: params.validate_params" in str(result["passed"])
 
     def test_nextflow_config_bad_name_fail(self):
@@ -37,7 +40,7 @@ class TestLintNextflowConfig(TestLint):
         lint_obj.nf_config["manifest"]["name"] = "bad_name"
         result = lint_obj.nextflow_config()
         assert len(result["failed"]) > 0
-        assert len(result["warned"]) == 0
+        assert result["warned"] == [MISSING_DIAGRAM_WARNING]
 
     def test_nextflow_config_dev_in_release_mode_failed(self):
         """Tests that config variable existence test fails with dev version in release mode"""
@@ -48,7 +51,7 @@ class TestLintNextflowConfig(TestLint):
         lint_obj.nf_config["manifest"]["version"] = "dev_is_bad_name"
         result = lint_obj.nextflow_config()
         assert len(result["failed"]) > 0
-        assert len(result["warned"]) == 0
+        assert result["warned"] == [MISSING_DIAGRAM_WARNING]
 
     def test_nextflow_config_missing_test_profile_failed(self):
         """Test failure if config file does not contain `test` profile."""
@@ -64,7 +67,7 @@ class TestLintNextflowConfig(TestLint):
         lint_obj.load_pipeline_config()
         result = lint_obj.nextflow_config()
         assert len(result["failed"]) > 0
-        assert len(result["warned"]) == 0
+        assert result["warned"] == [MISSING_DIAGRAM_WARNING]
 
     def test_default_values_fail(self):
         """Test linting fails if the default values in nextflow.config do not match the ones defined in the nextflow_schema.json."""
@@ -181,7 +184,7 @@ class TestLintNextflowConfig(TestLint):
         lint_obj.load_pipeline_config()
         result = lint_obj.nextflow_config()
         assert len(result["failed"]) == 0
-        assert len(result["warned"]) == 0
+        assert result["warned"] == [MISSING_DIAGRAM_WARNING]
         assert "Config default value correct: params.dummy" in str(result["passed"])
 
     def test_default_values_float_fail(self):
@@ -214,5 +217,44 @@ class TestLintNextflowConfig(TestLint):
         result = lint_obj.nextflow_config()
 
         assert len(result["failed"]) == 1
-        assert len(result["warned"]) == 0
+        assert result["warned"] == [MISSING_DIAGRAM_WARNING]
         assert "Config default value incorrect: `params.dummy" in str(result["failed"])
+
+    def test_manifest_diagram_pass(self):
+        """Test that a `manifest.diagram` pointing at an existing file passes."""
+        diagram = Path(self.new_pipeline) / "docs" / "images" / "metro_map.svg"
+        diagram.parent.mkdir(parents=True, exist_ok=True)
+        diagram.write_text("<svg></svg>")
+        self._set_manifest_diagram("docs/images/metro_map.svg")
+
+        result = self._lint_new_pipeline()
+        assert len(result["failed"]) == 0
+        assert len(result["warned"]) == 0
+        assert "Config ``manifest.diagram`` file found: ``docs/images/metro_map.svg``" in result["passed"]
+
+    def test_manifest_diagram_missing_file_fail(self):
+        """Test that a `manifest.diagram` pointing at a non-existent file fails."""
+        self._set_manifest_diagram("docs/images/metro_map.svg")
+
+        result = self._lint_new_pipeline()
+        assert "Config ``manifest.diagram`` file not found: ``docs/images/metro_map.svg``" in result["failed"]
+
+    def test_manifest_diagram_url_fail(self):
+        """Test that a `manifest.diagram` set to a URL fails - it should be a relative path."""
+        url = "https://example.com/metro_map.svg"
+        self._set_manifest_diagram(url)
+
+        result = self._lint_new_pipeline()
+        assert f"Config ``manifest.diagram`` should be a relative path, not a URL: ``{url}``" in result["failed"]
+
+    def _set_manifest_diagram(self, value: str) -> None:
+        """Uncomment the templated `manifest.diagram` line and set it to `value`."""
+        nf_conf_file = Path(self.new_pipeline) / "nextflow.config"
+        content = nf_conf_file.read_text()
+        assert "// diagram" in content
+        nf_conf_file.write_text(content.replace("// diagram", f"diagram = '{value}' //"))
+
+    def _lint_new_pipeline(self) -> dict:
+        lint_obj = nf_core.pipelines.lint.PipelineLint(self.new_pipeline)
+        lint_obj.load_pipeline_config()
+        return lint_obj.nextflow_config()


### PR DESCRIPTION
Nextflow [recently added](https://github.com/nextflow-io/nextflow/pull/7578) `manifest.diagram`: a relative path to the pipeline's workflow diagram. It lands in Nextflow 26.10. Older versions ignore unknown manifest fields, so it's safe to set in any pipeline today.

### Template

Adds the field to `nextflow.config`, commented out with a TODO, since a brand new pipeline has no metro map yet:

```nextflow
// TODO nf-core: Make a metro map (nf-metro or drawn) and add relative path to the SVG below
// diagram      = 'docs/images/metro_map.svg'
```

nf-metro is mentioned as a recommendation, not a requirement — any SVG works, however you make it.

### Linting

Both checks live in the existing `nextflow_config` lint test rather than a new one:

- **Warning** if `manifest.diagram` is not set. A freshly created pipeline gets this warning until the author draws a map, alongside the other template TODO warnings.
- **Failure** if it is set but is a URL rather than a relative path, is not one of the image formats Nextflow accepts (`.svg`, `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`), or points at a file that isn't in the repository.

The lint docs are generated from the test's docstring, which is updated to cover both.

Since a new pipeline now always produces the missing-diagram warning, the existing `assert len(result["warned"]) == 0` assertions in `test_nextflow_config.py` now assert that this is the only warning. Four new tests cover the valid path, missing file, unsupported format and URL cases.

### CI

`create-lint-wf` and `create-test-lint-wf-template` lint the generated test pipeline with `--fail-warned`, so the missing-diagram warning would fail those jobs. Both now create a placeholder `docs/images/metro_map.svg` and uncomment the `diagram` line first, in the same way they already neutralise the template TODOs and `includeConfig`.

Pipelines themselves are unaffected: the template's `linting.yml` doesn't use `--fail-warned`, so authors get the nudge as a warning.

### Docs

The nf-core website side is in nf-core/website#4390 — a new section on the [workflow schematics](https://nf-co.re/docs/community/brand/workflow-schematics) page.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Documentation in `docs` is updated



