### PR TITLE
git-ignore nf-test files in pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Template
 
+- git-ignore nf-test files ([#4461](https://github.com/nf-core/tools/pull/4461))
+
 ### Version updates
 
 ## [v4.1.0 - Marshalled Mamba](https://github.com/nf-core/tools/releases/tag/4.1.0) - [2026-07-29]

--- a/nf_core/pipeline-template/.gitignore
+++ b/nf_core/pipeline-template/.gitignore
@@ -8,3 +8,5 @@ testing*
 *.pyc
 null/
 .lineage/
+.nf-test/
+.nf-test.log


### PR DESCRIPTION
`git status` shows nf-test files in all my pipeline repos and it made me realised those files were not in `.gitignore`, unlike `.nextflow.log` etc

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/main/.github/CONTRIBUTING.md
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
