### PR TITLE
Bumped nf-schema and enabled type-casting to support Nextflow 26.04 out of the box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Template
 
 - git-ignore nf-test files ([#4461](https://github.com/nf-core/tools/pull/4461))
+- Bump nf-schema to 2.7.3 to allow running pipelines with Nextflow 26.04 ([#4463](https://github.com/nf-core/tools/pull/4463))
 
 ### Version updates
 

--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -318,7 +318,7 @@ manifest {
 {% if nf_schema -%}
 // Nextflow plugins
 plugins {
-    id 'nf-schema@2.5.1' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-schema@2.7.3' // Validation of pipeline parameters and creation of an input channel from a sample sheet
 }
 
 validation {

--- a/nf_core/pipeline-template/subworkflows/local/utils_nfcore_pipeline_pipeline/main.nf
+++ b/nf_core/pipeline-template/subworkflows/local/utils_nfcore_pipeline_pipeline/main.nf
@@ -99,7 +99,7 @@ workflow PIPELINE_INITIALISATION {
         before_text,
         after_text,
         command,
-        false
+        null
     )
     {%- endif %}
 


### PR DESCRIPTION
We found out that nf-schema 2.7.2 (recommended in https://nf-co.re/blog/2026/parameter-types ) doesn't actually require Nextflow 26.04 . It [requires 25.10](https://registry.nextflow.io/plugins/nf-schema@2.7.3) which is the current minimal version defined in the template.

I propose to bump up the plugin version and change the `cli_typecast` parameter to _null_ so that [no `cast_cli_params` is passed to the plugin](https://github.com/nf-core/tools/blob/4.1.0/nf_core/pipeline-template/subworkflows/nf-core/utils_nfschema_plugin/main.nf#L69-L71). No value means this according to the [doc](https://nextflow-io.github.io/nf-schema/latest/parameters/validation/#validateparameters):

> A boolean to enable or disable type casting of parameters provided via the CLI (optional, default: `true` if the syntax parser version is 2 and `false` otherwise).

which is interesting because the problem comes from the syntax parser itself, not the nextflow version per se.

As a result:

- old parser: `null` is interpreted as `false`. No type casting, but still a newer plugin version which comes with extra features
- new parser: the new plugin will automatically convert strings to the right boolean/number type for validation _and_ the rest of the pipeline, meaning pipelines don't need to do any casting themselves.

NB: I used nf-schema v2.7.3, not v2.7.2, since it's the last to work with 25.10

Yes, the ultimate solution will be to introduce typed parameters, etc. I see this as a temporary measure to simplify running pipelines with Nextflow 26.04 out of the box.
<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/main/.github/CONTRIBUTING.md
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
