### PR TITLE
Fix the CodSpeed benchmarks workflow

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Nextflow
         uses: nf-core/setup-nextflow@893c28b667aedeba26e37f296d260ccc5bc4d914 # v3
         with:
-          version: ${{ github.event.inputs.nextflow-version || matrix.nextflow-version }}
+          version: "25.10.4"
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         name: Check out source-code repository
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7


### PR DESCRIPTION
The CodSpeed benchmarks job has been failing on `dev` since at least 6 August, on every run:

```
Error: Could not retrieve Nextflow release matching .
The nf-co.re/nextflow_version endpoint returned malformed metadata.
```

### Cause

The `Install Nextflow` step asks for this version:

```yaml
version: ${{ github.event.inputs.nextflow-version || matrix.nextflow-version }}
```

That expression was copied from `pytest.yml`, where it is backed by both a `workflow_dispatch` input and a `strategy.matrix`. This workflow has neither, so both sides resolve to an empty string and `setup-nextflow` is asked for a release matching `""` — hence the stray full stop in the error message.

Pinned to `25.10.4`, the same version `pytest.yml` pins. A benchmark job wants a fixed Nextflow so that numbers stay comparable between runs, rather than a moving `latest-stable`. Making it overridable via a `workflow_dispatch` input is easy to add later if that turns out to be useful, but nothing needs it today.

### Also

Cleared the `GITHUB_TOKEN` from the checkout, which resolves the zizmor `artipacked` finding on this file. Nothing in the job uses git credentials: the CodSpeed action authenticates over OIDC (`id-token: write`), and the modules cache warm-up is an anonymous clone of a public repo into a separate cache directory. zizmor now reports no findings for this workflow.

No `CHANGELOG.md` entry, since this is CI-only and not user facing — happy to add one if you'd rather.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated